### PR TITLE
fix: update CI task gen to ignore buf lock file changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Generate api
         run: |
           task gen
-          if [[ -n "$(git status --porcelain)" ]]; then
+          if [[ -n "$(git status --porcelain | grep -v 'api/proto/buf.lock')" ]]; then
             echo "There are uncommitted changes after running 'task gen'. Please commit these changes."
             exit 1
           fi


### PR DESCRIPTION
Excludes `api/proto/buf.lock` from the git status check in the `verify-gen` CI job to prevent failures when this file is automatically generated during task gen. 

This issue could cause CI failures in release or main branch runs if OASF code was released after the last commit was merged.