### PR TITLE
fix(dir): locator based remote record search

### DIFF
--- a/server/routing/ROUTING.md
+++ b/server/routing/ROUTING.md
@@ -516,7 +516,7 @@ SEARCH EXECUTION (per user query):
 
 **Read Pattern**: 
 - **Discovery**: `O(1)` RPC call per new remote record
-- **Search**: `O(3×M)` KV reads where M = number of cached remote labels
+- **Search**: `O(4×M)` KV reads where M = number of cached remote labels (skills, domains, modules, locators)
 
 ### OR Logic with Minimum Threshold
 

--- a/server/routing/cleanup_core_test.go
+++ b/server/routing/cleanup_core_test.go
@@ -234,7 +234,7 @@ func simulateCleanupLabelsForCID(ctx context.Context, dstore types.Datastore, ci
 	}
 
 	// Find and remove all label keys for this CID using shared namespace iteration
-	entries, err := QueryAllNamespaces(ctx, dstore, true) // Include locators for complete cleanup
+	entries, err := QueryAllNamespaces(ctx, dstore)
 	if err != nil {
 		return false
 	}

--- a/server/routing/routing_local.go
+++ b/server/routing/routing_local.go
@@ -220,8 +220,8 @@ func (r *routeLocal) matchesAllQueries(ctx context.Context, cid string, queries 
 func (r *routeLocal) getRecordLabelsEfficiently(ctx context.Context, cid string) []labels.Label {
 	var labelList []labels.Label
 
-	// Use shared namespace iteration function (includes locators for local routing)
-	entries, err := QueryAllNamespaces(ctx, r.dstore, true) // Local routing needs locators namespace
+	// Use shared namespace iteration function
+	entries, err := QueryAllNamespaces(ctx, r.dstore)
 	if err != nil {
 		localLogger.Error("Failed to get namespace entries for labels", "cid", cid, "error", err)
 

--- a/server/routing/search_simple_test.go
+++ b/server/routing/search_simple_test.go
@@ -259,7 +259,7 @@ func simulateSearch(ctx context.Context, dstore types.Datastore, localPeerID str
 	limitInt := int(limit)
 
 	// Query all namespaces using shared function
-	entries, err := QueryAllNamespaces(ctx, dstore, false) // Test doesn't need locators
+	entries, err := QueryAllNamespaces(ctx, dstore)
 	if err != nil {
 		return results
 	}
@@ -321,7 +321,7 @@ func testMatchesAllQueriesSimple(ctx context.Context, dstore types.Datastore, ci
 	}
 
 	// Get labels for this CID/PeerID using shared namespace iteration
-	entries, err := QueryAllNamespaces(ctx, dstore, false) // Test doesn't need locators
+	entries, err := QueryAllNamespaces(ctx, dstore)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
1. Remove the `includeLocators` parameter from `QueryAllNamespaces`
2. Always include all label namespaces (skills, domains, modules, **locators**) in queries
3. Add comprehensive test coverage for `DOMAIN` and `MODULE` query types (previously missing)