### PR TITLE
feat: windows binary

### DIFF
--- a/.github/workflows/demo-local-windows.yaml
+++ b/.github/workflows/demo-local-windows.yaml
@@ -1,0 +1,60 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Dir - Local Demo on Windows
+
+description: |
+  This workflow demonstrates how to use the Dir CLI on Windows.
+  It includes steps for compiling the CLI, building an agent, and verifying the binary.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  demo:
+    runs-on: windows-latest
+    env:
+      ACTIONS_STEP_DEBUG: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create bin directory
+        run: |
+          echo "Creating bin directory"
+          mkdir bin
+
+      # TODO Replace with curl once windows binary is available with release
+      - name: Compile
+        run: |
+          echo "Compiling CLI"
+          task cli:compile
+
+      - name: Verify dirctl binary
+        run: |
+          if (Test-Path .\bin\dirctl.exe) {
+            echo "dirctl binary exists"
+          } else {
+            echo "dirctl binary is missing"
+            exit 1
+          }
+
+      - name: Run version command on windows
+        run: |
+          echo "Running version command"
+          .\bin\dirctl.exe version
+
+      - name: Run build command
+        run: |
+          echo "Running dir build command"
+          .\bin\dirctl.exe build e2e/testdata > agent.json
+          echo "Built agent.json:"
+          cat agent.json
+
+      # TODO Start server and run push/publish commands

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,10 +143,10 @@ tasks:
       GOOS: '{{ .GOOS | default OS }}'
       GOARCH: '{{ .GOARCH | default ARCH }}'
       BINARY_NAME: '{{ .BINARY_NAME | default "dirctl" }}'
-      OUT_DIR: '{{ .ROOT_DIR }}/bin'
+      OUT_BINARY: '{{ if eq OS "windows" }}{{ .ROOT_DIR }}\\bin\\{{ .BINARY_NAME }}.exe{{ else }}{{ .ROOT_DIR }}/bin/{{ .BINARY_NAME }}{{ end }}'
       LDFLAGS: '-s -w -extldflags -static {{ .VERSION_LDFLAGS }}'
     cmds:
-      - CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -ldflags="{{ .LDFLAGS }}" -o {{.OUT_DIR}}/{{.BINARY_NAME}} cli.go
+      - CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -ldflags="{{ .LDFLAGS }}" -o "{{.OUT_BINARY}}" cli.go
 
   cli:compile:all:
     desc: Compile CLI client binaries for multiple platforms
@@ -154,9 +154,15 @@ tasks:
     cmds:
       - for:
           matrix:
-            OS: ["linux", "darwin"]
+            OS: ["linux", "darwin", "windows"]
             ARCH: ["amd64", "arm64"]
-        cmd: GOOS={{.ITEM.OS}} GOARCH={{.ITEM.ARCH}} BINARY_NAME=dirctl-{{.ITEM.OS}}-{{.ITEM.ARCH}} task cli:compile
+        cmd: |
+          # Skip unsupported combinations (e.g., Windows ARM64)
+          if [ "{{.ITEM.OS}}" = "windows" ] && [ "{{.ITEM.ARCH}}" = "arm64" ]; then
+            echo "Skipping unsupported platform: {{.ITEM.OS}}/{{.ITEM.ARCH}}"
+          else
+            GOOS={{.ITEM.OS}} GOARCH={{.ITEM.ARCH}} BINARY_NAME=dirctl-{{.ITEM.OS}}-{{.ITEM.ARCH}} task cli:compile
+          fi
 
   cli:test:
     desc: Unit test CLI code


### PR DESCRIPTION
* Compile windows-amd64 binary
* Add CI workflow to compile the CLI, build an agent, and verify the binary on Windows (example run: https://github.com/paralta/dir/actions/runs/14405424553/job/40400673832)