### PR TITLE
fix: add login check to avoid segfault

### DIFF
--- a/hub/auth/login.go
+++ b/hub/auth/login.go
@@ -99,7 +99,7 @@ func Login(
 	return currentSession, nil
 }
 
-func IsLoggedIn(currentSession *sessionstore.HubSession) bool {
+func HasLoginCreds(currentSession *sessionstore.HubSession) bool {
 	if currentSession == nil || currentSession.AuthConfig == nil {
 		return false
 	}

--- a/hub/auth/login.go
+++ b/hub/auth/login.go
@@ -98,3 +98,20 @@ func Login(
 
 	return currentSession, nil
 }
+
+func IsLoggedIn(currentSession *sessionstore.HubSession) bool {
+	if currentSession == nil || currentSession.AuthConfig == nil {
+		return false
+	}
+
+	if currentSession.CurrentTenant == "" || len(currentSession.Tokens) == 0 {
+		return false
+	}
+
+	tokens, ok := currentSession.Tokens[currentSession.CurrentTenant]
+	if !ok || tokens == nil {
+		return false
+	}
+
+	return tokens.AccessToken != "" && tokens.IDToken != "" && tokens.RefreshToken != ""
+}

--- a/hub/cmd/logout/logout.go
+++ b/hub/cmd/logout/logout.go
@@ -31,7 +31,7 @@ func NewCommand(opts *options.HubOptions) *cobra.Command {
 			ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 			currentSession, ok := ctxSession.(*sessionstore.HubSession)
 
-			if !ok || currentSession == nil {
+			if !ok || !auth.IsLoggedIn(currentSession) {
 				return ErrSecretNotFoundForAddress
 			}
 			// Load session store for removal

--- a/hub/cmd/logout/logout.go
+++ b/hub/cmd/logout/logout.go
@@ -31,7 +31,7 @@ func NewCommand(opts *options.HubOptions) *cobra.Command {
 			ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 			currentSession, ok := ctxSession.(*sessionstore.HubSession)
 
-			if !ok || !auth.IsLoggedIn(currentSession) {
+			if !ok || !auth.HasLoginCreds(currentSession) {
 				return ErrSecretNotFoundForAddress
 			}
 			// Load session store for removal

--- a/hub/cmd/orgs/orgs.go
+++ b/hub/cmd/orgs/orgs.go
@@ -39,7 +39,7 @@ func NewCommand(hubOpts *hubOptions.HubOptions) *cobra.Command {
 		ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 		currentSession, ok := ctxSession.(*sessionstore.HubSession)
 
-		if !ok || currentSession == nil {
+		if !ok || !auth.IsLoggedIn(currentSession) {
 			return errors.New("no current session found. please login first")
 		}
 

--- a/hub/cmd/orgs/orgs.go
+++ b/hub/cmd/orgs/orgs.go
@@ -39,7 +39,7 @@ func NewCommand(hubOpts *hubOptions.HubOptions) *cobra.Command {
 		ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 		currentSession, ok := ctxSession.(*sessionstore.HubSession)
 
-		if !ok || !auth.IsLoggedIn(currentSession) {
+		if !ok || !auth.HasLoginCreds(currentSession) {
 			return errors.New("no current session found. please login first")
 		}
 

--- a/hub/cmd/orgswitch/switch.go
+++ b/hub/cmd/orgswitch/switch.go
@@ -41,7 +41,7 @@ organization. In any other case, org could be selected from an interactive list.
 		ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 		currentSession, ok := ctxSession.(*sessionstore.HubSession)
 
-		if !ok || !auth.IsLoggedIn(currentSession) {
+		if !ok || !auth.HasLoginCreds(currentSession) {
 			fmt.Fprintf(cmd.OutOrStderr(), "Could not get current session\n")
 
 			return errors.New("no current session found. please login first")

--- a/hub/cmd/orgswitch/switch.go
+++ b/hub/cmd/orgswitch/switch.go
@@ -41,10 +41,10 @@ organization. In any other case, org could be selected from an interactive list.
 		ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 		currentSession, ok := ctxSession.(*sessionstore.HubSession)
 
-		if !ok || currentSession == nil {
+		if !ok || !auth.IsLoggedIn(currentSession) {
 			fmt.Fprintf(cmd.OutOrStderr(), "Could not get current session\n")
 
-			return errors.New("could not get current session")
+			return errors.New("no current session found. please login first")
 		}
 		// Load session store for saving
 		sessionStore := sessionstore.NewFileSessionStore(fileUtils.GetSessionFilePath())

--- a/hub/cmd/pull/pull.go
+++ b/hub/cmd/pull/pull.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/agntcy/dir/hub/auth"
 	hubClient "github.com/agntcy/dir/hub/client/hub"
 	service "github.com/agntcy/dir/hub/service"
 	"github.com/agntcy/dir/hub/sessionstore"
@@ -43,7 +44,7 @@ Examples:
 			// Retrieve session from context
 			ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 			currentSession, ok := ctxSession.(*sessionstore.HubSession)
-			if !ok || currentSession == nil {
+			if !ok || !auth.IsLoggedIn(currentSession) {
 				return errors.New("could not get current hub session")
 			}
 

--- a/hub/cmd/pull/pull.go
+++ b/hub/cmd/pull/pull.go
@@ -44,7 +44,7 @@ Examples:
 			// Retrieve session from context
 			ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 			currentSession, ok := ctxSession.(*sessionstore.HubSession)
-			if !ok || !auth.IsLoggedIn(currentSession) {
+			if !ok || !auth.HasLoginCreds(currentSession) {
 				return errors.New("could not get current hub session")
 			}
 

--- a/hub/cmd/push/push.go
+++ b/hub/cmd/push/push.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/agntcy/dir/cli/util/agent"
+	"github.com/agntcy/dir/hub/auth"
 	hubClient "github.com/agntcy/dir/hub/client/hub"
 	hubOptions "github.com/agntcy/dir/hub/cmd/options"
 	"github.com/agntcy/dir/hub/service"
@@ -49,7 +50,7 @@ Examples:
 		ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 
 		currentSession, ok := ctxSession.(*sessionstore.HubSession)
-		if !ok || currentSession == nil {
+		if !ok || !auth.IsLoggedIn(currentSession) {
 			return errors.New("you need to be logged in to push to the hub\nuse `dirctl hub login` command to login")
 		}
 

--- a/hub/cmd/push/push.go
+++ b/hub/cmd/push/push.go
@@ -50,7 +50,7 @@ Examples:
 		ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 
 		currentSession, ok := ctxSession.(*sessionstore.HubSession)
-		if !ok || !auth.IsLoggedIn(currentSession) {
+		if !ok || !auth.HasLoginCreds(currentSession) {
 			return errors.New("you need to be logged in to push to the hub\nuse `dirctl hub login` command to login")
 		}
 


### PR DESCRIPTION
* Fix segfault when running the hub command to list orgs when user is not logged in.
* Plus, add login checks wherever required

Kudos to @jubarbot-cisco for finding this bug 🚀 
