### PR TITLE
chore: remove verbose logs from json output

### DIFF
--- a/hub/utils/auth/auth.go
+++ b/hub/utils/auth/auth.go
@@ -32,13 +32,13 @@ func CheckForCreds(cmd *cobra.Command, currentSession *sessionstore.HubSession, 
 }
 
 // resolveAPIKeyCredentials returns the effective clientID and secret (base64-encoded).
-func resolveAPIKeyCredentials(clientID, secret string) (string, string, string) {
+func resolveAPIKeyCredentials(clientID, secret string) (string, string) {
 	effectiveClientID := clientID
 	effectiveSecret := secret
 
 	// CLI opts take priority
 	if effectiveClientID != "" && effectiveSecret != "" {
-		return effectiveClientID, effectiveSecret, "command opts"
+		return effectiveClientID, effectiveSecret
 	}
 
 	// Environment variables
@@ -46,10 +46,10 @@ func resolveAPIKeyCredentials(clientID, secret string) (string, string, string) 
 	envSecret := os.Getenv("DIRCTL_CLIENT_SECRET")
 
 	if envClientID != "" && envSecret != "" {
-		return envClientID, envSecret, "environment variables"
+		return envClientID, envSecret
 	}
 
-	return effectiveClientID, effectiveSecret, ""
+	return effectiveClientID, effectiveSecret
 }
 
 // GetOrCreateSession gets session from context or creates in-memory session with API key with the following priority:
@@ -58,12 +58,7 @@ func resolveAPIKeyCredentials(clientID, secret string) (string, string, string) 
 // 3. Existing session from context (session file created via 'dirctl hub login').
 // Secret must be provided as base64-encoded.
 func GetOrCreateSession(cmd *cobra.Command, serverAddress, clientID, secret string, jsonOutput bool) (*sessionstore.HubSession, error) {
-	effectiveClientID, effectiveSecret, source := resolveAPIKeyCredentials(clientID, secret)
-	if source == "" {
-		source = "session file"
-	}
-
-	fmt.Fprintf(cmd.OutOrStdout(), "Using API key authentication from %s\n", source)
+	effectiveClientID, effectiveSecret := resolveAPIKeyCredentials(clientID, secret)
 
 	// If API key credentials are available, use in-memory session.
 	if effectiveClientID != "" && effectiveSecret != "" {

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   agent-directory:
-    version: v0.2.11
+    version: v0.2.13
     modules:
       - github.com/agntcy/dir/api
       - github.com/agntcy/dir/cli


### PR DESCRIPTION
Remove verbose auth logs from JSON output.
Fixed issue where authentication logs were corrupting JSON output, making it unparseable.