### PR TITLE
feat: add --insecure to dirctl hub commands

### DIFF
--- a/hub/auth/internal/webserver/server.go
+++ b/hub/auth/internal/webserver/server.go
@@ -54,8 +54,8 @@ func StartLocalServer(ctx context.Context, h *Handler, port int, errCh chan erro
 
 		var resp *http.Response
 
-		resp, err = httpUtils.CreateSecureHTTPClient().Do(req)
-		if err != nil {
+		insecure := false
+		if resp, err = httpUtils.CreateSecureHTTPClient(insecure).Do(req); err != nil {
 			continue
 		}
 

--- a/hub/auth/tenant.go
+++ b/hub/auth/tenant.go
@@ -183,7 +183,8 @@ func tenantsToMap(tenants []*idp.TenantResponse) map[string]string {
 // FetchUserTenants retrieves the list of tenants for the current user session from the IDP.
 // Returns a slice of TenantResponse or an error if the request fails.
 func FetchUserTenants(ctx context.Context, currentSession *sessionstore.HubSession) ([]*idp.TenantResponse, error) {
-	idpClient := idp.NewClient(currentSession.AuthConfig.IdpBackendAddress, httpUtils.CreateSecureHTTPClient())
+	insecure := false
+	idpClient := idp.NewClient(currentSession.AuthConfig.IdpBackendAddress, httpUtils.CreateSecureHTTPClient(insecure))
 	accessToken := currentSession.Tokens[currentSession.CurrentTenant].AccessToken
 	productID := currentSession.AuthConfig.IdpProductID
 

--- a/hub/client/hub/client.go
+++ b/hub/client/hub/client.go
@@ -37,11 +37,14 @@ type client struct {
 
 // New creates a new Agent Hub client for the given server address.
 // Returns the client or an error if the connection could not be established.
-func New(serverAddr string) (*client, error) { //nolint:revive
+func New(serverAddr string, insecure bool) (*client, error) { //nolint:revive
 	// Create connection
 	conn, err := grpc.NewClient(
 		serverAddr,
-		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})),
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: insecure, // #nosec G402
+		})),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create grpc client: %w", err)

--- a/hub/cmd/login/login.go
+++ b/hub/cmd/login/login.go
@@ -40,7 +40,8 @@ func NewCommand(hubOptions *options.HubOptions) *cobra.Command {
 		// Load session store for saving
 		sessionStore := sessionstore.NewFileSessionStore(file.GetSessionFilePath())
 		// Construct Okta client
-		oktaClient := okta.NewClient(currentSession.AuthConfig.IdpIssuerAddress, http.CreateSecureHTTPClient())
+		insecure := false
+		oktaClient := okta.NewClient(currentSession.AuthConfig.IdpIssuerAddress, http.CreateSecureHTTPClient(insecure))
 		// Call auth.Login with loaded objects
 		updatedSession, err := auth.Login(cmd.Context(), oktaClient, currentSession)
 		if err != nil {

--- a/hub/cmd/logout/logout.go
+++ b/hub/cmd/logout/logout.go
@@ -36,7 +36,8 @@ func NewCommand(opts *options.HubOptions) *cobra.Command {
 			}
 			// Load session store for removal
 			sessionStore := sessionstore.NewFileSessionStore(fileUtils.GetSessionFilePath())
-			oktaClient := okta.NewClient(currentSession.AuthConfig.IdpIssuerAddress, httpUtils.CreateSecureHTTPClient())
+			insecure := false
+			oktaClient := okta.NewClient(currentSession.AuthConfig.IdpIssuerAddress, httpUtils.CreateSecureHTTPClient(insecure))
 
 			err := auth.Logout(opts, currentSession, sessionStore, oktaClient)
 			if err != nil {

--- a/hub/cmd/options/hub.go
+++ b/hub/cmd/options/hub.go
@@ -15,12 +15,15 @@ const (
 	hubAddressFlagName = "server-address"
 
 	hubAddressConfigPath = "hub.server-address"
+	insecureFlagName     = "insecure"
+	insecureConfigPath   = "hub.insecure"
 )
 
 type HubOptions struct {
 	*BaseOption
 
 	ServerAddress string
+	Insecure      bool
 }
 
 func NewHubOptions(base *BaseOption, cmd *cobra.Command) *HubOptions {
@@ -32,9 +35,14 @@ func NewHubOptions(base *BaseOption, cmd *cobra.Command) *HubOptions {
 		func() error {
 			flags := cmd.PersistentFlags()
 			flags.String(hubAddressFlagName, config.DefaultHubAddress, "AgentHub address")
+			flags.Bool(insecureFlagName, false, "WARNING: Disables SSL certificate verification. This is insecure and not recommended for production use.")
 
 			if err := viper.BindPFlag(hubAddressConfigPath, flags.Lookup(hubAddressFlagName)); err != nil {
 				return fmt.Errorf("unable to bind flag %s: %w", hubAddressFlagName, err)
+			}
+
+			if err := viper.BindPFlag(insecureConfigPath, flags.Lookup(insecureFlagName)); err != nil {
+				return fmt.Errorf("unable to bind flag %s: %w", insecureFlagName, err)
 			}
 
 			return nil
@@ -43,6 +51,7 @@ func NewHubOptions(base *BaseOption, cmd *cobra.Command) *HubOptions {
 
 	hubOpts.AddCompleteFn(func() {
 		hubOpts.ServerAddress = viper.GetString(hubAddressConfigPath)
+		hubOpts.Insecure = viper.GetBool(insecureConfigPath)
 	})
 
 	return hubOpts

--- a/hub/cmd/orgswitch/switch.go
+++ b/hub/cmd/orgswitch/switch.go
@@ -50,7 +50,8 @@ organization. In any other case, org could be selected from an interactive list.
 		sessionStore := sessionstore.NewFileSessionStore(fileUtils.GetSessionFilePath())
 
 		// Load tenants directly using idp client
-		idpClient := idp.NewClient(currentSession.AuthConfig.IdpBackendAddress, httpUtils.CreateSecureHTTPClient())
+		insecure := false
+		idpClient := idp.NewClient(currentSession.AuthConfig.IdpBackendAddress, httpUtils.CreateSecureHTTPClient(insecure))
 		accessToken := currentSession.Tokens[currentSession.CurrentTenant].AccessToken
 		productID := currentSession.AuthConfig.IdpProductID
 
@@ -69,7 +70,7 @@ organization. In any other case, org could be selected from an interactive list.
 
 		tenants := idpResp.TenantList.Tenants
 
-		oktaClient := okta.NewClient(currentSession.AuthConfig.IdpIssuerAddress, httpUtils.CreateSecureHTTPClient())
+		oktaClient := okta.NewClient(currentSession.AuthConfig.IdpIssuerAddress, httpUtils.CreateSecureHTTPClient(insecure))
 
 		updatedSession, msg, err := auth.SwitchTenant(cmd.Context(), opts, tenants, currentSession, oktaClient)
 		if err != nil {

--- a/hub/cmd/pull/pull.go
+++ b/hub/cmd/pull/pull.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agntcy/dir/hub/auth"
 	hubClient "github.com/agntcy/dir/hub/client/hub"
+	hubOptions "github.com/agntcy/dir/hub/cmd/options"
 	service "github.com/agntcy/dir/hub/service"
 	"github.com/agntcy/dir/hub/sessionstore"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ import (
 // NewCommand creates the "pull" command for the Agent Hub CLI.
 // It pulls an agent from the hub by digest or repository:version and prints the result.
 // Returns the configured *cobra.Command.
-func NewCommand() *cobra.Command {
+func NewCommand(hubOpts *hubOptions.HubOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull <agent_ref>",
 		Short: "Pull an agent from Agent Hub",
@@ -48,7 +49,7 @@ Examples:
 				return errors.New("could not get current hub session")
 			}
 
-			hc, err := hubClient.New(currentSession.HubBackendAddress)
+			hc, err := hubClient.New(currentSession.HubBackendAddress, hubOpts.Insecure)
 			if err != nil {
 				return fmt.Errorf("failed to create hub client: %w", err)
 			}

--- a/hub/cmd/push/push.go
+++ b/hub/cmd/push/push.go
@@ -54,7 +54,7 @@ Examples:
 			return errors.New("you need to be logged in to push to the hub\nuse `dirctl hub login` command to login")
 		}
 
-		hc, err := hubClient.New(currentSession.HubBackendAddress)
+		hc, err := hubClient.New(currentSession.HubBackendAddress, hubOpts.Insecure)
 		if err != nil {
 			return fmt.Errorf("failed to create hub client: %w", err)
 		}

--- a/hub/config/config.go
+++ b/hub/config/config.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	httpUtils "github.com/agntcy/dir/hub/utils/http"
-	urlutils "github.com/agntcy/dir/hub/utils/url"
+	urlUtils "github.com/agntcy/dir/hub/utils/url"
 )
 
 var (
@@ -37,8 +37,8 @@ type AuthConfig struct {
 // FetchAuthConfig retrieves and parses the AuthConfig from the given frontend URL.
 // It validates the URL, fetches the config.json, and normalizes backend addresses.
 // Returns the AuthConfig or an error if the operation fails.
-func FetchAuthConfig(ctx context.Context, frontendURL string) (*AuthConfig, error) {
-	if err := urlutils.ValidateSecureURL(frontendURL); err != nil {
+func FetchAuthConfig(ctx context.Context, frontendURL string, insecure bool) (*AuthConfig, error) {
+	if err := urlUtils.ValidateSecureURL(frontendURL); err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrInvalidFrontendURL, err)
 	}
 
@@ -52,7 +52,7 @@ func FetchAuthConfig(ctx context.Context, frontendURL string) (*AuthConfig, erro
 		return nil, fmt.Errorf("%w: %w", ErrFetchingConfig, err)
 	}
 
-	resp, err := httpUtils.CreateSecureHTTPClient().Do(req)
+	resp, err := httpUtils.CreateSecureHTTPClient(insecure).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrFetchingConfig, err)
 	}

--- a/hub/utils/http/http.go
+++ b/hub/utils/http/http.go
@@ -16,13 +16,13 @@ const (
 	httpClientIdleConnTimeout     = 90 * time.Second
 )
 
-func CreateSecureHTTPClient() *http.Client {
+func CreateSecureHTTPClient(insecure bool) *http.Client {
 	return &http.Client{
 		Timeout: httpClientTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				MinVersion:         tls.VersionTLS12,
-				InsecureSkipVerify: false,
+				InsecureSkipVerify: insecure, // #nosec G402
 			},
 			MaxIdleConns:        httpClientMaxIdleConns,
 			MaxIdleConnsPerHost: httpClientMaxIdleConnsPerHost,


### PR DESCRIPTION
Here is a proposition to add a new `--insecure` flag to disable certificate validity checks. It can be handy when developing locally.

ex: `./bin/dirctl hub orgs --server-address https://localhost --insecure`


If `--insecure`, skips tls certificate check when:
- getting config.json from the hub,
- doing gRPC connections to the hub.

idp and okta client connections are still done securely.

## Discussion
If that flag makes sense and is accepted by the maintainers, then we can even propose to move this flag "upper", it order to also have it for other non-hub subcommands

## Remark
The other (non-hub) sub commands are apparently using a insecure gRPC connection to the dir: 
https://github.com/agntcy/dir/blob/main/client/client.go#L61.

Is it the expected behavior ?