### PR TITLE
feat: improve grpc error handling

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -182,3 +182,15 @@ dirctl list info
 # Get label summary details across the network
 dirctl list info --network
 ```
+
+### gRPC Error Codes
+
+The following table lists the gRPC error codes returned by the server APIs, along with a description of when each code is used:
+
+| Error Code                | Description                                                                                                                 |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `codes.InvalidArgument`   | Returned when the client provides an invalid or malformed argument, such as a missing or invalid object reference or agent. |
+| `codes.NotFound`          | Returned when the requested object does not exist in the local store or across the network.                                 |
+| `codes.FailedPrecondition`| Returned when the server environment or configuration is not in the required state (e.g., failed to create a directory or temp file, unsupported provider in config). |
+| `codes.Internal`          | Returned for unexpected internal errors, such as I/O failures, serialization errors, or other server-side issues.           |
+| `codes.Canceled`          | Returned when the operation is canceled by the client or context expires.                                                   |

--- a/server/controller/routing.go
+++ b/server/controller/routing.go
@@ -5,14 +5,14 @@ package controller
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	coretypes "github.com/agntcy/dir/api/core/v1alpha1"
 	routingtypes "github.com/agntcy/dir/api/routing/v1alpha1"
 	"github.com/agntcy/dir/server/types"
 	"github.com/agntcy/dir/utils/logging"
 	"github.com/opencontainers/go-digest"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -37,7 +37,9 @@ func (c *routingCtlr) Publish(ctx context.Context, req *routingtypes.PublishRequ
 
 	ref, agent, err := c.getAgent(ctx, req.GetRecord())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get agent: %w", err)
+		st := status.Convert(err)
+
+		return nil, status.Errorf(st.Code(), "failed to get agent: %s", st.Message())
 	}
 
 	err = c.routing.Publish(ctx, &coretypes.Object{
@@ -45,7 +47,9 @@ func (c *routingCtlr) Publish(ctx context.Context, req *routingtypes.PublishRequ
 		Agent: agent,
 	}, req.GetNetwork())
 	if err != nil {
-		return nil, fmt.Errorf("failed to publish: %w", err)
+		st := status.Convert(err)
+
+		return nil, status.Errorf(st.Code(), "failed to publish: %s", st.Message())
 	}
 
 	return &emptypb.Empty{}, nil
@@ -56,7 +60,9 @@ func (c *routingCtlr) List(req *routingtypes.ListRequest, srv routingtypes.Routi
 
 	itemChan, err := c.routing.List(srv.Context(), req)
 	if err != nil {
-		return fmt.Errorf("failed to list: %w", err)
+		st := status.Convert(err)
+
+		return status.Errorf(st.Code(), "failed to list: %s", st.Message())
 	}
 
 	items := []*routingtypes.ListResponse_Item{}
@@ -65,7 +71,7 @@ func (c *routingCtlr) List(req *routingtypes.ListRequest, srv routingtypes.Routi
 	}
 
 	if err := srv.Send(&routingtypes.ListResponse{Items: items}); err != nil {
-		return fmt.Errorf("failed to send: %w", err)
+		return status.Errorf(codes.Internal, "failed to send list response: %v", err)
 	}
 
 	return nil
@@ -76,7 +82,9 @@ func (c *routingCtlr) Unpublish(ctx context.Context, req *routingtypes.Unpublish
 
 	ref, agent, err := c.getAgent(ctx, req.GetRecord())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get agent: %w", err)
+		st := status.Convert(err)
+
+		return nil, status.Errorf(st.Code(), "failed to get agent: %s", st.Message())
 	}
 
 	err = c.routing.Unpublish(ctx, &coretypes.Object{
@@ -84,7 +92,9 @@ func (c *routingCtlr) Unpublish(ctx context.Context, req *routingtypes.Unpublish
 		Agent: agent,
 	}, req.GetNetwork())
 	if err != nil {
-		return nil, fmt.Errorf("failed to publish: %w", err)
+		st := status.Convert(err)
+
+		return nil, status.Errorf(st.Code(), "failed to unpublish: %s", st.Message())
 	}
 
 	return &emptypb.Empty{}, nil
@@ -94,41 +104,45 @@ func (c *routingCtlr) getAgent(ctx context.Context, ref *coretypes.ObjectRef) (*
 	routingLogger.Debug("Called routing controller's getAgent method", "ref", ref)
 
 	if ref == nil || ref.GetType() == "" {
-		return nil, nil, errors.New("record is required")
+		return nil, nil, status.Errorf(codes.InvalidArgument, "object reference is required and must have a type")
 	}
 
 	if ref.GetDigest() == "" {
-		return nil, nil, errors.New("digest is required")
+		return nil, nil, status.Errorf(codes.InvalidArgument, "object reference must have a digest")
 	}
 
 	_, err := digest.Parse(ref.GetDigest())
 	if err != nil {
-		return nil, nil, fmt.Errorf("invalid digest: %w", err)
+		return nil, nil, status.Errorf(codes.InvalidArgument, "invalid digest: %v", err)
 	}
 
 	ref, err = c.store.Lookup(ctx, ref)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to lookup: %w", err)
+		st := status.Convert(err)
+
+		return nil, nil, status.Errorf(st.Code(), "failed to lookup object: %s", st.Message())
 	}
 
 	if ref.GetSize() > 4*1024*1024 {
-		return nil, nil, errors.New("size is too large")
+		return nil, nil, status.Errorf(codes.InvalidArgument, "object size exceeds maximum limit of 4MB")
 	}
 
 	if ref.GetType() != coretypes.ObjectType_OBJECT_TYPE_AGENT.String() {
-		return nil, nil, errors.New("unsupported object type")
+		return nil, nil, status.Errorf(codes.InvalidArgument, "object type must be %s", coretypes.ObjectType_OBJECT_TYPE_AGENT.String())
 	}
 
 	reader, err := c.store.Pull(ctx, ref)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to pull: %w", err)
+		st := status.Convert(err)
+
+		return nil, nil, status.Errorf(st.Code(), "failed to pull object: %s", st.Message())
 	}
 
 	agent := &coretypes.Agent{}
 
 	_, err = agent.LoadFromReader(reader)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to load agent: %w", err)
+		return nil, nil, status.Errorf(codes.Internal, "failed to load agent from reader: %v", err)
 	}
 
 	return ref, agent, nil

--- a/server/controller/store.go
+++ b/server/controller/store.go
@@ -9,13 +9,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 
 	coretypes "github.com/agntcy/dir/api/core/v1alpha1"
 	storetypes "github.com/agntcy/dir/api/store/v1alpha1"
 	"github.com/agntcy/dir/server/types"
 	"github.com/agntcy/dir/utils/logging"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -41,7 +42,7 @@ func (s storeCtrl) Push(stream storetypes.StoreService_PushServer) error {
 	// TODO: validate
 	firstMessage, err := stream.Recv()
 	if err != nil {
-		return fmt.Errorf("failed to receive first message: %w", err)
+		return status.Errorf(codes.InvalidArgument, "failed to receive first message: %v", err)
 	}
 
 	storeLogger.Debug("Called store contoller's Push method",
@@ -97,13 +98,13 @@ func (s storeCtrl) Push(stream storetypes.StoreService_PushServer) error {
 	// Read input
 	agent := &coretypes.Agent{}
 	if _, err := agent.LoadFromReader(pr); err != nil {
-		return fmt.Errorf("failed to process agent: %w", err)
+		return status.Errorf(codes.Internal, "failed to load agent from reader: %v", err)
 	}
 
 	// Convert agent to JSON to drop additional fields
 	agentJSON, err := json.Marshal(agent)
 	if err != nil {
-		return fmt.Errorf("failed to marshal agent: %w", err)
+		return status.Errorf(codes.Internal, "failed to marshal agent to JSON: %v", err)
 	}
 
 	// Validate agent
@@ -111,18 +112,20 @@ func (s storeCtrl) Push(stream storetypes.StoreService_PushServer) error {
 	// This does not validate the signature itself, but only checks if it is set.
 	// NOTE: we can still push agents with bogus signatures, but we will not be able to verify them.
 	if agent.GetSignature() == nil {
-		return errors.New("agent signature is required")
+		return status.Error(codes.InvalidArgument, "agent signature is required")
 	}
 
 	// Size validation
 	if len(agentJSON) > maxAgentSize {
-		return fmt.Errorf("agent size exceeds maximum size of %d bytes", maxAgentSize)
+		return status.Errorf(codes.InvalidArgument, "agent size exceeds maximum size of %d bytes", maxAgentSize)
 	}
 
 	// Push to underlying store
 	ref, err = s.store.Push(stream.Context(), firstMessage.GetRef(), bytes.NewReader(agentJSON))
 	if err != nil {
-		return fmt.Errorf("failed to push: %w", err)
+		st := status.Convert(err)
+
+		return status.Errorf(st.Code(), "failed to push object to store: %s", st.Message())
 	}
 
 	return stream.SendAndClose(ref)
@@ -134,13 +137,17 @@ func (s storeCtrl) Pull(req *coretypes.ObjectRef, stream storetypes.StoreService
 	// lookup (maybe not needed)
 	ref, err := s.store.Lookup(stream.Context(), req)
 	if err != nil {
-		return fmt.Errorf("failed to lookup: %w", err)
+		st := status.Convert(err)
+
+		return status.Errorf(st.Code(), "failed to lookup object: %v", st.Message())
 	}
 
 	// pull
 	reader, err := s.store.Pull(stream.Context(), ref)
 	if err != nil {
-		return fmt.Errorf("failed to pull: %w", err)
+		st := status.Convert(err)
+
+		return status.Errorf(st.Code(), "failed to pull object: %v", st.Message())
 	}
 
 	buf := make([]byte, 4096) //nolint:mnd
@@ -156,7 +163,7 @@ func (s storeCtrl) Pull(req *coretypes.ObjectRef, stream storetypes.StoreService
 
 		if readErr != io.EOF && readErr != nil {
 			// return if a non-nil error and stream was not fully read
-			return fmt.Errorf("failed to read: %w", err)
+			return status.Errorf(codes.Internal, "failed to read: %v", readErr)
 		}
 
 		// forward data
@@ -164,7 +171,7 @@ func (s storeCtrl) Pull(req *coretypes.ObjectRef, stream storetypes.StoreService
 			Data: buf[:n],
 		})
 		if err != nil {
-			return fmt.Errorf("failed to send: %w", err)
+			return status.Errorf(codes.Internal, "failed to send data: %v", err)
 		}
 	}
 }
@@ -174,7 +181,7 @@ func (s storeCtrl) Lookup(ctx context.Context, req *coretypes.ObjectRef) (*coret
 
 	// validate
 	if req.GetDigest() == "" {
-		return nil, errors.New("digest is required")
+		return nil, status.Error(codes.InvalidArgument, "digest is required")
 	}
 
 	// TODO: add caching to avoid querying the Storage API
@@ -182,7 +189,9 @@ func (s storeCtrl) Lookup(ctx context.Context, req *coretypes.ObjectRef) (*coret
 	// lookup
 	meta, err := s.store.Lookup(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lookup: %w", err)
+		st := status.Convert(err)
+
+		return nil, status.Errorf(st.Code(), "failed to lookup object: %s", st.Message())
 	}
 
 	return meta, nil
@@ -192,12 +201,14 @@ func (s storeCtrl) Delete(ctx context.Context, req *coretypes.ObjectRef) (*empty
 	storeLogger.Debug("Called store contoller's Delete method", "req", req)
 
 	if req.GetDigest() == "" {
-		return nil, errors.New("digest is required")
+		return nil, status.Error(codes.InvalidArgument, "digest is required")
 	}
 
 	err := s.store.Delete(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to delete: %w", err)
+		st := status.Convert(err)
+
+		return nil, status.Errorf(st.Code(), "failed to delete object: %s", st.Message())
 	}
 
 	return &emptypb.Empty{}, nil

--- a/server/routing/routing_local_test.go
+++ b/server/routing/routing_local_test.go
@@ -34,7 +34,7 @@ func TestPublish_InvalidObject(t *testing.T) {
 		}, true)
 
 		assert.Error(t, err)
-		assert.Equal(t, "invalid object reference: <nil>", err.Error())
+		assert.ErrorContains(t, err, "invalid object reference")
 	})
 }
 

--- a/server/store/oci/oci.go
+++ b/server/store/oci/oci.go
@@ -253,7 +253,7 @@ func (s *store) Delete(ctx context.Context, ref *coretypes.ObjectRef) error {
 	case *remote.Repository:
 		return s.deleteFromRemoteRepository(ctx, repo, ref)
 	default:
-		return status.Errorf(codes.Unimplemented, "unsupported repo type: %T", s.repo)
+		return status.Errorf(codes.FailedPrecondition, "unsupported repo type: %T", s.repo)
 	}
 }
 

--- a/server/store/oci/oci.go
+++ b/server/store/oci/oci.go
@@ -7,7 +7,6 @@ package oci
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +20,8 @@ import (
 	"github.com/agntcy/dir/utils/logging"
 	ocidigest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/oci"
 	"oras.land/oras-go/v2/registry/remote"
@@ -117,7 +118,9 @@ func (s *store) Push(ctx context.Context, ref *coretypes.ObjectRef, contents io.
 	// push raw data
 	blobRef, blobDesc, err := s.pushData(ctx, ref, contents)
 	if err != nil {
-		return nil, fmt.Errorf("failed to push data: %w", err)
+		st := status.Convert(err)
+
+		return nil, status.Errorf(st.Code(), "failed to push data: %s", st.Message())
 	}
 
 	// set annotations for manifest
@@ -163,13 +166,17 @@ func (s *store) Lookup(ctx context.Context, ref *coretypes.ObjectRef) (*coretype
 	{
 		exists, err := s.repo.Exists(ctx, ocispec.Descriptor{Digest: ocidigest.Digest(ref.GetDigest())})
 		if err != nil {
-			return nil, fmt.Errorf("failed to check if object exists: %w", err)
+			if strings.Contains(err.Error(), "invalid reference") {
+				return nil, status.Errorf(codes.InvalidArgument, "invalid object reference: %s", ref.GetDigest())
+			}
+
+			return nil, status.Errorf(codes.Internal, "failed to check if object exists: %v", err)
 		}
 
 		logger.Debug("Checked if object exists in OCI store", "exists", exists)
 
 		if !exists {
-			return nil, types.ErrDigestNotFound
+			return nil, status.Errorf(codes.NotFound, "object not found: %s", ref.GetDigest())
 		}
 	}
 
@@ -193,17 +200,17 @@ func (s *store) Lookup(ctx context.Context, ref *coretypes.ObjectRef) (*coretype
 		// fetch manifest from remote
 		manifestRd, err := s.repo.Fetch(ctx, manifestDesc)
 		if err != nil {
-			return ref, fmt.Errorf("failed to fetch manifest: %w", err)
+			return ref, status.Errorf(codes.Internal, "failed to fetch manifest: %v", err)
 		}
 
 		// read manifest
 		manifestData, err := io.ReadAll(manifestRd)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read manifest: %w", err)
+			return nil, status.Errorf(codes.Internal, "failed to read manifest: %v", err)
 		}
 
 		if err := json.Unmarshal(manifestData, &manifest); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+			return nil, status.Errorf(codes.Internal, "failed to unmarshal manifest: %v", err)
 		}
 	}
 
@@ -216,7 +223,7 @@ func (s *store) Lookup(ctx context.Context, ref *coretypes.ObjectRef) (*coretype
 	// read object type from manifest metadata
 	objectType, ok := manifest.Annotations[manifestDirObjectTypeKey]
 	if !ok {
-		return nil, errors.New("not a dir-specific object")
+		return nil, status.Errorf(codes.Internal, "object type not found in manifest annotations: %s", manifestDirObjectTypeKey)
 	}
 
 	// return clean ref
@@ -246,7 +253,7 @@ func (s *store) Delete(ctx context.Context, ref *coretypes.ObjectRef) error {
 	case *remote.Repository:
 		return s.deleteFromRemoteRepository(ctx, repo, ref)
 	default:
-		return fmt.Errorf("unsupported repo type: %T", s.repo)
+		return status.Errorf(codes.Unimplemented, "unsupported repo type: %T", s.repo)
 	}
 }
 
@@ -264,7 +271,7 @@ func (s *store) deleteFromOCIStore(ctx context.Context, store *oci.Store, ref *c
 	if err != nil {
 		logger.Debug("Failed to resolve manifest", "error", err)
 	} else if err := store.Delete(ctx, manifestDesc); err != nil {
-		return fmt.Errorf("failed to delete manifest: %w", err)
+		return status.Errorf(codes.Internal, "failed to delete manifest: %v", err)
 	}
 
 	// Delete the blob associated with the descriptor.
@@ -272,7 +279,7 @@ func (s *store) deleteFromOCIStore(ctx context.Context, store *oci.Store, ref *c
 		Digest: ocidigest.Digest(ref.GetDigest()),
 	}
 	if err := store.Delete(ctx, blobDesc); err != nil {
-		return fmt.Errorf("failed to delete blob: %w", err)
+		return status.Errorf(codes.Internal, "failed to delete blob: %v", err)
 	}
 
 	return nil
@@ -286,7 +293,7 @@ func (s *store) deleteFromRemoteRepository(ctx context.Context, repo *remote.Rep
 	if err != nil {
 		logger.Debug("Failed to resolve manifest", "error", err)
 	} else if err := repo.Manifests().Delete(ctx, manifestDesc); err != nil {
-		return fmt.Errorf("failed to delete manifest: %w", err)
+		return status.Errorf(codes.Internal, "failed to delete manifest: %v", err)
 	}
 
 	// Delete the blob associated with the descriptor.
@@ -294,7 +301,7 @@ func (s *store) deleteFromRemoteRepository(ctx context.Context, repo *remote.Rep
 		Digest: ocidigest.Digest(ref.GetDigest()),
 	}
 	if err := repo.Blobs().Delete(ctx, blobDesc); err != nil {
-		return fmt.Errorf("failed to delete blob: %w", err)
+		return status.Errorf(codes.Internal, "failed to delete blob: %v", err)
 	}
 
 	return nil
@@ -317,7 +324,7 @@ func (s *store) pushData(ctx context.Context, ref *coretypes.ObjectRef, rd io.Re
 
 		// return only for non-valid errors
 		if !strings.Contains(err.Error(), "already exists") {
-			return nil, ocispec.Descriptor{}, err
+			return nil, ocispec.Descriptor{}, status.Errorf(codes.Internal, "failed to push blob: %v", err)
 		}
 	}
 

--- a/server/store/oci/oci_test.go
+++ b/server/store/oci/oci_test.go
@@ -81,7 +81,7 @@ func TestStore(t *testing.T) {
 	// lookup op
 	_, err = store.Lookup(testCtx, dgst)
 	assert.Error(t, err, "lookup should fail after delete")
-	assert.EqualError(t, err, "digest does not exist")
+	assert.ErrorContains(t, err, "object not found")
 }
 
 func BenchmarkLocalStore(b *testing.B) {

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -24,7 +24,7 @@ func New(opts types.APIOptions) (types.StoreAPI, error) {
 	case LocalFS:
 		store, err := localfs.New(opts.Config().LocalFS)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create OCI store: %w", err)
+			return nil, fmt.Errorf("failed to create localfs store: %w", err)
 		}
 
 		return store, nil

--- a/server/types/store.go
+++ b/server/types/store.go
@@ -5,13 +5,10 @@ package types
 
 import (
 	"context"
-	"errors"
 	"io"
 
 	coretypes "github.com/agntcy/dir/api/core/v1alpha1"
 )
-
-var ErrDigestNotFound = errors.New("digest does not exist")
 
 // StoreAPI handles management of content-addressable object storage.
 type StoreAPI interface {


### PR DESCRIPTION
Replace all `fmt.Errorf` errors returned from your store and routing methods with `status.Errorf` and appropriate `codes` from http://google.golang.org/grpc/status and https://pkg.go.dev/google.golang.org/grpc/codes, respectively.

**Error Message Example 1**

old
```sh
Error: failed to pull data: failed to receive object: rpc error: code = Unknown desc = failed to lookup: digest does not exist
```

new
```sh
Error: failed to pull data: failed to receive object: rpc error: code = NotFound desc = failed to lookup object: object not found: sha256:1beb8653b5bf888274c1e2c3754e096b0242ceee8518c330be3239fa88a4fc80
```

**Error Message Example 2**

old
```sh
Error: failed to pull data: failed to receive object: rpc error: code = Unknown desc = failed to lookup: failed to check if object exists: invalid reference: invalid digest "sha256:1beb8653b5bf888274c1e2c3754e096b0242ceee8518c330be3239fa88a4fc": invalid checksum digest length
```

new
```sh
Error: failed to pull data: failed to receive object: rpc error: code = InvalidArgument desc = failed to lookup object: failed to check if object exists: invalid reference: invalid digest "sha256:1beb8653b5bf888274c1e2c3754e096b0242ceee8518c330be3239fa88a4fc": invalid checksum digest length
```