### PR TITLE
fix: list command outputs with network flag

### DIFF
--- a/.github/workflows/reusable-test-e2e.yaml
+++ b/.github/workflows/reusable-test-e2e.yaml
@@ -1,0 +1,143 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Test
+
+on:
+  workflow_call:
+    inputs:
+      image_repo:
+        required: true
+        type: string
+        description: 'Image repo to use.'
+      image_tag:
+        required: true
+        type: string
+        description: 'Image tag to use.'
+      helm-version:
+        required: false
+        default: "3.12.1"
+        type: string
+        description: 'Helm version'
+      # helm-ct-version:
+      #   required: false
+      #   default: "3.11.0"
+      #   type: string
+      #   description: 'Helm chart-testing version'
+      kind-version:
+        required: false
+        default: "0.24.0"
+        type: string
+        description: 'Kind version'
+      taskfile-task:
+        required: false
+        default: "test:e2e"
+        type: string
+        description: 'Taskfile task to run'
+
+jobs:
+  test-e2e:
+    name: End-to-end
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: notused
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Setup Taskfile
+        shell: bash
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.1'
+          check-latest: true
+          cache-dependency-path: "**/*.sum"
+
+      #
+      # Install kubernetes tools
+      #
+      - name: Setup Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: ${{ inputs.helm-version }}
+
+      # - name: Set up Helm chart-testing
+      #   uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
+      #   with:
+      #     version: ${{ inputs.helm-ct-version }}
+
+      - name: Setup kind
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        with:
+          version: v${{ inputs.kind-version }}
+          install_only: true
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
+
+      #
+      # Setup cluster
+      #
+      - name: Setup Kind cluster
+        shell: bash
+        run: |
+          # Create cluster config
+          KIND_CONFIG_FILE=$(mktemp -p /tmp)
+          cat <<EOF > $KIND_CONFIG_FILE
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          networking:
+            apiServerAddress: "127.0.0.1"
+            apiServerPort: 6443
+          EOF
+
+          # Create cluster
+          kind create cluster --config $KIND_CONFIG_FILE --name kind
+          kubectl cluster-info
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.9
+        with:
+          path: tmp/artifacts
+          merge-multiple: true
+
+      - name: Load images to local Docker registry
+        run: |
+          for image_archive in tmp/artifacts/*.tar; do
+            docker load --input "$image_archive"
+          done
+          docker images
+
+      - name: Compile CLI
+        if: ${{ inputs.taskfile-task == 'test:e2e:network' }}
+        run: |
+          task cli:compile
+
+      - name: Run end-to-end tests
+        env:
+          IMAGE_REPO: ${{ inputs.image_repo }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          E2E_COMPILE_OUTPUT_DIR: tmp
+        run: |
+          task ${{ inputs.taskfile-task }}
+
+      # - name: Export agent model
+      #   id: export
+      #   run: |
+      #     echo "## Agent Model" >> $GITHUB_STEP_SUMMARY
+
+      #     # Export agent model
+      #     echo "**Agent model**"
+      #     echo '```json' >> $GITHUB_STEP_SUMMARY
+      #     cat e2e/tmp/agent.json >> $GITHUB_STEP_SUMMARY
+      #     echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -55,103 +55,22 @@ jobs:
         run: |
           task test:unit
 
-  test-e2e:
-    name: End-to-end
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-        with:
-          fetch-depth: 0
+  test-e2e-local:
+    name: End-to-end local
+    uses: ./.github/workflows/reusable-test-e2e.yaml
+    with:
+      image_repo: ${{ inputs.image_repo }}
+      image_tag: ${{ inputs.image_tag }}
+      helm-version: ${{ inputs.helm-version }}
+      kind-version: ${{ inputs.kind-version }}
+      taskfile-task: "test:e2e:local"
 
-      - name: Login to ghcr.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          registry: ghcr.io
-          username: notused
-          password: ${{ secrets.GITHUB_TOKEN  }}
-
-      - name: Setup Taskfile
-        shell: bash
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24.1'
-          check-latest: true
-          cache-dependency-path: "**/*.sum"
-
-      #
-      # Install kubernetes tools
-      #
-      - name: Setup Helm
-        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
-        with:
-          version: ${{ inputs.helm-version }}
-
-      # - name: Set up Helm chart-testing
-      #   uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
-      #   with:
-      #     version: ${{ inputs.helm-ct-version }}
-
-      - name: Setup kind
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
-        with:
-          version: v${{ inputs.kind-version }}
-          install_only: true
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
-
-      #
-      # Setup cluster
-      #
-      - name: Setup Kind cluster
-        shell: bash
-        run: |
-          # Create cluster config
-          KIND_CONFIG_FILE=$(mktemp -p /tmp)
-          cat <<EOF > $KIND_CONFIG_FILE
-          kind: Cluster
-          apiVersion: kind.x-k8s.io/v1alpha4
-          networking:
-            apiServerAddress: "127.0.0.1"
-            apiServerPort: 6443
-          EOF
-
-          # Create cluster
-          kind create cluster --config $KIND_CONFIG_FILE --name kind
-          kubectl cluster-info
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4.1.9
-        with:
-          path: tmp/artifacts
-          merge-multiple: true
-
-      - name: Load images to local Docker registry
-        run: |
-          for image_archive in tmp/artifacts/*.tar; do
-            docker load --input "$image_archive"
-          done
-          docker images
-
-      - name: Run end-to-end tests
-        env:
-          IMAGE_REPO: ${{ inputs.image_repo }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
-          E2E_COMPILE_OUTPUT_DIR: tmp
-        run: |
-          task test:e2e
-
-      # - name: Export agent model
-      #   id: export
-      #   run: |
-      #     echo "## Agent Model" >> $GITHUB_STEP_SUMMARY
-
-      #     # Export agent model
-      #     echo "**Agent model**"
-      #     echo '```json' >> $GITHUB_STEP_SUMMARY
-      #     cat e2e/tmp/agent.json >> $GITHUB_STEP_SUMMARY
-      #     echo '```' >> $GITHUB_STEP_SUMMARY
+  test-e2e-network:
+    name: End-to-end network
+    uses: ./.github/workflows/reusable-test-e2e.yaml
+    with:
+      image_repo: ${{ inputs.image_repo }}
+      image_tag: ${{ inputs.image_tag }}
+      helm-version: ${{ inputs.helm-version }}
+      kind-version: ${{ inputs.kind-version }}
+      taskfile-task: "test:e2e:network"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -512,8 +512,15 @@ tasks:
       - echo "Done"
 
   test:e2e:
-    desc: Run end-to-end tests
+    desc: Run end-to-end tests for local deployment and network deployment
     aliases: [e2e]
+    cmds:
+      - task: test:e2e:local
+      - task: test:e2e:network
+
+  test:e2e:local:
+    desc: Run end-to-end tests for local deployment
+    aliases: [e2e:local]
     cmds:
       - defer: { task: deploy:kubernetes:local:cleanup }
       - defer: { task: deploy:kubernetes:local:port-forward:cleanup }
@@ -521,6 +528,21 @@ tasks:
       # NOTE: Run as a dedicated task instead of dependency, otherwise the port forwarding won't work
       - task: deploy:kubernetes:local
       - task: deploy:kubernetes:local:port-forward
+      # Run tests
+      - 'go -C ./e2e test -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 2h -timeout 2h -ginkgo.v .'
+
+  test:e2e:network:
+    desc: Run end-to-end tests for network deployment
+    aliases: [e2e:network]
+    env:
+      DIRECTORY_E2E_DEPLOYMENT_MODE: 'network'
+    cmds:
+      - defer: { task: deploy:kubernetes:network:cleanup }
+      - defer: { task: deploy:kubernetes:network:port-forward:cleanup }
+      # Bootstrap
+      # NOTE: Run as a dedicated task instead of dependency, otherwise the port forwarding won't work
+      - task: deploy:kubernetes:network
+      - task: deploy:kubernetes:network:port-forward
       # Run tests
       - 'go -C ./e2e test -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 2h -timeout 2h -ginkgo.v .'
 

--- a/e2e/client_test.go
+++ b/e2e/client_test.go
@@ -12,12 +12,19 @@ import (
 	coretypes "github.com/agntcy/dir/api/core/v1alpha1"
 	routingv1alpha1 "github.com/agntcy/dir/api/routing/v1alpha1"
 	"github.com/agntcy/dir/client"
+	"github.com/agntcy/dir/e2e/config"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/opencontainers/go-digest"
 )
 
-var _ = ginkgo.Describe("client end-to-end tests", func() {
+var _ = ginkgo.Describe("Running client end-to-end tests using a local single node deployment", func() {
+	ginkgo.BeforeEach(func() {
+		if cfg.DeploymentMode != config.DeploymentModeLocal {
+			ginkgo.Skip("Skipping test, not in local mode")
+		}
+	})
+
 	var err error
 	ctx := context.Background()
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,0 +1,57 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+)
+
+type DeploymentMode string
+
+const (
+	DeploymentModeLocal   DeploymentMode = "local"
+	DeploymentModeNetwork DeploymentMode = "network"
+)
+
+const (
+	DefaultEnvPrefix = "DIRECTORY_E2E"
+
+	DefaultDeploymentMode = DeploymentModeLocal
+)
+
+type Config struct {
+	DeploymentMode DeploymentMode `json:"deployment_mode,omitempty" mapstructure:"deployment_mode"`
+}
+
+func LoadConfig() (*Config, error) {
+	v := viper.NewWithOptions(
+		viper.KeyDelimiter("."),
+		viper.EnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_")),
+	)
+
+	v.SetEnvPrefix(DefaultEnvPrefix)
+	v.AllowEmptyEnv(true)
+	v.AutomaticEnv()
+
+	_ = v.BindEnv("deployment_mode")
+	v.SetDefault("deployment_mode", DefaultDeploymentMode)
+
+	// Load configuration into struct
+	decodeHooks := mapstructure.ComposeDecodeHookFunc(
+		mapstructure.TextUnmarshallerHookFunc(),
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.StringToSliceHookFunc(","),
+	)
+
+	config := &Config{}
+	if err := v.Unmarshal(config, viper.DecodeHook(decodeHooks)); err != nil {
+		return nil, fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	return config, nil
+}

--- a/e2e/dirctl_network_cmd_test.go
+++ b/e2e/dirctl_network_cmd_test.go
@@ -1,0 +1,169 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"bytes"
+	_ "embed"
+	"os"
+	"path/filepath"
+	"strings"
+
+	clicmd "github.com/agntcy/dir/cli/cmd"
+	initcmd "github.com/agntcy/dir/cli/cmd/network/init"
+	"github.com/agntcy/dir/e2e/config"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Running dirctl end-to-end tests for network commands", func() {
+	var (
+		tempDir     string
+		tempKeyPath string
+	)
+
+	ginkgo.BeforeEach(func() {
+		if cfg.DeploymentMode != config.DeploymentModeLocal {
+			ginkgo.Skip("Skipping test, not in local mode")
+		}
+
+		// Create temporary directory for test keys
+		var err error
+		tempDir, err = os.MkdirTemp("", "network-test")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Generate OpenSSL-style ED25519 key
+		_, privateKey, err := initcmd.GenerateED25519OpenSSLKey()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Write the private key to a temporary file
+		tempKeyPath = filepath.Join(tempDir, "test_key")
+		err = os.WriteFile(tempKeyPath, privateKey, 0o0600)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.AfterEach(func() {
+		// Cleanup temporary directory
+		err := os.RemoveAll(tempDir)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.Context("info command", func() {
+		ginkgo.It("should generate a peer ID from a valid ED25519 key", func() {
+			var outputBuffer bytes.Buffer
+
+			infoCmd := clicmd.RootCmd
+			infoCmd.SetOut(&outputBuffer)
+			infoCmd.SetArgs([]string{
+				"network",
+				"info",
+				tempKeyPath,
+			})
+
+			err := infoCmd.Execute()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Verify that the output is not empty
+			output := strings.TrimSpace(outputBuffer.String())
+			gomega.Expect(output).NotTo(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should fail with non-existent key file", func() {
+			var outputBuffer bytes.Buffer
+
+			infoCmd := clicmd.RootCmd
+			infoCmd.SetOut(&outputBuffer)
+			infoCmd.SetArgs([]string{
+				"network",
+				"info",
+				"non-existent-key-file",
+			})
+
+			err := infoCmd.Execute()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should fail with empty key path", func() {
+			var outputBuffer bytes.Buffer
+
+			infoCmd := clicmd.RootCmd
+			infoCmd.SetOut(&outputBuffer)
+			infoCmd.SetArgs([]string{
+				"network",
+				"info",
+				"",
+			})
+
+			err := infoCmd.Execute()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.Context("init command", func() {
+		ginkgo.It("should generate a new peer ID and save the key to specified output", func() {
+			outputPath := filepath.Join(tempDir, "generated.key")
+			var outputBuffer bytes.Buffer
+
+			initCmd := clicmd.RootCmd
+			initCmd.SetOut(&outputBuffer)
+			initCmd.SetArgs([]string{
+				"network",
+				"init",
+				"--output",
+				outputPath,
+			})
+
+			err := initCmd.Execute()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Verify that the output file exists
+			_, err = os.Stat(outputPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Verify file permissions
+			info, err := os.Stat(outputPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(info.Mode().Perm()).To(gomega.Equal(os.FileMode(0o0600)))
+
+			// Verify that the output is not empty and is a valid peer ID
+			output := strings.TrimSpace(outputBuffer.String())
+			gomega.Expect(output).NotTo(gomega.BeEmpty())
+			gomega.Expect(output).To(gomega.HavePrefix("12D3"))
+
+			// Verify that the generated key can be used with the info command
+			var infoBuffer bytes.Buffer
+			infoCmd := clicmd.RootCmd
+			infoCmd.SetOut(&infoBuffer)
+			infoCmd.SetArgs([]string{
+				"network",
+				"info",
+				outputPath,
+			})
+
+			err = infoCmd.Execute()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Verify that info command returns the same peer ID
+			infoOutput := strings.TrimSpace(infoBuffer.String())
+			gomega.Expect(infoOutput).To(gomega.Equal(output))
+		})
+
+		ginkgo.It("should fail when output directory doesn't exist and cannot be created", func() {
+			// Try to write to a location that should fail
+			var outputBuffer bytes.Buffer
+
+			initCmd := clicmd.RootCmd
+			initCmd.SetOut(&outputBuffer)
+			initCmd.SetArgs([]string{
+				"network",
+				"init",
+				"--output",
+				"/nonexistent/directory/key.pem",
+			})
+
+			err := initCmd.Execute()
+			gomega.Expect(err).To(gomega.HaveOccurred())
+		})
+	})
+})

--- a/e2e/dirctl_network_deploy_test.go
+++ b/e2e/dirctl_network_deploy_test.go
@@ -1,0 +1,193 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"bytes"
+	"strings"
+
+	clicmd "github.com/agntcy/dir/cli/cmd"
+	"github.com/agntcy/dir/e2e/config"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+)
+
+const (
+	Peer1Addr = "0.0.0.0:8890"
+	Peer2Addr = "0.0.0.0:8891"
+	Peer3Addr = "0.0.0.0:8892"
+)
+
+var peerAddrs = []string{Peer1Addr, Peer2Addr, Peer3Addr}
+
+var _ = ginkgo.Describe("Running dirctl end-to-end tests using a network multi peer deployment", func() {
+	ginkgo.BeforeEach(func() {
+		if cfg.DeploymentMode != config.DeploymentModeNetwork {
+			ginkgo.Skip("Skipping test, not in network mode")
+		}
+	})
+
+	// Test params
+	var tempAgentDigest string
+
+	ginkgo.It("should push an agent to peer 1", func() {
+		var outputBuffer bytes.Buffer
+
+		pushCmd := clicmd.RootCmd
+		pushCmd.SetOut(&outputBuffer)
+		pushCmd.SetArgs([]string{
+			"push",
+			"./testdata/agent.json",
+			"--server-addr",
+			Peer1Addr,
+		})
+
+		err := pushCmd.Execute()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		tempAgentDigest = outputBuffer.String()
+
+		// Ensure the digest is valid
+		_, err = digest.Parse(tempAgentDigest)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should pull the agent from peer 1", func() {
+		var outputBuffer bytes.Buffer
+
+		pullCmd := clicmd.RootCmd
+		pullCmd.SetOut(&outputBuffer)
+		pullCmd.SetArgs([]string{
+			"pull",
+			tempAgentDigest,
+			"--server-addr",
+			Peer1Addr,
+		})
+
+		err := pullCmd.Execute()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should fail to pull the agent from peer 2", func() {
+		var outputBuffer bytes.Buffer
+
+		pullCmd := clicmd.RootCmd
+		pullCmd.SetOut(&outputBuffer)
+		pullCmd.SetArgs([]string{
+			"pull",
+			tempAgentDigest,
+			"--server-addr",
+			Peer2Addr,
+		})
+
+		err := pullCmd.Execute()
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should publish an agent to the network on peer 1", func() {
+		var outputBuffer bytes.Buffer
+
+		publishCmd := clicmd.RootCmd
+		publishCmd.SetOut(&outputBuffer)
+		publishCmd.SetArgs([]string{
+			"publish",
+			tempAgentDigest,
+			"--server-addr",
+			Peer1Addr,
+			"--network",
+		})
+
+		err := publishCmd.Execute()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should fail publish an agent to the network on peer 2 that does not store the agent", func() {
+		var outputBuffer bytes.Buffer
+
+		publishCmd := clicmd.RootCmd
+		publishCmd.SetOut(&outputBuffer)
+		publishCmd.SetArgs([]string{
+			"publish",
+			tempAgentDigest,
+			"--server-addr",
+			Peer2Addr,
+			"--network",
+		})
+
+		err := publishCmd.Execute()
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("should list by digest on all peers", func() {
+		for _, addr := range peerAddrs {
+			var outputBuffer bytes.Buffer
+
+			listCmd := clicmd.RootCmd
+			listCmd.SetOut(&outputBuffer)
+			listCmd.SetArgs([]string{
+				"list",
+				"--digest",
+				tempAgentDigest,
+				"--server-addr",
+				addr,
+			})
+
+			err := listCmd.Execute()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Validate the output contains the expected digest
+			output := strings.TrimSpace(outputBuffer.String()) // Trim trailing whitespace and newlines
+
+			// Extract the Peer ID/hash from the output
+			peerIDStart := strings.Index(output, "Peer ") + len("Peer ")
+			peerIDEnd := strings.Index(output[peerIDStart:], "\n") + peerIDStart
+			gomega.Expect(peerIDStart).NotTo(gomega.Equal(-1), "Peer ID not found in output")
+			peerID := output[peerIDStart:peerIDEnd]
+
+			// Build the expected output string
+			expectedOutput := "Peer " + peerID + "\n" +
+				"  Digest: " + tempAgentDigest + "\n" +
+				"  Labels: /skills/Natural Language Processing/Text Completion, /skills/Natural Language Processing/Problem Solving, /domains/research, /features/runtime/framework, /features/runtime/language"
+
+			// Validate the output matches the expected format
+			gomega.Expect(output).To(gomega.Equal(expectedOutput))
+		}
+	})
+
+	ginkgo.It("should list by skill on all peers", func() {
+		for _, addr := range peerAddrs {
+			var outputBuffer bytes.Buffer
+
+			listCmd := clicmd.RootCmd
+			listCmd.SetOut(&outputBuffer)
+			listCmd.SetArgs([]string{
+				"list",
+				"\"/skills/Natural Language Processing\"",
+				"--server-addr",
+				addr,
+			})
+
+			err := listCmd.Execute()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Validate the output contains the expected digest
+			output := strings.TrimSpace(outputBuffer.String()) // Trim trailing whitespace and newlines
+
+			// Extract the Peer ID/hash from the output
+			peerIDStart := strings.Index(output, "Peer ") + len("Peer ")
+			peerIDEnd := strings.Index(output[peerIDStart:], "\n") + peerIDStart
+			gomega.Expect(peerIDStart).NotTo(gomega.Equal(-1), "Peer ID not found in output")
+			peerID := output[peerIDStart:peerIDEnd]
+
+			// Build the expected output string
+			expectedOutput := "Peer " + peerID + "\n" +
+				"  Digest: " + tempAgentDigest + "\n" +
+				"  Labels: /skills/Natural Language Processing/Text Completion, /skills/Natural Language Processing/Problem Solving, /domains/research, /features/runtime/framework, /features/runtime/language"
+
+			// Validate the output matches the expected format
+			gomega.Expect(output).To(gomega.Equal(expectedOutput))
+		}
+	})
+})

--- a/e2e/dirctl_test.go
+++ b/e2e/dirctl_test.go
@@ -8,10 +8,9 @@ import (
 	_ "embed"
 	"os"
 	"path/filepath"
-	"strings"
 
 	clicmd "github.com/agntcy/dir/cli/cmd"
-	initcmd "github.com/agntcy/dir/cli/cmd/network/init"
+	"github.com/agntcy/dir/e2e/config"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/opencontainers/go-digest"
@@ -20,7 +19,13 @@ import (
 //go:embed testdata/agent.json
 var expectedAgentJSON []byte
 
-var _ = ginkgo.Describe("dirctl end-to-end tests", func() {
+var _ = ginkgo.Describe("Running dirctl end-to-end tests using a local single node deployment", func() {
+	ginkgo.BeforeEach(func() {
+		if cfg.DeploymentMode != config.DeploymentModeLocal {
+			ginkgo.Skip("Skipping test, not in local mode")
+		}
+	})
+
 	// Test params
 	var tempAgentDigest string
 
@@ -58,7 +63,7 @@ var _ = ginkgo.Describe("dirctl end-to-end tests", func() {
 	})
 
 	ginkgo.Context("agent push and pull", func() {
-		ginkgo.It("should push an agent", func() {
+		ginkgo.It("should successfully push an agent", func() {
 			var outputBuffer bytes.Buffer
 
 			pushCmd := clicmd.RootCmd
@@ -78,7 +83,7 @@ var _ = ginkgo.Describe("dirctl end-to-end tests", func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("should pull an existing agent", func() {
+		ginkgo.It("should successfully pull an existing agent", func() {
 			var outputBuffer bytes.Buffer
 
 			pullCmd := clicmd.RootCmd
@@ -150,7 +155,7 @@ var _ = ginkgo.Describe("dirctl end-to-end tests", func() {
 	})
 
 	ginkgo.Context("agent delete", func() {
-		ginkgo.It("should delete an agent", func() {
+		ginkgo.It("should successfully delete an agent", func() {
 			var outputBuffer bytes.Buffer
 
 			deleteCmd := clicmd.RootCmd
@@ -176,153 +181,6 @@ var _ = ginkgo.Describe("dirctl end-to-end tests", func() {
 
 			err := pullCmd.Execute()
 			gomega.Expect(err).To(gomega.HaveOccurred())
-		})
-	})
-
-	ginkgo.Context("network commands", func() {
-		var (
-			tempDir     string
-			tempKeyPath string
-		)
-
-		ginkgo.BeforeEach(func() {
-			// Create temporary directory for test keys
-			var err error
-			tempDir, err = os.MkdirTemp("", "network-test")
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Generate OpenSSL-style ED25519 key
-			_, privateKey, err := initcmd.GenerateED25519OpenSSLKey()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-			// Write the private key to a temporary file
-			tempKeyPath = filepath.Join(tempDir, "test_key")
-			err = os.WriteFile(tempKeyPath, privateKey, 0o0600)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-
-		ginkgo.AfterEach(func() {
-			// Cleanup temporary directory
-			err := os.RemoveAll(tempDir)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		})
-
-		ginkgo.Context("info command", func() {
-			ginkgo.It("should generate a peer ID from a valid ED25519 key", func() {
-				var outputBuffer bytes.Buffer
-
-				infoCmd := clicmd.RootCmd
-				infoCmd.SetOut(&outputBuffer)
-				infoCmd.SetArgs([]string{
-					"network",
-					"info",
-					tempKeyPath,
-				})
-
-				err := infoCmd.Execute()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// Verify that the output is not empty
-				output := strings.TrimSpace(outputBuffer.String())
-				gomega.Expect(output).NotTo(gomega.BeEmpty())
-			})
-
-			ginkgo.It("should fail with non-existent key file", func() {
-				var outputBuffer bytes.Buffer
-
-				infoCmd := clicmd.RootCmd
-				infoCmd.SetOut(&outputBuffer)
-				infoCmd.SetArgs([]string{
-					"network",
-					"info",
-					"non-existent-key-file",
-				})
-
-				err := infoCmd.Execute()
-				gomega.Expect(err).To(gomega.HaveOccurred())
-			})
-
-			ginkgo.It("should fail with empty key path", func() {
-				var outputBuffer bytes.Buffer
-
-				infoCmd := clicmd.RootCmd
-				infoCmd.SetOut(&outputBuffer)
-				infoCmd.SetArgs([]string{
-					"network",
-					"info",
-					"",
-				})
-
-				err := infoCmd.Execute()
-				gomega.Expect(err).To(gomega.HaveOccurred())
-			})
-		})
-
-		ginkgo.Context("init command", func() {
-			ginkgo.It("should generate a new peer ID and save the key to specified output", func() {
-				outputPath := filepath.Join(tempDir, "generated.key")
-				var outputBuffer bytes.Buffer
-
-				initCmd := clicmd.RootCmd
-				initCmd.SetOut(&outputBuffer)
-				initCmd.SetArgs([]string{
-					"network",
-					"init",
-					"--output",
-					outputPath,
-				})
-
-				err := initCmd.Execute()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// Verify that the output file exists
-				_, err = os.Stat(outputPath)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// Verify file permissions
-				info, err := os.Stat(outputPath)
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(info.Mode().Perm()).To(gomega.Equal(os.FileMode(0o0600)))
-
-				// Verify that the output is not empty and is a valid peer ID
-				output := strings.TrimSpace(outputBuffer.String())
-				gomega.Expect(output).NotTo(gomega.BeEmpty())
-				gomega.Expect(output).To(gomega.HavePrefix("12D3"))
-
-				// Verify that the generated key can be used with the info command
-				var infoBuffer bytes.Buffer
-				infoCmd := clicmd.RootCmd
-				infoCmd.SetOut(&infoBuffer)
-				infoCmd.SetArgs([]string{
-					"network",
-					"info",
-					outputPath,
-				})
-
-				err = infoCmd.Execute()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-				// Verify that info command returns the same peer ID
-				infoOutput := strings.TrimSpace(infoBuffer.String())
-				gomega.Expect(infoOutput).To(gomega.Equal(output))
-			})
-
-			ginkgo.It("should fail when output directory doesn't exist and cannot be created", func() {
-				// Try to write to a location that should fail
-				var outputBuffer bytes.Buffer
-
-				initCmd := clicmd.RootCmd
-				initCmd.SetOut(&outputBuffer)
-				initCmd.SetArgs([]string{
-					"network",
-					"init",
-					"--output",
-					"/nonexistent/directory/key.pem",
-				})
-
-				err := initCmd.Execute()
-				gomega.Expect(err).To(gomega.HaveOccurred())
-			})
 		})
 	})
 })

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -14,9 +14,11 @@ require (
 	github.com/agntcy/dir/api v0.2.1
 	github.com/agntcy/dir/cli v0.2.1
 	github.com/agntcy/dir/client v0.2.1
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/spf13/viper v1.20.1
 )
 
 require (
@@ -148,7 +150,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect
@@ -197,7 +198,6 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/spf13/viper v1.20.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/sylabs/sif/v2 v2.20.2 // indirect
 	github.com/sylabs/squashfs v1.0.4 // indirect

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -1,16 +1,24 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e_test
+package e2e
 
 import (
 	"testing"
 
+	"github.com/agntcy/dir/e2e/config"
 	ginkgo "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
 
+var cfg *config.Config
+
 func TestEndToEnd(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	var err error
+	cfg, err = config.LoadConfig()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	ginkgo.RunSpecs(t, "Run end-to-end tests")
 }

--- a/server/routing/handler.go
+++ b/server/routing/handler.go
@@ -1,11 +1,11 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint
 package routing
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -39,16 +39,26 @@ func (h *handler) AddProvider(ctx context.Context, key []byte, prov peer.AddrInf
 		handlerLogger.Error("Failed to handle announce", "error", err)
 	}
 
-	return h.ProviderManager.AddProvider(ctx, key, prov)
+	if err := h.ProviderManager.AddProvider(ctx, key, prov); err != nil {
+		return fmt.Errorf("failed to add provider: %w", err)
+	}
+
+	return nil
 }
 
 func (h *handler) GetProviders(ctx context.Context, key []byte) ([]peer.AddrInfo, error) {
-	return h.ProviderManager.GetProviders(ctx, key)
+	providers, err := h.ProviderManager.GetProviders(ctx, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get providers: %w", err)
+	}
+
+	return providers, nil
 }
 
 // handleAnnounce tries to parse the data from provider in order to update the local routing data
 // about the content and peer.
-func (h *handler) handleAnnounce(ctx context.Context, key []byte, prov peer.AddrInfo) error {
+// nolint:unparam
+func (h *handler) handleAnnounce(_ context.Context, key []byte, prov peer.AddrInfo) error {
 	handlerLogger.Debug("Received announcement event", "key", key, "provider", prov)
 
 	// validete if the provider is not the same as the host

--- a/server/routing/handler_test.go
+++ b/server/routing/handler_test.go
@@ -1,7 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint
+//nolint:testifylint
 package routing
 
 import (
@@ -43,8 +43,9 @@ func TestHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	// push the data
-	data, _ := json.Marshal(testAgent)
-	testRef, err = secondNode.remote.storeAPI.Push(t.Context(), testRef, bytes.NewReader(data))
+	data, err := json.Marshal(testAgent)
+	assert.NoError(t, err)
+	_, err = secondNode.remote.storeAPI.Push(t.Context(), testRef, bytes.NewReader(data))
 	assert.NoError(t, err)
 
 	// announce the key

--- a/server/routing/test_utils.go
+++ b/server/routing/test_utils.go
@@ -1,7 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint
+//nolint:testifylint
 package routing
 
 import (
@@ -35,6 +35,7 @@ func toPtr[T any](v T) *T {
 	return &v
 }
 
+//nolint:revive
 func newTestServer(t *testing.T, ctx context.Context, bootPeers []string) *route {
 	t.Helper()
 
@@ -68,5 +69,9 @@ func newTestServer(t *testing.T, ctx context.Context, bootPeers []string) *route
 	r, err := New(ctx, s, opts)
 	assert.NoError(t, err)
 
-	return r.(*route)
+	// check the type assertion
+	routeInstance, ok := r.(*route)
+	assert.True(t, ok, "expected r to be of type *route")
+
+	return routeInstance
 }


### PR DESCRIPTION
Check https://github.com/agntcy/dir/actions/runs/14832685915/job/41637153235#step:12:15 for logs showing the issues described below

* When an agent was pushed and published on Peer 1, the output of `dirctl list "/skills/Natural Language Processing" --server-addr peer1 --network` was empty. This was happening because we skipped running list on self, thus no agent was found. Please check https://github.com/agntcy/dir/commit/c11a1da5bfbf5ac8320ce9b3a83b57149e394a8f for the fix.
* On a network with a bootstrap node and 3 other nodes, when an agent was pushed and published on Peer 1, the output of `dirctl list "/skills/Natural Language Processing" --server-addr peer2 --network` was 4 agents each on a different node. This happened because all "searched" peers are connected to the peer that holds the agent and output was printing the incorrect Peer ID for the agent. To avoid repeated output items, we need to skip already seen items. Please note that there is planned roadmap work to enhance how we traverse peers, check https://github.com/agntcy/dir/commit/71ccce21d689a69b587ce9e49b998a3200014817 for the fix
* Add a base e2e test for network deployments
* Fix linter 