### PR TITLE
chore(dir): turn off go workspace for go toolchain

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -945,6 +945,8 @@ tasks:
   test:unit:
     desc: Run unit tests on codebase
     aliases: [test]
+    env:
+      GOWORK: off
     vars:
       EXTRA_ARGS: '{{ .EXTRA_ARGS | default "" }}'
     cmds:


### PR DESCRIPTION
This small change is allows to use `go.work` locally (without tracking with Git) but disable the use of it when go toolchain is used. When the `go.work` is not used some of the IDE does not shows all of references, definitions across multiple modules due to Go LSP behavior.

This PR enables to use `go.work` to connect multiple `go.mod` together for the LSP and the build process is remains unchanged.

Source: https://github.com/golang/go/issues/73781#issuecomment-2891734102