### PR TITLE
fix: rename zot-config.json to config.json

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -197,7 +197,7 @@ tasks:
     cmds:
       - |
         # mount config
-        cat > /tmp/zot-config.json <<EOF
+        cat > /tmp/config.json <<EOF
         {
           "distSpecVersion": "1.1.1",
           "storage": {


### PR DESCRIPTION
Keep getting the following error when running `task server:start`
```
Error: statfs /tmp/config.json: no such file or directory
```