### PR TITLE
feat: new hub https://hub.agntcy.org/directory

### DIFF
--- a/hub/config/config.go
+++ b/hub/config/config.go
@@ -11,10 +11,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	httpUtils "github.com/agntcy/dir/hub/utils/http"
-	"github.com/agntcy/dir/hub/utils/url"
+	urlutils "github.com/agntcy/dir/hub/utils/url"
 )
 
 var (
@@ -36,12 +37,17 @@ type AuthConfig struct {
 // FetchAuthConfig retrieves and parses the AuthConfig from the given frontend URL.
 // It validates the URL, fetches the config.json, and normalizes backend addresses.
 // Returns the AuthConfig or an error if the operation fails.
-func FetchAuthConfig(ctx context.Context, frontedURL string) (*AuthConfig, error) {
-	if err := url.ValidateSecureURL(frontedURL); err != nil {
+func FetchAuthConfig(ctx context.Context, frontendURL string) (*AuthConfig, error) {
+	if err := urlutils.ValidateSecureURL(frontendURL); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidFrontendURL, err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, frontedURL+"/config.json", nil)
+	configJSONURL, err := url.JoinPath(frontendURL, "config.json")
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidFrontendURL, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, configJSONURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrFetchingConfig, err)
 	}

--- a/hub/config/constants.go
+++ b/hub/config/constants.go
@@ -9,7 +9,7 @@ const (
 	LocalWebserverPort = 48043
 
 	// DefaultHubAddress is the default URL for the Agent Hub service.
-	DefaultHubAddress = "https://hub.agntcy.org"
+	DefaultHubAddress = "https://hub.agntcy.org/directory"
 	// DefaultHubBackendGRPCPort is the default gRPC port for the Agent Hub backend.
 	DefaultHubBackendGRPCPort = 443
 )


### PR DESCRIPTION
The new official location of the directory is
https://hub.agntcy.org/directory.

Old dirctl client will still work for some time because, at the moment, there is a 302 temporary HTTP redirection from https://hub.agntcy.org to https://hub.agntcy.org/directory.