### PR TITLE
fix: local search

### DIFF
--- a/cli/cmd/search/search.go
+++ b/cli/cmd/search/search.go
@@ -57,7 +57,7 @@ func runCommand(cmd *cobra.Command) error {
 			continue
 		}
 
-		presenter.Print(cmd, recordCid)
+		presenter.Print(cmd, recordCid+"\n")
 	}
 
 	return nil

--- a/e2e/dirctl_test.go
+++ b/e2e/dirctl_test.go
@@ -155,7 +155,7 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests using a local single no
 	})
 
 	ginkgo.Context("agent search", func() {
-		ginkgo.It("should search for an agent with filters and return the cid", func() {
+		ginkgo.It("should search for records with every filter and return their CID", func() {
 			var outputBuffer bytes.Buffer
 
 			searchCmd := clicmd.RootCmd
@@ -184,7 +184,7 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests using a local single no
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Check if the output contains the expected CID
-			gomega.Expect(outputBuffer.String()).To(gomega.Equal("sha256:1beb8653b5bf888274c1e2c3754e096b0242ceee8518c330be3239fa88a4fc80"))
+			gomega.Expect(outputBuffer.String()).To(gomega.Equal("sha256:1beb8653b5bf888274c1e2c3754e096b0242ceee8518c330be3239fa88a4fc80\n"))
 		})
 	})
 

--- a/server/search/sqlite/record.go
+++ b/server/search/sqlite/record.go
@@ -126,7 +126,7 @@ func (d *DB) GetRecords(opts ...types.FilterOption) ([]types.RecordObject, error
 	}
 
 	// Start with the base query for records.
-	query := d.gormDB.Model(&Record{})
+	query := d.gormDB.Model(&Record{}).Distinct()
 
 	// Apply pagination.
 	if cfg.Limit > 0 {


### PR DESCRIPTION
CLI fix to print every CID on a new line.
Fixes a bug where the same record returned multiple times because of JOINs.