### PR TITLE
fix(dir): sign and verify options

### DIFF
--- a/hub/cmd/hub.go
+++ b/hub/cmd/hub.go
@@ -113,8 +113,8 @@ func NewHubCommand(ctx context.Context, baseOption *options.BaseOption) *cobra.C
 		orgs.NewCommand(opts),
 		apikey.NewCommand(opts),
 		info.NewCommand(opts),
-		sign.Command,
-		verify.Command,
+		sign.NewCommand(opts),
+		verify.NewCommand(opts),
 	)
 
 	return cmd


### PR DESCRIPTION
Base options (like `server-address`) to sign and verify subcommands were not actually passed (but overwritten by NewHubOptions).