### PR TITLE
ci: add local demo workflow 

### DIFF
--- a/.github/workflows/demo-local.yaml
+++ b/.github/workflows/demo-local.yaml
@@ -1,11 +1,11 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-name: Demo
+name: Dir - Local Demo
 
 description: |
   This workflow demonstrates how to use the Dir CLI with a Kind cluster and Helm chart.
-  It includes steps for building, pushing, publishing, and listing images.
+  It includes steps for building, pushing, publishing, and listing agents.
 
 on:
   workflow_dispatch:
@@ -47,10 +47,6 @@ jobs:
       - name: Load image into Kind
         run: |
           kind load docker-image ${{ inputs.dir-apiserver-image }}:${{ inputs.dir-version }} --name dir-demo
-
-      - name: Login to OCI Registry
-        run: |
-          helm registry login ghcr.io -u notused -p ${{ secrets.GITHUB_TOKEN }}
 
       # TODO Remove values file once release with fix is available
       - name: Deploy Helm Chart

--- a/.github/workflows/reusable-dir-demo.yaml
+++ b/.github/workflows/reusable-dir-demo.yaml
@@ -1,0 +1,116 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Demo
+
+description: |
+  This workflow demonstrates how to use the Dir CLI with a Kind cluster and Helm chart.
+  It includes steps for building, pushing, publishing, and listing images.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dir-apiserver-image:
+        required: true
+        type: string
+        default: "ghcr.io/agntcy/dir-apiserver"
+      dir-helm-chart:
+        required: true
+        type: string
+        default: "oci://ghcr.io/agntcy/dir/helm-charts/dir"
+      dir-version:
+        required: true
+        type: string
+        default: "v0.2.0"
+      network:
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.12.0
+        with:
+          version: v0.24.0
+          cluster_name: dir-demo
+
+      - name: Pull Docker image
+        run: |
+          docker pull ${{ inputs.dir-apiserver-image }}:${{ inputs.dir-version }}
+
+      - name: Load image into Kind
+        run: |
+          kind load docker-image ${{ inputs.dir-apiserver-image }}:${{ inputs.dir-version }} --name dir-demo
+
+      - name: Login to OCI Registry
+        run: |
+          helm registry login ghcr.io -u notused -p ${{ secrets.GITHUB_TOKEN }}
+
+      # TODO Remove values file once release with fix is available
+      - name: Deploy Helm Chart
+        run: |
+          helm pull ${{ inputs.dir-helm-chart }} --version ${{ inputs.dir-version }}
+          helm upgrade --install dir ${{ inputs.dir-helm-chart }} --version ${{ inputs.dir-version }} \
+            --values install/charts/dir/values.yaml \
+            --wait --wait-for-jobs --timeout "15m"
+
+      - name: Port-forward to Dir API server
+        run: |
+          kubectl port-forward service/dir-apiserver 8888:8888 -n default &
+
+      - name: Setup Dirctl
+        run: |
+          curl -L -o dirctl https://github.com/agntcy/dir/releases/download/${{ inputs.dir-version }}/dirctl-linux-amd64
+          chmod +x dirctl
+
+      - name: Run build command
+        run: |
+          echo "Running dir build command"
+          ./dirctl build e2e/testdata > agent.json
+          echo "Built agent.json:"
+          cat agent.json
+
+      - name: Run push command
+        run: |
+          echo "Running dir push command"
+          ./dirctl push agent.json > digest.txt
+          echo "Pushed image digest:"
+          cat digest.txt
+
+      - name: Run publish command
+        run: |
+          echo "Running dir publish command"
+          if [ "${{ inputs.network }}" = "true" ]; then
+            ./dirctl publish $(cat digest.txt) --network
+          else
+            ./dirctl publish $(cat digest.txt)
+          fi
+
+      - name: Run list info command
+        run: |
+          echo "Running dir list info command"
+          if [ "${{ inputs.network }}" = "true" ]; then
+            ./dirctl list info --network
+          else
+            ./dirctl list info
+          fi
+
+      - name: Run list search by skill command
+        run: |
+          echo "Running dir list search by skill command"
+          if [ "${{ inputs.network }}" = "true" ]; then
+            ./dirctl list "/skills/Natural Language Processing" --network
+          else
+            ./dirctl list "/skills/Natural Language Processing"
+          fi
+
+      - name: Run pull command
+        run: |
+          echo "Running dir pull command"
+          ./dirctl pull $(cat digest.txt)

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -27,7 +27,7 @@ config:
     # local_dir: ""
 
     # Registry address to connect to
-    registry_address: "agntcy-dir-zot.default.svc.cluster.local:5000"
+    registry_address: "dir-zot.default.svc.cluster.local:5000"
     # All data will be stored under this repo.
     # Objects are pushed as tags, manifests, and blobs.
     # repository_name: ""

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -25,7 +25,7 @@ apiserver:
       # local_dir: ""
 
       # Registry address to connect to
-      registry_address: "agntcy-dir-zot.default.svc.cluster.local:5000"
+      registry_address: "dir-zot.default.svc.cluster.local:5000"
 
       # All data will be stored under this repo.
       # Objects are pushed as tags, manifests, and blobs.


### PR DESCRIPTION
* Fix zot service name in helm values
* Add demo workflow that runs agent directory build/push/publish/pull commands with one dir server node
* Example run https://github.com/paralta/dir/actions/runs/14226199344/job/39866198246