### PR TITLE
ci: enable go setup cache

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -49,12 +49,7 @@ jobs:
         with:
           go-version: '1.24.1'
           check-latest: true
-          cache-dependency-path: |
-            api/go.sum
-            cli/go.sum
-            client/go.sum
-            e2e/go.sum
-            server/go.sum
+          cache-dependency-path: "**/*.sum"
 
       - name: Run unit tests
         run: |
@@ -85,12 +80,7 @@ jobs:
         with:
           go-version: '1.24.1'
           check-latest: true
-          cache-dependency-path: |
-            api/go.sum
-            cli/go.sum
-            client/go.sum
-            e2e/go.sum
-            server/go.sum
+          cache-dependency-path: "**/*.sum"
 
       #
       # Install kubernetes tools


### PR DESCRIPTION
https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs

First CI run: unit 4m54s e2e 5m9s 🐢 
Second CI run: unit 49s e2e 2m44s 🐇 