### PR TITLE
ci(homebrew): use local tap for testing homebrew formulae

### DIFF
--- a/.github/workflows/brew-formula-update.yaml
+++ b/.github/workflows/brew-formula-update.yaml
@@ -10,6 +10,15 @@ description: |
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      create-pr:
+        type: boolean
+        default: true
+        description: Enable to create PR
+      run-without-diff:
+        type: boolean
+        default: false
+        description: Run even if there are no changes.
   release:
     types: [released]
 
@@ -78,7 +87,7 @@ jobs:
           fi
 
       - name: Test new formula
-        if: ${{ steps.brew-formula.outputs.DIFF_FOUND == 1 }}
+        if: ${{ steps.brew-formula.outputs.DIFF_FOUND == 1 || inputs.run-without-diff == true || inputs.run-without-diff == 'true' }}
         run: |
           apt update && apt install curl git -y
 
@@ -86,11 +95,17 @@ jobs:
 
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 
-          brew install --build-from-source ./HomebrewFormula/dirctl.rb --verbose
+          # Make local formula for testing from the repo homebrew formula file
+          brew tap-new --no-git agntcy/dir-test
+
+          FORMULA_DIR="$(brew --repository)/Library/Taps/agntcy/homebrew-dir-test/Formula/"
+          cp ./HomebrewFormula/dirctl.rb "$FORMULA_DIR"
+
+          brew install agntcy/dir-test/dirctl --verbose
 
           dirctl --help
 
       - name: Create PR
-        if: ${{ steps.brew-formula.outputs.DIFF_FOUND == 1 }}
+        if: ${{ steps.brew-formula.outputs.DIFF_FOUND == 1 &&  inputs.create-pr == true || inputs.create-pr == 'true'  }}
         run: |
           gh pr create --title "chore: update brew formula to ${{ steps.release-infos.outputs.LATEST_VERSION }}" --body "This PR is created by brew-formula-update workflow."

--- a/HomebrewFormula/README.md
+++ b/HomebrewFormula/README.md
@@ -8,8 +8,6 @@
 ## How to install a formula
 ```bash
     brew install dirctl
-    # or with extension
-    brew install dirctl --with-hub
 ```
 
 ## How to remove an installed formula


### PR DESCRIPTION
The homebrew binary beyond the 4.6.3 version break the local file installation which our CI relies on for testing the updated formulae. This fix is creating a new local tap for testing and copy the formula from the repository into it