### PR TITLE
fix(sdk/js): prefix for rc tags and default latest otherwise

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -369,6 +369,7 @@ tasks:
       - task: sdk:release:python
 
   sdk:release:python:
+    ignore_error: true # FIXME: Need to check if package version already exists
     desc: Release python client SDK package
     dir: ./sdk/dir-py
     env:
@@ -379,6 +380,7 @@ tasks:
       - '{{.UV_BIN}} publish'
 
   sdk:release:javascript:
+    ignore_error: true # FIXME: Need to check if package version already exists
     desc: Release javascript client SDK package
     dir: ./sdk/dir-js
     env:


### PR DESCRIPTION
As NPM does not allow to have semver compliant tag for packages we need to make sure to avoid it by using a `rc` prefix when the git commit hash contains only numbers like `7965064` otherwise the latest tag will be used for non rc releases.