### PR TITLE
ci(csit-integration): update input parameters

### DIFF
--- a/.github/actions/trigger-integrations/action.yaml
+++ b/.github/actions/trigger-integrations/action.yaml
@@ -38,7 +38,7 @@ runs:
               workflow_id: 'test-integrations.yaml',
               ref: 'main',
               inputs: {
-                  skip_slim_test: true,
+                  skip_diretory_test: false,
                   override_directory_image_tag: '${{ steps.tags.outputs.IMAGE_TAG }}',
                   override_directory_chart_tag: '${{ steps.tags.outputs.CHART_TAG }}',
               },


### PR DESCRIPTION
The CSIT integration workflow input parameters are changed to disable all tests by default. This way every dependent are needed to explicitly enable the necessarry tests.

https://github.com/agntcy/csit/pull/122