### PR TITLE
refactor: remove builder artifacts and build cmd usages

### DIFF
--- a/.github/workflows/demo-local-windows.yaml
+++ b/.github/workflows/demo-local-windows.yaml
@@ -5,7 +5,7 @@ name: Dir - Local Demo on Windows
 
 description: |
   This workflow demonstrates how to use the Dir CLI on Windows.
-  It includes steps for compiling the CLI, building an agent, and verifying the binary.
+  It includes steps for compiling the CLI and verifying the binary.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/demo-local-windows.yaml
+++ b/.github/workflows/demo-local-windows.yaml
@@ -50,11 +50,4 @@ jobs:
           echo "Running version command"
           .\bin\dirctl.exe version
 
-      - name: Run build command
-        run: |
-          echo "Running dir build command"
-          .\bin\dirctl.exe build e2e/testdata > agent.json
-          echo "Built agent.json:"
-          cat agent.json
-
       # TODO Start server and run push/publish commands

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -6,7 +6,7 @@ name: Dir - Demo
 description: |
   This workflow demonstrates how to use the Dir CLI with a Kind cluster and Helm chart.
   It can be run in either local mode or network mode.
-  It includes steps for building, pushing, publishing, listing and pulling agents.
+  It includes steps for building, pushing, publishing, listing and pulling records.
 
 on:
   workflow_dispatch:
@@ -77,21 +77,14 @@ jobs:
             task deploy:local:port-forward
           fi
 
-      - name: Run build command
-        run: |
-          echo "Running dir build command"
-          bin/dirctl build e2e/testdata > agent.json
-          echo "Built agent.json:"
-          cat agent.json
-
       - name: Run push command
         run: |
           if [ "${{ inputs.network }}" = "true" ]; then
             echo "Running dir push command on Peer 1"
-            bin/dirctl push agent.json --server-addr 127.0.0.1:8890 > digest.txt
+            bin/dirctl push e2e/testdata/record_v1.json --server-addr 127.0.0.1:8890 > digest.txt
           else
             echo "Running dir push command"
-            bin/dirctl push agent.json > digest.txt
+            bin/dirctl push e2e/testdata/record_v1.json > digest.txt
           fi
           echo "Pushed image digest:"
           cat digest.txt
@@ -177,13 +170,6 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.8.2
 
-      - name: Run build command
-        run: |
-          echo "Running dir build command"
-          bin/dirctl build e2e/testdata > agent.json
-          echo "Built agent.json:"
-          cat agent.json
-
       - name: Get Github OIDC token
         id: oidc-token
         run: |
@@ -192,24 +178,29 @@ jobs:
           echo "::add-mask::$OIDC_TOKEN"
           echo "token=$OIDC_TOKEN" >> $GITHUB_OUTPUT
 
-      - name: Run sign command
+      - name: Deploy Dir
+        run: |
+          echo "Deploying Dir"
+          IMAGE_TAG=${{ inputs.dir-version }} task deploy:local
+          task deploy:local:port-forward
+
+      - name: Push record
+        run: |
+          echo "Pushing record"
+          bin/dirctl push e2e/testdata/record_v1.json > digest.txt
+
+      - name: Sign record
         run: |
           echo "Running dir sign command"
-          bin/dirctl sign agent.json \
+          bin/dirctl sign $(cat digest.txt) \
             --oidc-token ${{ steps.oidc-token.outputs.token }} \
             --oidc-provider-url "https://token.actions.githubusercontent.com" \
-            --oidc-client-id "https://github.com/${{ github.repository }}/.github/workflows/demo.yaml@${{ github.ref }}" \
-            --stdin > signed.model.json
-          echo "Signed agent.json to signed.model.json"
-          cat signed.model.json
-          mv signed.model.json agent.json
+            --oidc-client-id "https://github.com/${{ github.repository }}/.github/workflows/demo.yaml@${{ github.ref }}"
 
       - name: Run verify command
         run: |
           echo "Running dir verify command"
-          bin/dirctl verify agent.json \
-            --oidc-issuer "https://token.actions.githubusercontent.com" \
-            --oidc-identity "https://github.com/${{ github.repository }}/.github/workflows/demo.yaml@${{ github.ref }}"
+          bin/dirctl verify $(cat digest.txt)
 
   sign-and-verify-with-key:
       # This job demonstrates how to sign and verify a record using Cosign keys.
@@ -233,22 +224,23 @@ jobs:
           cosign generate-key-pair
           echo "Cosign keys generated successfully"
 
-      - name: Run build command
+      - name: Deploy Dir
         run: |
-          echo "Running dir build command"
-          bin/dirctl build e2e/testdata > agent.json
-          echo "Built agent.json:"
-          cat agent.json
+          echo "Deploying Dir"
+          IMAGE_TAG=${{ inputs.dir-version }} task deploy:local
+          task deploy:local:port-forward
 
-      - name: Run sign command
+      - name: Push record
+        run: |
+          echo "Pushing record"
+          bin/dirctl push e2e/testdata/record_v1.json > digest.txt
+
+      - name: Sign record
         run: |
           echo "Running dir sign command"
-          bin/dirctl sign agent.json --key cosign.key --stdin > signed.model.json
-          echo "Signed agent.json:"
-          cat signed.model.json
-          mv signed.model.json agent.json
+          bin/dirctl sign $(cat digest.txt) --key cosign.key
 
-      - name: Run verify command
+      - name: Verify record
         run: |
           echo "Running dir verify command"
-          bin/dirctl verify agent.json --key cosign.pub
+          bin/dirctl verify $(cat digest.txt)

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -11,22 +11,11 @@ description: |
 on:
   workflow_dispatch:
     inputs:
-      dir-apiserver-image:
+      git-ref:
         required: true
         type: string
-        default: "ghcr.io/agntcy/dir-apiserver"
-      dir-ctl-image:
-        required: true
-        type: string
-        default: "ghcr.io/agntcy/dir-ctl"
-      dir-helm-chart:
-        required: true
-        type: string
-        default: "oci://ghcr.io/agntcy/dir/helm-charts/dir"
-      dir-version:
-        required: true
-        type: string
-        default: "v0.2.1"
+        default: "main"
+        description: "Git branch, tag, or commit hash to build from"
       network:
         required: true
         type: boolean
@@ -42,16 +31,29 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.5'
 
       - name: Setup Taskfile
         shell: bash
         run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
 
-      - name: Setup Dirctl
+      - name: Build Dirctl
         run: |
-          mkdir -p bin
-          curl -L -o bin/dirctl https://github.com/agntcy/dir/releases/download/${{ inputs.dir-version }}/dirctl-linux-amd64
-          chmod +x bin/dirctl
+          # Generate API code and compile CLI
+          task cli:compile
+          ls -la bin/
+
+      - name: Build Docker Images
+        run: |
+          # Build Docker images from source using commit SHA as tag
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG=${COMMIT_SHA} task build
 
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.12.0
@@ -60,20 +62,16 @@ jobs:
           cluster_name: dir-demo
           install_only: true
 
-      - name: Pull Docker image
-        run: |
-          docker pull ${{ inputs.dir-apiserver-image }}:${{ inputs.dir-version }}
-          docker pull ${{ inputs.dir-ctl-image }}:${{ inputs.dir-version }}
-
       - name: Deploy Dir
         run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
           if [ ${{ inputs.network }} = "true" ]; then
             echo "Using network mode"
-            IMAGE_TAG=${{ inputs.dir-version }} task deploy:network
+            IMAGE_TAG=${COMMIT_SHA} task deploy:network
             task deploy:network:port-forward
           else
             echo "Using local mode"
-            IMAGE_TAG=${{ inputs.dir-version }} task deploy:local
+            IMAGE_TAG=${COMMIT_SHA} task deploy:local
             task deploy:local:port-forward
           fi
 
@@ -81,10 +79,10 @@ jobs:
         run: |
           if [ "${{ inputs.network }}" = "true" ]; then
             echo "Running dir push command on Peer 1"
-            bin/dirctl push e2e/testdata/record_v1.json --server-addr 127.0.0.1:8890 > digest.txt
+            bin/dirctl push e2e/testdata/agent_v1.json --server-addr 127.0.0.1:8890 > digest.txt
           else
             echo "Running dir push command"
-            bin/dirctl push e2e/testdata/record_v1.json > digest.txt
+            bin/dirctl push e2e/testdata/agent_v1.json > digest.txt
           fi
           echo "Pushed image digest:"
           cat digest.txt
@@ -160,12 +158,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
 
-      - name: Setup Dirctl
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.5'
+
+      - name: Setup Taskfile
+        shell: bash
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+
+      - name: Build Dirctl
         run: |
-          mkdir -p bin
-          curl -L -o bin/dirctl https://github.com/agntcy/dir/releases/download/${{ inputs.dir-version }}/dirctl-linux-amd64
-          chmod +x bin/dirctl
+          task cli:compile
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.8.2
@@ -178,16 +185,22 @@ jobs:
           echo "::add-mask::$OIDC_TOKEN"
           echo "token=$OIDC_TOKEN" >> $GITHUB_OUTPUT
 
+      - name: Build Docker Images
+        run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG=${COMMIT_SHA} task build
+
       - name: Deploy Dir
         run: |
           echo "Deploying Dir"
-          IMAGE_TAG=${{ inputs.dir-version }} task deploy:local
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG=${COMMIT_SHA} task deploy:local
           task deploy:local:port-forward
 
       - name: Push record
         run: |
           echo "Pushing record"
-          bin/dirctl push e2e/testdata/record_v1.json > digest.txt
+          bin/dirctl push e2e/testdata/agent_v1.json > digest.txt
 
       - name: Sign record
         run: |
@@ -208,12 +221,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.git-ref }}
 
-      - name: Setup Dirctl
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24.5'
+
+      - name: Setup Taskfile
+        shell: bash
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+
+      - name: Build Dirctl
         run: |
-          mkdir -p bin
-          curl -L -o bin/dirctl https://github.com/agntcy/dir/releases/download/${{ inputs.dir-version }}/dirctl-linux-amd64
-          chmod +x bin/dirctl
+          task cli:compile
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.8.2
@@ -224,16 +246,22 @@ jobs:
           cosign generate-key-pair
           echo "Cosign keys generated successfully"
 
+      - name: Build Docker Images
+        run: |
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG=${COMMIT_SHA} task build
+
       - name: Deploy Dir
         run: |
           echo "Deploying Dir"
-          IMAGE_TAG=${{ inputs.dir-version }} task deploy:local
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG=${COMMIT_SHA} task deploy:local
           task deploy:local:port-forward
 
       - name: Push record
         run: |
           echo "Pushing record"
-          bin/dirctl push e2e/testdata/record_v1.json > digest.txt
+          bin/dirctl push e2e/testdata/agent_v1.json > digest.txt
 
       - name: Sign record
         run: |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Directory also leverages [CSIT](https://github.com/agntcy/csit) for continuous s
 
 - **Data Models** - Defines a standard schema for data representation and exchange.
 - **Dev Kit** - Provides CLI tooling to simplify development workflows and facilitate API interactions.
-- **Plugins** - Pluggable components to extend the build process of agent data models for custom use cases.
 - **Announce** - Allows publication of records to the network.
 - **Discover** - Listen, search, and retrieve records across the network by their attributes and constraints.
 - **Security** - Relies on well-known security principles to provide data provenance, integrity, and ownership.
@@ -21,7 +20,6 @@ Check the [Usage Scenarios](https://docs.agntcy.org/dir/scenarios/) for a full w
 
 - [api](./api) - gRPC specification for data models and services
 - [cli](./cli) - command line client for interacting with system components
-  - [builder](./cli/builder) - common data model build tools and plugins
 - [client](./client) - client SDK for development and API workflows
 - [e2e](./e2e) - end-to-end testing framework
 - [docs](./docs) - research details and documentation around the project

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -51,7 +51,6 @@ func init() {
 	RootCmd.AddCommand(
 		// local commands
 		version.Command,
-		// build.Command, // REMOVED: Builder functionality
 		// initialize.Command, // REMOVED: Initialize functionality
 		sign.Command,
 		verify.Command,


### PR DESCRIPTION
This PR removes the deprecated builder functionality and updates the demo workflows to support building from any git reference instead of fixed release versions.

* Remove obsolete builder test data files (agent.base.json, build.config.yml, pyproject.toml)
* Remove `build` command references from CLI and documentation
* Replace demo workflow `version` inputs with `git-ref` parameter for branch/tag/commit builds
* Update signing workflows

https://github.com/agntcy/dir/actions/runs/17240310110 Successful run ✅ 