### PR TITLE
refactor: small fixes on cli

### DIFF
--- a/cli/cmd/build/build.go
+++ b/cli/cmd/build/build.go
@@ -86,10 +86,7 @@ func runCommand(cmd *cobra.Command, agentPath string) error {
 	}
 
 	// Print to output
-	_, err = fmt.Fprint(cmd.OutOrStdout(), string(agentRaw))
-	if err != nil {
-		return fmt.Errorf("failed to print built data: %w", err)
-	}
+	cmd.Print(string(agentRaw))
 
 	return nil
 }

--- a/cli/cmd/build/options.go
+++ b/cli/cmd/build/options.go
@@ -11,7 +11,6 @@ type options struct {
 	ArtifactUrl  string
 	ArtifactType string
 	CreatedAt    string
-	Inputs       []string
 	LLMAnalyzer  bool
 
 	// Base extension
@@ -27,12 +26,6 @@ func init() {
 	flags.StringVar(&opts.Version, "version", "", "Version of the agent")
 	flags.StringVar(&opts.ArtifactUrl, "artifact-url", "", "Agent artifact URL")
 	flags.StringVar(&opts.ArtifactType, "artifact-type", "", "Agent artifact type")
-	flags.StringSliceVar(
-		&opts.Inputs,
-		"input",
-		[]string{},
-		"Inputs to set for the agent. Overrides builder defaults. Example usage: --input number --input text",
-	)
 	flags.BoolVarP(&opts.LLMAnalyzer, "llmanalyzer", "l", false, "Enable LLMAnalyzer extension")
 
 	// Base extension

--- a/cli/cmd/pull/options.go
+++ b/cli/cmd/pull/options.go
@@ -7,11 +7,11 @@ var opts = &options{}
 
 type options struct {
 	AgentDigest string
-	OutputFormat      string
+	JSON        bool
 }
 
 func init() {
 	flags := Command.Flags()
 	flags.StringVar(&opts.AgentDigest, "digest", "", "Digest of the agent to pull")
-	Command.Flags().StringVarP(&opts.OutputFormat, "output", "o", "json", "Output format (json|yaml)")
+	flags.BoolVar(&opts.JSON, "json", false, "Output in JSON format")
 }

--- a/cli/cmd/pull/options.go
+++ b/cli/cmd/pull/options.go
@@ -7,9 +7,11 @@ var opts = &options{}
 
 type options struct {
 	AgentDigest string
+	OutputFormat      string
 }
 
 func init() {
 	flags := Command.Flags()
 	flags.StringVar(&opts.AgentDigest, "digest", "", "Digest of the agent to pull")
+	Command.Flags().StringVarP(&opts.OutputFormat, "output", "o", "json", "Output format (json|yaml)")
 }

--- a/cli/cmd/push/push.go
+++ b/cli/cmd/push/push.go
@@ -28,7 +28,7 @@ var Command = &cobra.Command{
 	dirctl build <args> | dirctl push
 
 	# From pull
-	dirctl pull --id agent-id | dirctl push
+	dirctl pull --digest sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef | dirctl push
 
 `,
 	RunE: func(cmd *cobra.Command, _ []string) error {
@@ -74,10 +74,7 @@ func runCommand(cmd *cobra.Command) error {
 	}
 
 	// Print digest to output
-	_, err = fmt.Fprint(cmd.OutOrStdout(), digest.Encode())
-	if err != nil {
-		return fmt.Errorf("failed to print digest: %w", err)
-	}
+	cmd.Print(digest.Encode())
 
 	return nil
 }

--- a/cli/cmd/push/push.go
+++ b/cli/cmd/push/push.go
@@ -28,7 +28,7 @@ var Command = &cobra.Command{
 	dirctl build <args> | dirctl push
 
 	# From pull
-	dirctl pull --digest sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef | dirctl push
+	dirctl pull --digest <digest-string> --json | dirctl push
 
 `,
 	RunE: func(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
This PR adds the output format flags to the pull cli command and changes the `fmt.Fprint()` calls to `cmd.Print` calls.