### PR TITLE
fix: on Hub, load client_id for apikey accessToken from Phoenix UI

### DIFF
--- a/hub/auth/apikey.go
+++ b/hub/auth/apikey.go
@@ -21,7 +21,7 @@ func RefreshAPIKeyAccessToken(ctx context.Context, session *sessionstore.HubSess
 		return errors.New("no API key access token available in the session")
 	}
 
-	idpClient := idp.NewClient(session.AuthConfig.IdpIssuerAddress, httpUtils.CreateSecureHTTPClient())
+	idpClient := idp.NewClient(session.AuthConfig.IdpIssuerAddress, httpUtils.CreateSecureHTTPClient(), session.AuthConfig.ApiKeyClientID)
 
 	var err error
 

--- a/hub/client/idp/client.go
+++ b/hub/client/idp/client.go
@@ -18,15 +18,14 @@ import (
 const (
 	// Path to the IDP API for retrieving an AccessToken for ApiKey Access.
 	AccessTokenEndpoint = "/v1/token"
-	// Fixed Client ID for the access token request. THIS IS NOT THE CLIENT ID THAT WILL BE IN ACCESS TOKEN.
-	AccessTokenClientID = "0oackfvbjvy65qVi41d7" //nolint:gosec
 	// Scope for the access token request.
 	AccessTokenScope = "openid offline_access"
 	// Grant type for the access token request.
 	AccessTokenGrantType = "password"
 	// AccessTokenGrantTypeClientCredentials is the grant type for client credentials.
 	AccessTokenGrantTypeClientCredentials = "client_credentials"
-	AccessTokenCustomScope                = "customScope" // Custom scope for the access token request.
+	// Custom scope for the access token request.
+	AccessTokenCustomScope = "customScope"
 )
 
 // GetAccessTokenResponse contains the response when requesting an access token from the IDP API.
@@ -62,19 +61,21 @@ type Client interface {
 
 // client implements the Client interface for the IDP API.
 type client struct {
-	httpClient *http.Client
-	baseURL    string
+	httpClient     *http.Client
+	baseURL        string
+	apiKeyClientID string
 }
 
 // NewClient creates a new IDP client with the given base URL and HTTP client.
-func NewClient(baseURL string, httpClient *http.Client) Client {
+func NewClient(baseURL string, httpClient *http.Client, apiKeyClientID string) Client {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 
 	return &client{
-		baseURL:    baseURL,
-		httpClient: httpClient,
+		baseURL:        baseURL,
+		httpClient:     httpClient,
+		apiKeyClientID: apiKeyClientID,
 	}
 }
 
@@ -86,7 +87,7 @@ func (c *client) GetAccessTokenFromAPIKey(ctx context.Context, username string, 
 	data.Set("username", username)
 	data.Set("password", secret)
 	data.Set("scope", AccessTokenScope)
-	data.Set("client_id", AccessTokenClientID)
+	data.Set("client_id", c.apiKeyClientID)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, strings.NewReader(data.Encode()))
 	if err != nil {

--- a/hub/cmd/hub.go
+++ b/hub/cmd/hub.go
@@ -69,6 +69,7 @@ func NewHubCommand(ctx context.Context, baseOption *options.BaseOption) *cobra.C
 			IdpBackendAddress:  authConfig.IdpBackendAddress,
 			IdpIssuerAddress:   authConfig.IdpIssuerAddress,
 			HubBackendAddress:  authConfig.HubBackendAddress,
+			ApiKeyClientID:     authConfig.ApiKeyClientID,
 		}
 
 		// Only refresh token if not running login or logout

--- a/hub/config/config.go
+++ b/hub/config/config.go
@@ -31,6 +31,7 @@ type AuthConfig struct {
 	IdpBackendAddress  string `json:"IAM_API"`
 	IdpFrontendAddress string `json:"IAM_UI"`
 	HubBackendAddress  string `json:"HUB_API"`
+	ApiKeyClientID     string `json:"API_KEY_CLIENT_ID"`
 }
 
 // FetchAuthConfig retrieves and parses the AuthConfig from the given frontend URL.

--- a/hub/sessionstore/type.go
+++ b/hub/sessionstore/type.go
@@ -39,6 +39,7 @@ type AuthConfig struct {
 	IdpBackendAddress  string `json:"idp_backend"`
 	IdpIssuerAddress   string `json:"idp_issuer"`
 	HubBackendAddress  string `json:"hub_backend"`
+	ApiKeyClientID     string `json:"api_key_client_id"`
 }
 
 type APIKey struct {


### PR DESCRIPTION
Previously, the client_id to use when request access token for apikey hub access was hard coded.
Now, the value is read with the AuthConfig retrieves from the Phoenix UI