### PR TITLE
feat(dir/helm): add dnsNameTemplates support to DIR API

### DIFF
--- a/install/charts/dir/apiserver/templates/clusterspiffeids.yaml
+++ b/install/charts/dir/apiserver/templates/clusterspiffeids.yaml
@@ -15,8 +15,10 @@ spec:
     - k8s:sa:{{ include "chart.serviceAccountName" . }}
   spiffeIDTemplate: {{ "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}" }}
   autoPopulateDNSNames: true
+  {{- if .Values.spire.dnsNameTemplates }}
   dnsNameTemplates:
-    {{- .Values.spire.dnsNameTemplates | toYaml | nindent 4 }}
+    {{- toYaml .Values.spire.dnsNameTemplates | nindent 4 }}
+  {{- end }}
   {{- if .Values.spire.federation }}
   federatesWith:
   {{ range .Values.spire.federation }}

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -211,6 +211,15 @@ config:
 spire:
   enabled: false
   trustDomain: example.org
+  
+  # Custom DNS names to add to the X.509-SVID certificate SANs
+  # Useful for external access with proper TLS verification without --tls-skip-verify
+  # Example:
+  # dnsNameTemplates:
+  #   - "dir-api.example.com"
+  #   - "api.example.com"
+  dnsNameTemplates: []
+  
   federation: []
     # # Config: https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterfederatedtrustdomain-crd.md
     # - trustDomain: dir-cluster


### PR DESCRIPTION
ClusterSPIFFEID

- Add conditional dnsNameTemplates field to ClusterSPIFFEID template
- Initialize dnsNameTemplates as empty array in values.yaml
- Add documentation and examples for custom DNS configuration
- Fix template to only include dnsNameTemplates when defined

This enables adding custom DNS names to the X.509-SVID certificate SANs, allowing proper TLS verification for external access without --tls-skip-verify.