### PR TITLE
chore(dir): bump oasf sdk version 0.0.6

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.24.5
 require (
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.9-20250917120021-8b2bf93bf8dc.1
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.9-20250917090956-ba2d05f62118.1
-	github.com/agntcy/oasf-sdk/pkg v0.0.5
+	github.com/agntcy/oasf-sdk/pkg v0.0.6
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/stretchr/testify v1.10.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -2,8 +2,8 @@ buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.9-20250917120021-8b2bf
 buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.9-20250917120021-8b2bf93bf8dc.1/go.mod h1:uTsOo9jnzYqVE9RVbE0CJBKn1S9aNcDS/0OFp1nwurw=
 buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.9-20250917090956-ba2d05f62118.1 h1:/woChozR+ReghDHPp9vwdetbBpqfDxHYUH9Iso+Bsww=
 buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.9-20250917090956-ba2d05f62118.1/go.mod h1:0oAU8mfSDwDA9l2HycLTYpJ2Ifn3YO5rI2xJP1XwPzs=
-github.com/agntcy/oasf-sdk/pkg v0.0.5 h1:ooQqaGZw0bVc+RpplXDiekn1Ju5mWaBiTxTSxlKGYY4=
-github.com/agntcy/oasf-sdk/pkg v0.0.5/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
+github.com/agntcy/oasf-sdk/pkg v0.0.6 h1:fNtiEfZyjkS2lwPE5JDqIiRYdXNy79TJiCTRwtlFco4=
+github.com/agntcy/oasf-sdk/pkg v0.0.6/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/agntcy/dirhub/backport/api v0.0.0-00010101000000-000000000000 // indirect
-	github.com/agntcy/oasf-sdk/pkg v0.0.5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v0.0.6 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -689,8 +689,8 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/agntcy/dir/api v0.2.13 h1:X0jRpGmyGwFh6kfrADkhC5ZWzLlUp9TBJ/XZo+EQr/o=
 github.com/agntcy/dir/api v0.2.13/go.mod h1:dPSvpgfwqJsj0KoMuMTOh2/T190egQZLt5WV0Pxrnyk=
-github.com/agntcy/oasf-sdk/pkg v0.0.5 h1:ooQqaGZw0bVc+RpplXDiekn1Ju5mWaBiTxTSxlKGYY4=
-github.com/agntcy/oasf-sdk/pkg v0.0.5/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
+github.com/agntcy/oasf-sdk/pkg v0.0.6 h1:fNtiEfZyjkS2lwPE5JDqIiRYdXNy79TJiCTRwtlFco4=
+github.com/agntcy/oasf-sdk/pkg v0.0.6/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/client/go.mod
+++ b/client/go.mod
@@ -109,7 +109,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.53.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 // indirect
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
-	github.com/agntcy/oasf-sdk/pkg v0.0.5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v0.0.6 // indirect
 	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -685,8 +685,8 @@ github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/oasf-sdk/pkg v0.0.5 h1:ooQqaGZw0bVc+RpplXDiekn1Ju5mWaBiTxTSxlKGYY4=
-github.com/agntcy/oasf-sdk/pkg v0.0.5/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
+github.com/agntcy/oasf-sdk/pkg v0.0.6 h1:fNtiEfZyjkS2lwPE5JDqIiRYdXNy79TJiCTRwtlFco4=
+github.com/agntcy/oasf-sdk/pkg v0.0.6/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/agntcy/dir/hub v0.3.0 // indirect
 	github.com/agntcy/dirhub/backport/api v0.0.0-00010101000000-000000000000 // indirect
-	github.com/agntcy/oasf-sdk/pkg v0.0.5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v0.0.6 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -689,8 +689,8 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/agntcy/dir/api v0.2.13 h1:X0jRpGmyGwFh6kfrADkhC5ZWzLlUp9TBJ/XZo+EQr/o=
 github.com/agntcy/dir/api v0.2.13/go.mod h1:dPSvpgfwqJsj0KoMuMTOh2/T190egQZLt5WV0Pxrnyk=
-github.com/agntcy/oasf-sdk/pkg v0.0.5 h1:ooQqaGZw0bVc+RpplXDiekn1Ju5mWaBiTxTSxlKGYY4=
-github.com/agntcy/oasf-sdk/pkg v0.0.5/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
+github.com/agntcy/oasf-sdk/pkg v0.0.6 h1:fNtiEfZyjkS2lwPE5JDqIiRYdXNy79TJiCTRwtlFco4=
+github.com/agntcy/oasf-sdk/pkg v0.0.6/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/server/go.mod
+++ b/server/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Portshift/go-utils v0.0.0-20220421083203-89265d8a6487
 	github.com/agntcy/dir/api v0.3.0
 	github.com/agntcy/dir/utils v0.3.0
-	github.com/agntcy/oasf-sdk/pkg v0.0.5
+	github.com/agntcy/oasf-sdk/pkg v0.0.6
 	github.com/casbin/casbin/v2 v2.120.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/ipfs/go-datastore v0.8.2

--- a/server/go.sum
+++ b/server/go.sum
@@ -704,8 +704,8 @@ github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/oasf-sdk/pkg v0.0.5 h1:ooQqaGZw0bVc+RpplXDiekn1Ju5mWaBiTxTSxlKGYY4=
-github.com/agntcy/oasf-sdk/pkg v0.0.5/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
+github.com/agntcy/oasf-sdk/pkg v0.0.6 h1:fNtiEfZyjkS2lwPE5JDqIiRYdXNy79TJiCTRwtlFco4=
+github.com/agntcy/oasf-sdk/pkg v0.0.6/go.mod h1:7hlTa7Wd65g9Msu3ZKthvD0Q7SKaMjgAb2ya289OHUU=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=


### PR DESCRIPTION
This PR bumps the OASF SDK version to v0.0.6.