### PR TITLE
chore: disable flaky sync test

### DIFF
--- a/e2e/dirctl_network_deploy_test.go
+++ b/e2e/dirctl_network_deploy_test.go
@@ -51,9 +51,10 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests using a network multi p
 		cli.Pull(cid).OnServer(utils.Peer1Addr).ShouldSucceed()
 	})
 
-	ginkgo.It("should fail to pull the record from peer 2", func() {
-		_ = cli.Pull(cid).OnServer(utils.Peer2Addr).ShouldFail()
-	})
+	// TODO: fix flaky test around SYNC record presence between nodes
+	// ginkgo.It("should fail to pull the record from peer 2", func() {
+	// 	_ = cli.Pull(cid).OnServer(utils.Peer2Addr).ShouldFail()
+	// })
 
 	ginkgo.It("should publish an record to the network on peer 1", func() {
 		cli.Routing().Publish(cid).OnServer(utils.Peer1Addr).ShouldSucceed()


### PR DESCRIPTION
## Overview

This PR disables the flaky e2e test related to presence of record when in multi-dir setup. The flaky test is most likely related to one of these issues:
- shared volume across kind clusters -- reused data in ZOT
- timing issues between sync -- indexing is triggered before test
- sync trigger issue -- unstable logic during sync due to time checks