### PR TITLE
refactor: distroless docker images

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 RUN xx-verify /bin/dirctl
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
 
 COPY --from=builder ["/bin/dirctl", "/bin/dirctl"]
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -25,7 +25,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 ARG BUILD_OPTS
 ARG EXTRA_LDFLAGS
 
-ENV CGO_ENABLED=1
+# TODO(adamtagscherer): Currently we don't need C libraries but in the future we may need to turn this on once we add
+# security libraries, etc.
+ENV CGO_ENABLED=0
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -36,8 +38,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN xx-verify /bin/dirctl
 
 FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
-
-COPY --from=builder ["/bin/dirctl", "/bin/dirctl"]
+WORKDIR /
+COPY --from=builder /bin/dirctl ./dirctl
 
 USER 65532:65532
-ENTRYPOINT ["/bin/dirctl"]
+ENTRYPOINT ["./dirctl"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -35,12 +35,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 RUN xx-verify /bin/dirctl
 
-FROM alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
-
-RUN apk add --update --no-cache \
-    ca-certificates \
-    libc6-compat
+FROM gcr.io/distroless/static:nonroot
 
 COPY --from=builder ["/bin/dirctl", "/bin/dirctl"]
 
+USER nonroot:nonroot
 ENTRYPOINT ["/bin/dirctl"]

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -39,5 +39,5 @@ FROM gcr.io/distroless/static:nonroot
 
 COPY --from=builder ["/bin/dirctl", "/bin/dirctl"]
 
-USER nonroot:nonroot
+USER 65532:65532
 ENTRYPOINT ["/bin/dirctl"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -39,5 +39,5 @@ FROM gcr.io/distroless/static:nonroot
 
 COPY --from=builder ["/bin/apiserver", "/bin/apiserver"]
 
-USER nonroot:nonroot
+USER 65532:65532
 ENTRYPOINT ["/bin/apiserver", "run"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 RUN xx-verify /bin/apiserver
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
 
 COPY --from=builder ["/bin/apiserver", "/bin/apiserver"]
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -35,12 +35,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 RUN xx-verify /bin/apiserver
 
-FROM alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d
-
-RUN apk add --update --no-cache \
-    ca-certificates \
-    libc6-compat
+FROM gcr.io/distroless/static:nonroot
 
 COPY --from=builder ["/bin/apiserver", "/bin/apiserver"]
 
+USER nonroot:nonroot
 ENTRYPOINT ["/bin/apiserver", "run"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -25,7 +25,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 ARG BUILD_OPTS
 ARG EXTRA_LDFLAGS
 
-ENV CGO_ENABLED=1
+# TODO(adamtagscherer): Currently we don't need C libraries but in the future we may need to turn this on once we add
+# security libraries, etc.
+ENV CGO_ENABLED=0
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -36,8 +38,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN xx-verify /bin/apiserver
 
 FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc
-
-COPY --from=builder ["/bin/apiserver", "/bin/apiserver"]
+WORKDIR /
+COPY --from=builder /bin/apiserver ./apiserver
 
 USER 65532:65532
-ENTRYPOINT ["/bin/apiserver", "run"]
+ENTRYPOINT ["./apiserver", "run"]


### PR DESCRIPTION
This PR removes the `alpine` runner image from the `cli` and `server` dockerfiles and substitutes it with a `distroless` image.