### PR TITLE
feat: add option to enable or disable oasf validation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -49,6 +49,12 @@ builder:
 
  # Disable the runtime plugin
  runtime: false
+
+ # Enable OASF validation
+ oasf-validation: true
+
+ # Skip
+ 
 EOF
 
 # Build the agent

--- a/cli/build.config.yml
+++ b/cli/build.config.yml
@@ -12,3 +12,6 @@ builder:
 
   # Enable or disable the runtime plugin
   runtime: false
+
+  # Enable or disable OASF validation
+  oasf-validation: true

--- a/cli/builder/config/config.go
+++ b/cli/builder/config/config.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Builder struct {
-	BaseModelPath string   `yaml:"base-model"`
-	SourceIgnore  []string `yaml:"source-ignore"`
-	LLMAnalyzer   bool     `yaml:"llmanalyzer"`
-	Runtime       bool     `yaml:"runtime"`
+	BaseModelPath  string   `yaml:"base-model"`
+	SourceIgnore   []string `yaml:"source-ignore"`
+	LLMAnalyzer    bool     `yaml:"llmanalyzer"`
+	Runtime        bool     `yaml:"runtime"`
+	OASFValidation bool     `yaml:"oasf-validation"`
 }
 
 type Config struct {

--- a/cli/cmd/build/build.go
+++ b/cli/cmd/build/build.go
@@ -100,10 +100,12 @@ func runCommand(cmd *cobra.Command, agentPath string) error {
 	// User model will override plugin model
 	agent.Merge(builderAgent)
 
-	// Validate skills
-	err = oasf.ValidateSkills(agent.GetSkills())
-	if err != nil {
-		return fmt.Errorf("failed to validate skills: %w", err)
+	if cfg.Builder.OASFValidation {
+		// Validate skills
+		err = oasf.ValidateSkills(agent.GetSkills())
+		if err != nil {
+			return fmt.Errorf("failed to validate skills: %w", err)
+		}
 	}
 
 	// Construct output

--- a/e2e/testdata/build.config.yml
+++ b/e2e/testdata/build.config.yml
@@ -12,3 +12,6 @@ builder:
 
   # Enable or disable the runtime plugin
   runtime: false
+
+  # Enable or disable OASF validation
+  oasf-validation: true


### PR DESCRIPTION
* Add option to enable or disable oasf validation during build

Currently, compliance with OASF skills is mandatory, but this new option will accommodate DIR adopters who may not wish to adhere to these requirements.