### PR TITLE
chore(ci): update container tags for security scans

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -24,13 +24,13 @@ jobs:
         include:
           - image: dir-apiserver
             repo: ghcr.io/${{ github.repository_owner }}/dir-apiserver
-            version: latest
+            version: v0.4.0
           - image: dir-ctl
             repo: ghcr.io/${{ github.repository_owner }}/dir-ctl
-            version: latest
+            version: v0.4.0
           - image: zot
             repo: ghcr.io/project-zot/zot
-            version: latest
+            version: 2.1.8
           - image: spire-server
             repo: ghcr.io/spiffe/spire-server
             version: 1.9.6


### PR DESCRIPTION
Update image versions:
- `dir*:v0.4.0`
- `zot:2.1.8`