### PR TITLE
refactor: move server startup out from constructor

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,11 @@ func Run(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}
+
+	// Start server
+	if err := server.start(ctx); err != nil {
+		return fmt.Errorf("failed to start server: %w", err)
+	}
 	defer server.Close()
 
 	// Wait for deactivation
@@ -93,11 +98,6 @@ func New(ctx context.Context, cfg *config.Config) (*Server, error) {
 
 	// Register server
 	reflection.Register(server.grpcServer)
-
-	// Start server
-	if err := server.start(ctx); err != nil {
-		return nil, fmt.Errorf("failed to start server: %w", err)
-	}
 
 	return server, nil
 }


### PR DESCRIPTION
Fixes #171 

Currently, the `server.start(ctx)` method is called within the `New` constructor in `server.go`. This mixes object construction with side effects (such as starting background goroutines and network listeners), which is considered an anti-pattern in Go.

This issue proposes moving the call to `server.start(ctx)` out of the `New` constructor and into the `Run` function. This change will make the server lifecycle more explicit, improve testability, and align with Go best practices by separating object construction from side effects.