### PR TITLE
feat: add structured logging

### DIFF
--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/agntcy/dir/server"
 	"github.com/agntcy/dir/server/config"
+	"github.com/agntcy/dir/server/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +22,9 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to load config: %w", err)
 		}
 
-		return server.Run(cmd.Context(), cfg)
+		ctx := logging.WithLogger(cmd.Context(), cfg.LogFile)
+
+		return server.Run(ctx, cfg)
 	},
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	// API configuration
 	ListenAddress      string `json:"listen_address,omitempty"      mapstructure:"listen_address"`
 	HealthCheckAddress string `json:"healthcheck_address,omitempty" mapstructure:"healthcheck_address"`
+	LogFile            string `json:"log_file,omitempty"            mapstructure:"log_file"`
 
 	// Provider configuration
 	Provider string         `json:"provider,omitempty" mapstructure:"provider"`
@@ -59,6 +60,8 @@ func LoadConfig() (*Config, error) {
 
 	_ = v.BindEnv("healthcheck_address")
 	v.SetDefault("healthcheck_address", DefaultHealthCheckAddress)
+
+	_ = v.BindEnv("log_file")
 
 	//
 	// Provider configuration

--- a/server/logging/logging.go
+++ b/server/logging/logging.go
@@ -1,0 +1,48 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+)
+
+// Key for context storage
+type contextKey string
+
+const loggerKey contextKey = "AgntcyDirectoryServerContextLogger"
+
+// getLogOutput determines where logs should be written
+func getLogOutput(logFilePath string) *os.File {
+	if logFilePath != "" {
+		// Try to open or create the log file
+		file, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err == nil {
+			return file
+		}
+
+		// If file creation fails, log to stderr and fallback to stdout
+		slog.Error("Failed to open log file, defaulting to stdout", "error", err)
+	}
+
+	return os.Stdout
+}
+
+func WithLogger(ctx context.Context, logFilePath string) context.Context {
+	logOutput := getLogOutput(logFilePath)
+	logger := slog.New(slog.NewTextHandler(logOutput, nil))
+
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// Retrieve logger from context (fallback to default if missing)
+func LoggerFromContext(ctx context.Context) *slog.Logger {
+	logger, ok := ctx.Value(loggerKey).(*slog.Logger)
+	if !ok {
+		return slog.New(slog.NewJSONHandler(os.Stdout, nil)) // Default logger
+	}
+
+	return logger
+}

--- a/server/server.go
+++ b/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agntcy/dir/server/config"
 	"github.com/agntcy/dir/server/controller"
 	"github.com/agntcy/dir/server/datastore"
+	"github.com/agntcy/dir/server/logging"
 	"github.com/agntcy/dir/server/routing"
 	"github.com/agntcy/dir/server/store"
 	"github.com/agntcy/dir/server/types"
@@ -36,6 +37,7 @@ type Server struct {
 }
 
 func Run(ctx context.Context, cfg *config.Config) error {
+	logger := logging.LoggerFromContext(ctx).With("subsystem", "Server")
 	errCh := make(chan error)
 
 	// Start server
@@ -45,7 +47,7 @@ func Run(ctx context.Context, cfg *config.Config) error {
 	}
 	defer server.Close()
 
-	log.Printf("Server started: %s", cfg.ListenAddress)
+	logger.Info("Server started", "address", cfg.ListenAddress)
 
 	// Wait for deactivation
 	sigCh := make(chan os.Signal, 1)


### PR DESCRIPTION
This PR adds structured logging to the server part of the directory.
The logger can print the logs into a file if it's given, otherwise it prints them to the standard output.
The subsystems can get the structured logger from the context.