### PR TITLE
feat(hub): add support for hub auth via apikey file

### DIFF
--- a/hub/auth/apikey.go
+++ b/hub/auth/apikey.go
@@ -12,26 +12,8 @@ import (
 	"github.com/agntcy/dir/hub/client/idp"
 	"github.com/agntcy/dir/hub/config"
 	"github.com/agntcy/dir/hub/sessionstore"
-	"github.com/agntcy/dir/hub/utils/file"
 	httpUtils "github.com/agntcy/dir/hub/utils/http"
 )
-
-// RefreshAPIKeyAccessToken refreshes API key access token and saves to session file.
-func RefreshAPIKeyAccessToken(ctx context.Context, session *sessionstore.HubSession, sessionKey string) error {
-	if err := retrieveAccessTokenWithAPIKey(ctx, session); err != nil {
-		return fmt.Errorf("failed to refresh API key access token: %w", err)
-	}
-
-	// Load session store for saving
-	sessionStore := sessionstore.NewFileSessionStore(file.GetSessionFilePath())
-
-	// Save updated session
-	if err := sessionStore.SaveHubSession(sessionKey, session); err != nil {
-		return fmt.Errorf("failed to save sessions: %w", err)
-	}
-
-	return nil
-}
 
 // CreateInMemorySessionFromAPIKey authenticates via API key for the CLI without a session file.
 func CreateInMemorySessionFromAPIKey(ctx context.Context, serverAddress, clientID, secret string) (*sessionstore.HubSession, error) {
@@ -56,13 +38,9 @@ func CreateInMemorySessionFromAPIKey(ctx context.Context, serverAddress, clientI
 			HubBackendAddress:  authConfig.HubBackendAddress,
 			APIKeyClientID:     authConfig.APIKeyClientID,
 		},
-		APIKeyAccess: &sessionstore.APIKey{
-			ClientID: clientID,
-			Secret:   secret,
-		},
 	}
 
-	if err := retrieveAccessTokenWithAPIKey(ctx, session); err != nil {
+	if err := retrieveAccessTokenWithAPIKey(ctx, session, clientID, secret); err != nil {
 		return nil, fmt.Errorf("failed to authenticate with API key: %w", err)
 	}
 
@@ -70,9 +48,9 @@ func CreateInMemorySessionFromAPIKey(ctx context.Context, serverAddress, clientI
 }
 
 // retrieveAccessTokenWithAPIKey gets API key access tokens.
-func retrieveAccessTokenWithAPIKey(ctx context.Context, session *sessionstore.HubSession) error {
-	if session == nil || !HasAPIKey(session) {
-		return errors.New("no API key access available in the session")
+func retrieveAccessTokenWithAPIKey(ctx context.Context, session *sessionstore.HubSession, clientID, secret string) error {
+	if session == nil {
+		return errors.New("no session provided")
 	}
 
 	idpClient := idp.NewClient(session.AuthConfig.IdpIssuerAddress, httpUtils.CreateSecureHTTPClient(), session.AuthConfig.APIKeyClientID)
@@ -81,18 +59,18 @@ func retrieveAccessTokenWithAPIKey(ctx context.Context, session *sessionstore.Hu
 
 	var idpResp *idp.GetAccessTokenResponse
 	if utils.IsIAMAuthConfig(session) {
-		idpResp, err = idpClient.GetAccessTokenFromAPIKey(ctx, session.APIKeyAccess.ClientID, session.APIKeyAccess.Secret)
+		idpResp, err = idpClient.GetAccessTokenFromAPIKey(ctx, clientID, secret)
 		if err != nil {
-			return fmt.Errorf("failed to refresh API key access token: %w", err)
+			return fmt.Errorf("failed to retrieve API key access token: %w", err)
 		}
 	} else {
-		idpResp, err = idpClient.GetAccessTokenFromOkta(ctx, session.APIKeyAccess.ClientID, session.APIKeyAccess.Secret)
+		idpResp, err = idpClient.GetAccessTokenFromOkta(ctx, clientID, secret)
 		if err != nil {
-			return fmt.Errorf("failed to refresh API key access token: %w", err)
+			return fmt.Errorf("failed to retrieve API key access token: %w", err)
 		}
 	}
 
-	session.APIKeyAccessToken = &sessionstore.Tokens{
+	session.Tokens = &sessionstore.Tokens{
 		AccessToken:  idpResp.AccessToken,
 		RefreshToken: idpResp.RefreshToken,
 		IDToken:      idpResp.IDToken,

--- a/hub/auth/login.go
+++ b/hub/auth/login.go
@@ -110,19 +110,3 @@ func HasLoginCreds(currentSession *sessionstore.HubSession) bool {
 
 	return tokens.AccessToken != "" && tokens.IDToken != "" && tokens.RefreshToken != ""
 }
-
-func HasAPIKey(currentSession *sessionstore.HubSession) bool {
-	if currentSession == nil || currentSession.APIKeyAccess == nil {
-		return false
-	}
-
-	return currentSession.APIKeyAccess.ClientID != "" && currentSession.APIKeyAccess.Secret != ""
-}
-
-func HasAPIKeyCreds(currentSession *sessionstore.HubSession) bool {
-	if currentSession == nil || currentSession.APIKeyAccessToken == nil {
-		return false
-	}
-
-	return currentSession.APIKeyAccessToken.AccessToken != "" && currentSession.APIKeyAccessToken.IDToken != "" && currentSession.APIKeyAccessToken.RefreshToken != ""
-}

--- a/hub/auth/utils/utils.go
+++ b/hub/auth/utils/utils.go
@@ -18,11 +18,6 @@ func AddAuthToContext(ctx context.Context, session *sessionstore.HubSession) con
 			return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+t.AccessToken))
 		}
 	}
-	// Otherwise, using API key access token if present
-	if session != nil && session.APIKeyAccessToken != nil && session.APIKeyAccessToken.AccessToken != "" {
-		return metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", "Bearer "+session.APIKeyAccessToken.AccessToken))
-	}
-
 	return ctx
 }
 

--- a/hub/cmd/apikey/create/create.go
+++ b/hub/cmd/apikey/create/create.go
@@ -16,7 +16,6 @@ import (
 	service "github.com/agntcy/dir/hub/service"
 	"github.com/agntcy/dir/hub/sessionstore"
 	authUtils "github.com/agntcy/dir/hub/utils/auth"
-	"github.com/agntcy/dir/hub/utils/file"
 	"github.com/spf13/cobra"
 )
 
@@ -103,18 +102,6 @@ func runCommand(cmd *cobra.Command, _ []string, opts *options.APIKeyCreateOption
 
 	if !opts.JSONOutput {
 		fmt.Fprintf(cmd.OutOrStdout(), "API Key created successfully:\n")
-	}
-
-	// Store the base64-encoded secret in the session.
-	currentSession.APIKeyAccess = &sessionstore.APIKey{
-		ClientID: apikeyWithSecret.ClientID,
-		Secret:   encodedSecret,
-	}
-
-	// Save session with new api key
-	sessionStore := sessionstore.NewFileSessionStore(file.GetSessionFilePath())
-	if err := sessionStore.SaveHubSession(opts.ServerAddress, currentSession); err != nil {
-		return fmt.Errorf("failed to save tokens: %w", err)
 	}
 
 	// Output API key details

--- a/hub/cmd/apikey/create/create.go
+++ b/hub/cmd/apikey/create/create.go
@@ -95,8 +95,9 @@ func runCommand(cmd *cobra.Command, _ []string, opts *options.APIKeyCreateOption
 	encodedSecret := base64.StdEncoding.EncodeToString([]byte(apikeyWithSecret.Secret))
 
 	// Apikeywithsecret will not be shown for security reasons. Use apikey instead.
-	apikey := &service.APIKeyWithRoleName{
+	apikey := &service.APIKeyWithSecretWithRoleName{
 		ClientID: apikeyWithSecret.ClientID,
+		Secret:   encodedSecret,
 		RoleName: apikeyWithSecret.RoleName,
 	}
 

--- a/hub/cmd/apikey/create/create.go
+++ b/hub/cmd/apikey/create/create.go
@@ -30,13 +30,28 @@ Parameters:
   --role      <role>      Role name. One of ['ROLE_ORG_ADMIN', 'ROLE_ADMIN', 'ROLE_EDITOR', 'ROLE_VIEWER']
   --org-id    <org_id>    Organization ID
   --org-name  <org_name>  Organization Name
+  --json                  Output in JSON format (default: env file format)
+
+Output:
+  By default, the command outputs the API key in environment variable format:
+  DIRCTL_CLIENT_ID=<client_id>
+  DIRCTL_CLIENT_SECRET=<secret>
+
+  With --json flag, it outputs in JSON format:
+  {
+    "client_id": "<client_id>",
+    "secret": "<secret>"
+  }
 
 Example:
   # Create a new API key with role OrgAdmin for organization "MyOrg"
   dirctl hub apikey create --role ROLE_ORG_ADMIN --org-name MyOrg
 
   # Create a new API key with role OrgAdmin for organization with ID 935a67e3-0276-4f61-b1ff-000fb163eedd
-  dirctl hub apikey create --role ROLE_ORG_ADMIN --org-id "935a67e3-0276-4f61-b1ff-000fb163eedd"`,
+  dirctl hub apikey create --role ROLE_ORG_ADMIN --org-id "935a67e3-0276-4f61-b1ff-000fb163eedd"
+
+  # Create a new API key and output in JSON format
+  dirctl hub apikey create --role ROLE_ORG_ADMIN --org-name MyOrg --json`,
 	}
 
 	opts := options.NewAPIKeyCreateOptions(hubOpts, cmd)
@@ -93,27 +108,25 @@ func runCommand(cmd *cobra.Command, _ []string, opts *options.APIKeyCreateOption
 	// Base64 encode the secret after creation.
 	encodedSecret := base64.StdEncoding.EncodeToString([]byte(apikeyWithSecret.Secret))
 
-	// Apikeywithsecret will not be shown for security reasons. Use apikey instead.
-	apikey := &service.APIKeyWithSecretWithRoleName{
+	// Create API key structure with encoded secret for output
+	apikey := &service.APIKeyWithSecret{
 		ClientID: apikeyWithSecret.ClientID,
 		Secret:   encodedSecret,
-		RoleName: apikeyWithSecret.RoleName,
 	}
 
-	if !opts.JSONOutput {
-		fmt.Fprintf(cmd.OutOrStdout(), "API Key created successfully:\n")
-	}
+	if opts.JSONOutput {
+		// Output JSON format for API key details
+		prettyModel, err := json.MarshalIndent(apikey, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal API key: %w", err)
+		}
 
-	// Output API key details
-	prettyModel, err := json.MarshalIndent(apikey, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal API key: %w", err)
-	}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", string(prettyModel))
+	} else {
+		// Output in environment file format
+		fmt.Fprintf(cmd.OutOrStdout(), "DIRCTL_CLIENT_ID=%s\n", apikey.ClientID)
+		fmt.Fprintf(cmd.OutOrStdout(), "DIRCTL_CLIENT_SECRET=%s\n\n", apikey.Secret)
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s\n", string(prettyModel))
-
-	if !opts.JSONOutput {
-		fmt.Fprintf(cmd.OutOrStdout(), "The API Key has been added to your session file.\n")
 	}
 
 	return nil

--- a/hub/cmd/info/org/org.go
+++ b/hub/cmd/info/org/org.go
@@ -39,8 +39,8 @@ Examples:
 				cmd.SetOut(os.Stdout)
 				cmd.SetErr(os.Stderr)
 				_ = cmd.Help()
-
-				return nil
+				
+				return errors.New("missing required argument: organization ID")
 			}
 
 			return nil
@@ -48,6 +48,11 @@ Examples:
 	}
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// Check if organization ID is provided
+		if len(args) == 0 {
+			return errors.New("missing required argument: organization ID")
+		}
+
 		// Retrieve session from context
 		ctxSession := cmd.Context().Value(sessionstore.SessionContextKey)
 		currentSession, ok := ctxSession.(*sessionstore.HubSession)

--- a/hub/cmd/pull/pull.go
+++ b/hub/cmd/pull/pull.go
@@ -32,11 +32,11 @@ Parameters:
 
 Authentication:
   API key authentication can be provided via:
-  1. Command flags: --client-id and --secret
+  1. API key file: --apikey-file (JSON file with API key credentials)
   2. Environment variables: DIRCTL_CLIENT_ID and DIRCTL_CLIENT_SECRET
   3. Session file created via 'dirctl hub login'
 
-  Command flags take precedence over environment variables, which take precedence over session file.
+  API key file takes precedence over environment variables, which take precedence over session file.
 
 Examples:
   # Pull agent by digest
@@ -45,8 +45,13 @@ Examples:
   # Pull agent by repository and version
   dirctl hub pull owner/repo-name:v1.0.0
 
-  # Pull using API key authentication via flags
-  dirctl hub pull owner/repo-name:v1.0.0 --client-id YOUR_CLIENT_ID --secret YOUR_SECRET
+  # Pull using API key file (JSON format)
+  # File content example:
+  # {
+  #   "client_id": "your-client-id",
+  #   "secret": "your-secret"
+  # }
+  dirctl hub pull owner/repo-name:v1.0.0 --apikey-file /path/to/apikey.json
 
   # Pull using API key authentication via environment variables
   export DIRCTL_CLIENT_ID=your_client_id
@@ -61,10 +66,9 @@ Examples:
 	opts := hubOptions.NewHubPullOptions(hubOpts)
 
 	// API key authentication flags
-	var clientID, secret string
+	var apikeyFile string
 
-	cmd.Flags().StringVar(&clientID, "client-id", "", "API key client ID for authentication")
-	cmd.Flags().StringVar(&secret, "secret", "", "API key secret for authentication")
+	cmd.Flags().StringVar(&apikeyFile, "apikey-file", "", "Path to a JSON file containing API key credentials (format: {\"client_id\": \"...\", \"secret\": \"...\"})")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
@@ -74,8 +78,8 @@ Examples:
 		cmd.SetOut(os.Stdout)
 		cmd.SetErr(os.Stderr)
 
-		// Authenticate using either API key or session file
-		currentSession, err := authUtils.GetOrCreateSession(cmd, opts.ServerAddress, clientID, secret, false)
+		// Authenticate using either API key file or session file
+		currentSession, err := authUtils.GetOrCreateSession(cmd, opts.ServerAddress, "", "", apikeyFile, false)
 		if err != nil {
 			return fmt.Errorf("failed to get or create session: %w", err)
 		}

--- a/hub/cmd/push/push.go
+++ b/hub/cmd/push/push.go
@@ -22,60 +22,64 @@ import (
 // Returns the configured *cobra.Command.
 func NewCommand(hubOpts *hubOptions.HubOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "push <repository> {<model.json> | --stdin} ",
+		Use:   "push <org-name>/<name> {<model.json> | --stdin} ",
 		Short: "Push model to Agent Hub",
 		Long: `Push a model to the Agent Hub.
 
 Parameters:
-  <repository>    Repository name in the format of '<owner>/<name>'
+  <repository>    Repository name in the format of '<org-name>/<name>'
   <model.json>    Path to the model file (optional)
   --stdin         Read model from standard input (optional)
 
 Authentication:
   API key authentication can be provided via:
-  1. Command flags: --client-id and --secret
+  1. API key file: --apikey-file (JSON file with API key credentials)
   2. Environment variables: DIRCTL_CLIENT_ID and DIRCTL_CLIENT_SECRET
   3. Session file created via 'dirctl hub login'
 
-  Command flags take precedence over environment variables, which take precedence over session file.
+  API key file takes precedence over environment variables, which take precedence over session file.
 
 Examples:
   # Push model to a repository by name
-  dirctl hub push owner/repo-name model.json
+  dirctl hub push org-name/repo-name model.json
 
   # Push model to a repository by ID
   dirctl hub push 123e4567-e89b-12d3-a456-426614174000 model.json
 
   # Push model from stdin
-  dirctl hub push owner/repo-name --stdin < model.json
+  dirctl hub push org-name/repo-name --stdin < model.json
 
-  # Push using API key authentication via flags
-  dirctl hub push owner/repo-name model.json --client-id API_KEY_CLIENT_ID --secret API_KEY_SECRET
+  # Push using API key file (JSON format)
+  # File content example:
+  # {
+  #   "client_id": "your-client-id",
+  #   "secret": "your-secret"
+  # }
+  dirctl hub push org-name/repo-name model.json --apikey-file /path/to/apikey.json
 
   # Push using API key authentication via environment variables
   export DIRCTL_CLIENT_ID=your_client_id
   export DIRCTL_CLIENT_SECRET=your_secret
-  dirctl hub push owner/repo-name model.json
+  dirctl hub push org-name/repo-name model.json
 
   # Push using session file (after login)
   dirctl hub login
-  dirctl hub push owner/repo-name model.json`,
+  dirctl hub push org-name/repo-name model.json`,
 	}
 
 	opts := hubOptions.NewHubPushOptions(hubOpts, cmd)
 
 	// API key authentication flags
-	var clientID, secret string
+	var apikeyFile string
 
-	cmd.Flags().StringVar(&clientID, "client-id", "", "API key client ID for authentication")
-	cmd.Flags().StringVar(&secret, "secret", "", "API key secret for authentication")
+	cmd.Flags().StringVar(&apikeyFile, "apikey-file", "", "Path to a JSON file containing API key credentials (format: {\"client_id\": \"...\", \"secret\": \"...\"})")
 
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		cmd.SetOut(os.Stdout)
 		cmd.SetErr(os.Stderr)
 
-		// Authenticate using either API key or session file
-		currentSession, err := authUtils.GetOrCreateSession(cmd, opts.ServerAddress, clientID, secret, false)
+		// Authenticate using either API key file or session file
+		currentSession, err := authUtils.GetOrCreateSession(cmd, opts.ServerAddress, "", "", apikeyFile, false)
 		if err != nil {
 			return fmt.Errorf("failed to get or create session: %w", err)
 		}

--- a/hub/sessionstore/type.go
+++ b/hub/sessionstore/type.go
@@ -17,11 +17,9 @@ type HubSessions struct {
 
 // HubSession represents a user session, including tokens, current organization, user, and auth config.
 type HubSession struct {
-	Tokens            *Tokens `json:"tokens"`
-	User              string  `json:"user"`
-	APIKeyAccess      *APIKey `json:"api_key_access,omitempty"`
-	APIKeyAccessToken *Tokens `json:"access_token"`
-	*AuthConfig       `json:"auth_config,omitempty"`
+	Tokens      *Tokens `json:"tokens"`
+	User        string  `json:"user"`
+	*AuthConfig `json:"auth_config,omitempty"`
 }
 
 // Tokens holds ID, refresh, and access tokens for a session.
@@ -40,9 +38,4 @@ type AuthConfig struct {
 	IdpIssuerAddress   string `json:"idp_issuer"`
 	HubBackendAddress  string `json:"hub_backend"`
 	APIKeyClientID     string `json:"api_key_client_id"`
-}
-
-type APIKey struct {
-	ClientID string `json:"client_id"`
-	Secret   string `json:"secret"`
 }

--- a/hub/utils/auth/auth.go
+++ b/hub/utils/auth/auth.go
@@ -14,17 +14,7 @@ import (
 )
 
 func CheckForCreds(cmd *cobra.Command, currentSession *sessionstore.HubSession, serverAddress string, jsonOutput bool) error {
-	if !baseauth.HasLoginCreds(currentSession) && baseauth.HasAPIKey(currentSession) {
-		if !jsonOutput {
-			fmt.Fprintf(cmd.OutOrStdout(), "User is authenticated with API key, using it to get credentials...\n")
-		}
-
-		if err := baseauth.RefreshAPIKeyAccessToken(cmd.Context(), currentSession, serverAddress); err != nil {
-			return fmt.Errorf("failed to refresh API key access token: %w", err)
-		}
-	}
-
-	if !baseauth.HasLoginCreds(currentSession) && !baseauth.HasAPIKey(currentSession) {
+	if !baseauth.HasLoginCreds(currentSession) {
 		return errors.New("you need to be logged to execute this action\nuse `dirctl hub login` command to login")
 	}
 

--- a/hub/utils/auth/auth.go
+++ b/hub/utils/auth/auth.go
@@ -4,11 +4,13 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 
 	baseauth "github.com/agntcy/dir/hub/auth"
+	"github.com/agntcy/dir/hub/service"
 	"github.com/agntcy/dir/hub/sessionstore"
 	"github.com/spf13/cobra"
 )
@@ -22,13 +24,28 @@ func CheckForCreds(cmd *cobra.Command, currentSession *sessionstore.HubSession, 
 }
 
 // resolveAPIKeyCredentials returns the effective clientID and secret (base64-encoded).
-func resolveAPIKeyCredentials(clientID, secret string) (string, string) {
-	effectiveClientID := clientID
-	effectiveSecret := secret
+// It checks sources in the following order of priority:
+// 1. API key file (if provided)
+// 2. Environment variables
+func resolveAPIKeyCredentials(clientID, secret, apikeyFile string) (string, string, error) {
+	// Check API key file if provided
+	if apikeyFile != "" {
+		fileContent, err := os.ReadFile(apikeyFile)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to read API key file: %w", err)
+		}
 
-	// CLI opts take priority
-	if effectiveClientID != "" && effectiveSecret != "" {
-		return effectiveClientID, effectiveSecret
+		// Parse JSON file content to extract clientID and secret
+		var apiKey service.APIKeyWithSecret
+		if err := json.Unmarshal(fileContent, &apiKey); err != nil {
+			return "", "", fmt.Errorf("failed to parse API key file as JSON: %w", err)
+		}
+
+		if apiKey.ClientID == "" || apiKey.Secret == "" {
+			return "", "", fmt.Errorf("API key file must contain both client_id and secret fields")
+		}
+
+		return apiKey.ClientID, apiKey.Secret, nil
 	}
 
 	// Environment variables
@@ -36,19 +53,24 @@ func resolveAPIKeyCredentials(clientID, secret string) (string, string) {
 	envSecret := os.Getenv("DIRCTL_CLIENT_SECRET")
 
 	if envClientID != "" && envSecret != "" {
-		return envClientID, envSecret
+		return envClientID, envSecret, nil
 	}
 
-	return effectiveClientID, effectiveSecret
+	// Return empty values if no authentication source was found
+	// This will trigger the session-based authentication flow
+	return "", "", nil
 }
 
 // GetOrCreateSession gets session from context or creates in-memory session with API key with the following priority:
-// 1. API key from command opts
+// 1. API key from file (if provided via apikeyFile)
 // 2. API key from environment variables
 // 3. Existing session from context (session file created via 'dirctl hub login').
 // Secret must be provided as base64-encoded.
-func GetOrCreateSession(cmd *cobra.Command, serverAddress, clientID, secret string, jsonOutput bool) (*sessionstore.HubSession, error) {
-	effectiveClientID, effectiveSecret := resolveAPIKeyCredentials(clientID, secret)
+func GetOrCreateSession(cmd *cobra.Command, serverAddress, clientID, secret, apikeyFile string, jsonOutput bool) (*sessionstore.HubSession, error) {
+	effectiveClientID, effectiveSecret, err := resolveAPIKeyCredentials(clientID, secret, apikeyFile)
+	if err != nil {
+		return nil, err
+	}
 
 	// If API key credentials are available, use in-memory session.
 	if effectiveClientID != "" && effectiveSecret != "" {


### PR DESCRIPTION
# Enhanced API Key Authentication for dirctl hub commands

## Overview
This PR improves the authentication mechanism for dirctl hub commands by adding support for API key authentication through a file-based approach

## Changes

### Added API Key File Authentication
- Added a new `--apikey-file` option to multiple commands, allowing users to provide API key credentials in a JSON file
- The API key file follows the format: `{"client_id": "...", "secret": "..."}`
- Implemented in:
  - `hub pull` command
  - `hub push` command

### Improved Authentication Flow
- Enhanced the authentication logic to follow a clear priority order:
  1. API key from file (if provided via `--apikey-file`)
  2. API key from environment variables (DIRCTL_CLIENT_ID, DIRCTL_CLIENT_SECRET)
  3. Existing session from context (session file created via 'dirctl hub login')

### Security Improvements
- Removed command line options for directly providing client ID and secret in the `pull` and `push` commands
- This avoids exposing sensitive credentials in shell history or process lists

### Error Handling Improvements
- Improved error messaging when invalid parameters are provided
- Fixed a bug in the `hub info org` command that caused a fatal error when no organization ID was provided

## Usage Examples

```bash
# Pull an agent using API key file
dirctl hub pull owner/repo-name:v1.0.0 --apikey-file /path/to/apikey.json

# Push an agent using API key file
dirctl hub push --apikey-file /path/to/apikey.json ...

# File content example:
# {
#   "client_id": "your-client-id",
#   "secret": "your-secret"
# }