### PR TITLE
fix: cli hub subcommand to exit with 1 on fatal error

### DIFF
--- a/cli/cmd/hub/hub.go
+++ b/cli/cmd/hub/hub.go
@@ -11,10 +11,11 @@ func NewCommand(hub Hub) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "hub",
 		Short: "CLI tool to interact with Agent Hub implementation",
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = hub.Run(cmd.Context(), args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return hub.Run(cmd.Context(), args)
 		},
 		DisableFlagParsing: true,
+		SilenceUsage:       true,
 	}
 
 	return cmd

--- a/cli/cmd/push/push.go
+++ b/cli/cmd/push/push.go
@@ -103,7 +103,7 @@ func runCommand(cmd *cobra.Command, source io.ReadCloser) error {
 
 func getReader(fpath string, fromFile bool) (io.ReadCloser, error) {
 	if fpath == "" && !fromFile {
-		return nil, errors.New("reqired file path or --stdin flag")
+		return nil, errors.New("required file path or --stdin flag")
 	}
 
 	if fpath != "" {

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"regexp"
 
 	"github.com/agntcy/dir/hub/cmd"
 	"github.com/agntcy/dir/hub/cmd/options"
@@ -44,18 +43,14 @@ func (h *hub) Run(ctx context.Context, args []string) error {
 	c.SetOut(outBuf)
 	c.SetArgs(args)
 
-	var outStr string
-
 	if err = c.ExecuteContext(ctx); err != nil {
-		r := regexp.MustCompile("(\n\\s*)hub")
-		outStr = r.ReplaceAllString(outStr, "\n dirctl hub")
-
-		fmt.Fprintln(os.Stderr, errBuf.String())
-	} else {
-		outStr = outBuf.String()
+		return fmt.Errorf("%w", err)
 	}
 
-	fmt.Fprintln(os.Stdout, outStr)
+	outStr := outBuf.String()
+	if outStr != "" {
+		fmt.Fprintln(os.Stdout, outStr)
+	}
 
 	return nil
 }


### PR DESCRIPTION
The `hub` subcommands of `dirctl` returned with exit code 0 on error, now errors are propagated so cobra can exit with status code 1 in this case.