### PR TITLE
ci: build and push multi-arch image in release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,8 +152,8 @@ jobs:
     uses: ./.github/workflows/reusable-release.yaml
     with:
       image_repo: ghcr.io/agntcy
-      image_tag: ${{ needs.prepare-build.outputs.image_tag }}
       release_tag: ${{ needs.prepare-build.outputs.release_tag }}
+      bake_targets: ${{ needs.prepare-build.outputs.targets }}
 
   success:
     name: Success

--- a/.github/workflows/reusable-build-push.yaml
+++ b/.github/workflows/reusable-build-push.yaml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Cisco and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build and Push
+
+on:
+  workflow_call:
+    inputs:
+      bake_target:
+        required: true
+        type: string
+        description: "Bake target to build and push"
+      image_repo:
+        required: true
+        type: string
+        description: "Image repo to use."
+      image_tag:
+        required: true
+        type: string
+        description: "Image tag to use."
+
+jobs:
+  build-and-push:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: notused
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+
+      - name: Cache Docker layers
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ inputs.bake_target }}-buildx-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-${{ inputs.bake_target }}-buildx-
+
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: |
+            ${{ inputs.image_repo }}/${{ inputs.bake_target }},enable=true
+          tags: |
+            type=raw,value=${{ inputs.image_tag }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Create cache directory
+        run: mkdir -p /tmp/.buildx-cache
+
+      - name: Build and push
+        uses: docker/bake-action@a4d7f0b5b91c14a296d792d4ec53a9db17f02e67 # v5.5.0
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.metadata.outputs.bake-file }}
+          targets: ${{ inputs.bake_target }}
+          provenance: false
+          set: |
+            *.platform=linux/amd64,linux/arm64
+            *.output=type=registry
+            *.cache-from=type=local,src=/tmp/.buildx-cache
+        env:
+          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -10,14 +10,14 @@ on:
         required: true
         type: string
         description: "Image repo to use."
-      image_tag:
-        required: true
-        type: string
-        description: "Image tag to use."
       release_tag:
         required: true
         type: string
         description: "Release tag for all components."
+      bake_targets:
+        required: true
+        type: string
+        description: "Bake targets to build and push"
       helm-version:
         required: false
         default: "3.12.1"
@@ -28,12 +28,11 @@ jobs:
   images:
     name: Images
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        targets: ${{ fromJson(inputs.bake_targets) }}
     steps:
-      - name: Install Skopeo
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y skopeo
-
       - name: Checkout code
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
@@ -51,12 +50,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN  }}
 
       - name: Release images
-        env:
-          IMAGE_REPO: ${{ inputs.image_repo }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          task release -y
+        uses: ./.github/workflows/reusable-build-push.yaml
+        with:
+          bake_target: ${{ matrix.targets }}
+          image_repo: ${{ inputs.image_repo }}
+          image_tag: ${{ inputs.release_tag }}
 
   chart:
     name: Helm chart

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -71,21 +71,6 @@ tasks:
     cmds:
       - docker buildx bake {{.IMAGE_BAKE_OPTS}} --set=*.output=type=registry
 
-  release:
-    desc: Release images for all components with release tag tag
-    prompt:
-      - Are you sure you want to push the images to remote registry?
-    vars:
-      RELEASE_TAG: '{{ .RELEASE_TAG | default "v0.0.0-dev" }}'
-    cmds:
-      # TODO: use buildx to simplify
-      - |
-        images=$(docker buildx bake default --print | jq -r '.target | with_entries(.value |= .tags[0]) | to_entries[] | .value')
-        echo "$images" | while read image; do
-          release_image="${image%%:*}:{{.RELEASE_TAG}}"
-          skopeo copy --multi-arch all docker://$image docker://$release_image
-        done
-
   release:verify:
     desc: Verify release readiness
     deps:


### PR DESCRIPTION
* Currently, we are using `skopeo` to copy all single-arch images in GHCR into one multi-arch image during `release`. However, we no longer push images to GHCR during build.
* This PR adds a new workflow to build and push multi-arch images during `release`