### PR TITLE
feat(dir/helm): enable external secret config for api server and zot

### DIFF
--- a/install/charts/dir/apiserver/templates/deployment.yaml
+++ b/install/charts/dir/apiserver/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               value: {{ .Values.log_format }}
             - name: DIRECTORY_SERVER_LOGGING_VERBOSE
               value: "{{ .Values.grpc_logging_verbose }}"
-            {{- if or .Values.secrets.syncAuth.username .Values.secrets.syncAuth.password }}
+            {{- if or .Values.secrets.syncAuth.username .Values.secrets.syncAuth.password (and .Values.externalSecrets.enabled .Values.externalSecrets.syncAuth.enabled) }}
             - name: DIRECTORY_SERVER_SYNC_AUTH_CONFIG_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -80,7 +80,7 @@ spec:
                   name: {{ include "chart.fullname" . }}
                   key: sync-password
             {{- end }}
-            {{- if or .Values.secrets.ociAuth.username .Values.secrets.ociAuth.password }}
+            {{- if or .Values.secrets.ociAuth.username .Values.secrets.ociAuth.password (and .Values.externalSecrets.enabled .Values.externalSecrets.ociAuth.enabled) }}
             - name: DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -157,7 +157,7 @@ spec:
             - name: config-volume
               mountPath: /etc/agntcy/dir/server.config.yml
               subPath: server.config.yml
-            {{- if .Values.secrets.privKey }}
+            {{- if or .Values.secrets.privKey (and .Values.externalSecrets.enabled .Values.externalSecrets.nodeIdentity.enabled) }}
             - name: secret-volume
               mountPath: {{ .Values.config.routing.key_path }}
               subPath: node.privkey
@@ -197,7 +197,7 @@ spec:
             path: /run/spire/agent-sockets
             type: Directory
         {{- end }}
-        {{- if .Values.secrets.privKey }}
+        {{- if or .Values.secrets.privKey (and .Values.externalSecrets.enabled .Values.externalSecrets.nodeIdentity.enabled) }}
         - name: secret-volume
           secret:
             secretName: {{ include "chart.fullname" . }}

--- a/install/charts/dir/apiserver/templates/external-secret.yaml
+++ b/install/charts/dir/apiserver/templates/external-secret.yaml
@@ -1,0 +1,91 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.externalSecrets.enabled }}
+---
+# ExternalSecret for DIR API server credentials
+#
+# This syncs all sensitive credentials from HashiCorp Vault to a Kubernetes Secret.
+# The External Secrets Operator (ESO) manages the sync automatically.
+#
+# What it creates:
+# - Kubernetes Secret: {{ include "chart.fullname" . }}
+# - Contains all credentials: node identity, OCI auth, sync auth
+#
+# Prerequisites:
+# 1. Credentials stored in Vault at configured path
+# 2. ClusterSecretStore configured (referenced below)
+# 3. ESO has permissions to read from Vault path
+#
+# Lifecycle:
+# - ESO syncs from Vault every refresh interval (default: 1h)
+# - Secret is automatically updated if Vault values change
+# - Secret is automatically recreated if deleted
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secrets
+spec:
+  # Refresh interval - how often to sync from Vault
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "1h" }}
+  
+  # Reference to the ClusterSecretStore
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore }}
+    kind: {{ .Values.externalSecrets.secretStoreKind | default "ClusterSecretStore" }}
+  
+  # Target Kubernetes Secret to create/update
+  target:
+    name: {{ include "chart.fullname" . }}
+    creationPolicy: Owner  # ESO owns this secret (will recreate if deleted)
+    deletionPolicy: Retain # Keep secret even if ExternalSecret is deleted
+  
+  # Data to sync from Vault
+  data:
+    {{- if .Values.externalSecrets.nodeIdentity.enabled }}
+    # Node identity private key for stable P2P peer ID
+    - secretKey: node.privkey
+      remoteRef:
+        key: {{ .Values.externalSecrets.vaultPath }}
+        property: {{ .Values.externalSecrets.nodeIdentity.property | default "node.privkey" }}
+        conversionStrategy: Default
+        decodingStrategy: None
+    {{- end }}
+    
+    {{- if .Values.externalSecrets.ociAuth.enabled }}
+    # OCI registry authentication (for storing/retrieving agent records)
+    - secretKey: oci-username
+      remoteRef:
+        key: {{ .Values.externalSecrets.vaultPath }}
+        property: {{ .Values.externalSecrets.ociAuth.usernameProperty | default "oci-username" }}
+        conversionStrategy: Default
+        decodingStrategy: None
+    - secretKey: oci-password
+      remoteRef:
+        key: {{ .Values.externalSecrets.vaultPath }}
+        property: {{ .Values.externalSecrets.ociAuth.passwordProperty | default "oci-password" }}
+        conversionStrategy: Default
+        decodingStrategy: None
+    {{- end }}
+    
+    {{- if .Values.externalSecrets.syncAuth.enabled }}
+    # Sync authentication (shared with remote nodes for P2P sync)
+    - secretKey: sync-username
+      remoteRef:
+        key: {{ .Values.externalSecrets.vaultPath }}
+        property: {{ .Values.externalSecrets.syncAuth.usernameProperty | default "sync-username" }}
+        conversionStrategy: Default
+        decodingStrategy: None
+    - secretKey: sync-password
+      remoteRef:
+        key: {{ .Values.externalSecrets.vaultPath }}
+        property: {{ .Values.externalSecrets.syncAuth.passwordProperty | default "sync-password" }}
+        conversionStrategy: Default
+        decodingStrategy: None
+    {{- end }}
+{{- end }}
+

--- a/install/charts/dir/apiserver/templates/secret.yaml
+++ b/install/charts/dir/apiserver/templates/secret.yaml
@@ -1,7 +1,9 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.secrets -}}
+# This secret is only created when NOT using ExternalSecrets.
+# When externalSecrets.enabled=true, the ExternalSecret operator creates this secret instead.
+{{- if and .Values.secrets (not .Values.externalSecrets.enabled) -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -9,6 +11,7 @@ metadata:
   name: {{ include "chart.fullname" . }}
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+    app.kubernetes.io/component: secrets
 data:
   {{- if .Values.secrets.privKey }}
   node.privkey: {{ .Values.secrets.privKey | b64enc }}

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -370,6 +370,11 @@ extraEnv: []
 revisionHistoryLimit: 2
 
 # Secrets configuration
+# Choose ONE of two methods:
+# 1. Helm-managed secrets (secrets.*) - credentials in values.yaml
+# 2. ExternalSecrets (externalSecrets.*) - credentials synced from Vault
+#
+# Method 1: Helm-managed secrets (default)
 # Sensitive credentials are stored in Kubernetes secrets and injected as environment variables
 secrets:
   # Private key for peer-to-peer routing identity
@@ -389,3 +394,46 @@ secrets:
   ociAuth:
     username: ""
     password: ""
+
+# Method 2: ExternalSecrets configuration
+# Syncs credentials from HashiCorp Vault (or other secret providers) using External Secrets Operator
+# When enabled, the Helm-managed secret (above) is NOT created
+externalSecrets:
+  # Enable ExternalSecrets integration (default: false)
+  # When true, credentials are synced from Vault instead of using values.yaml
+  enabled: false
+  
+  # Vault path where credentials are stored (all credentials in one path)
+  # Example: "dir_staging/dev/credentials"
+  vaultPath: ""
+  
+  # ClusterSecretStore or SecretStore name to use
+  # This must be pre-configured in your cluster (managed by platform team)
+  secretStore: "vault-backend"
+  
+  # Secret store kind (default: ClusterSecretStore)
+  # Options: ClusterSecretStore (cluster-wide) or SecretStore (namespace-scoped)
+  secretStoreKind: "ClusterSecretStore"
+  
+  # Refresh interval - how often ESO syncs from Vault (default: 1h)
+  refreshInterval: "1h"
+  
+  # Node identity configuration
+  nodeIdentity:
+    enabled: true
+    # Property name in Vault secret (default: "node.privkey")
+    property: "node.privkey"
+  
+  # OCI registry authentication
+  ociAuth:
+    enabled: true
+    # Property names in Vault secret (defaults shown)
+    usernameProperty: "oci-username"
+    passwordProperty: "oci-password"
+  
+  # Sync authentication (shared with remote nodes)
+  syncAuth:
+    enabled: true
+    # Property names in Vault secret (defaults shown)
+    usernameProperty: "sync-username"
+    passwordProperty: "sync-password"

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -292,6 +292,11 @@ apiserver:
       - "/etc/zot/config.json"
 
   # Secrets configuration
+  # Choose ONE of two methods:
+  # 1. Helm-managed secrets (secrets.*) - credentials in values.yaml
+  # 2. ExternalSecrets (externalSecrets.*) - credentials synced from Vault
+  #
+  # Method 1: Helm-managed secrets (default)
   # Sensitive credentials are stored in Kubernetes secrets and injected as environment variables
   secrets:
     # Private key for peer-to-peer routing identity
@@ -311,3 +316,46 @@ apiserver:
     ociAuth:
       username: ""
       password: ""
+
+  # Method 2: ExternalSecrets configuration
+  # Syncs credentials from HashiCorp Vault (or other secret providers) using External Secrets Operator
+  # When enabled, the Helm-managed secret (above) is NOT created
+  externalSecrets:
+    # Enable ExternalSecrets integration (default: false)
+    # When true, credentials are synced from Vault instead of using values.yaml
+    enabled: false
+    
+    # Vault path where credentials are stored (all credentials in one path)
+    # Example: "dir_staging/dev/credentials"
+    vaultPath: ""
+    
+    # ClusterSecretStore or SecretStore name to use
+    # This must be pre-configured in your cluster (managed by platform team)
+    secretStore: "vault-backend"
+    
+    # Secret store kind (default: ClusterSecretStore)
+    # Options: ClusterSecretStore (cluster-wide) or SecretStore (namespace-scoped)
+    secretStoreKind: "ClusterSecretStore"
+    
+    # Refresh interval - how often ESO syncs from Vault (default: 1h)
+    refreshInterval: "1h"
+    
+    # Node identity configuration
+    nodeIdentity:
+      enabled: true
+      # Property name in Vault secret (default: "node.privkey")
+      property: "node.privkey"
+    
+    # OCI registry authentication
+    ociAuth:
+      enabled: true
+      # Property names in Vault secret (defaults shown)
+      usernameProperty: "oci-username"
+      passwordProperty: "oci-password"
+    
+    # Sync authentication (shared with remote nodes)
+    syncAuth:
+      enabled: true
+      # Property names in Vault secret (defaults shown)
+      usernameProperty: "sync-username"
+      passwordProperty: "sync-password"


### PR DESCRIPTION
- Add unified ExternalSecret template (apiserver/templates/external-secret.yaml) that syncs all three credential types (node identity, OCI auth, sync auth) from a single Vault path into one Kubernetes Secret
- Update Secret template (apiserver/templates/secret.yaml) to be conditionally created only when externalSecrets.enabled: false, preventing conflicts between Helm-managed and ESO-managed secrets
- Extend Deployment template (apiserver/templates/deployment.yaml) to support both secret management modes by updating conditionals for environment variable injection and volume mounts
- Add externalSecrets configuration section to apiserver/values.yaml with granular control over each credential type (node identity, OCI auth, sync auth), including Vault path, ClusterSecretStore reference, and refresh interval settings
- Propagate externalSecrets configuration to umbrella chart dir/values.yaml to enable users to configure ExternalSecrets when deploying the complete DIR chart
- Maintain backward compatibility by keeping externalSecrets.enabled: false as default, ensuring existing deployments continue working without changes
- Enable production-ready credential rotation by supporting automatic synchronization from Vault with configurable refresh intervals (default: 1h)
- Provide flexible deployment options allowing incremental migration by supporting selective enabling of individual credential types (node identity, OCI auth, sync auth) via ExternalSecrets