### PR TITLE
ci(dir): fix no unit test in CI

### DIFF
--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -9,11 +9,11 @@ on:
       image_repo:
         required: true
         type: string
-        description: 'Image repo to use.'
+        description: "Image repo to use."
       image_tag:
         required: true
         type: string
-        description: 'Image tag to use.'
+        description: "Image tag to use."
     secrets:
       CODECOV_TOKEN:
         description: "Codecov token for uploading coverage reports"
@@ -41,9 +41,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: '1.25.2'
+          go-version: "1.25.2"
           check-latest: true
-          cache-dependency-path: '**/*.sum'
+          cache-dependency-path: "**/*.sum"
 
       - name: Cache Go modules and build cache
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
@@ -55,8 +55,9 @@ jobs:
           restore-keys: |
             go-test-${{ runner.os }}-
 
-      - name: Run unit tests
-        run: task test:unit:coverage
+      - name: Generate coverage report
+        run: |
+          task test:unit:coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
@@ -66,6 +67,9 @@ jobs:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Run unit tests
+        run: |
+          task test:unit
   sdk:
     name: SDK
     uses: ./.github/workflows/reusable-test-sdk.yaml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -994,6 +994,7 @@ tasks:
             fi
           fi
         done
+
       - |
         set -euo pipefail
         echo "[coverage] Generating per-module summaries"
@@ -1013,6 +1014,7 @@ tasks:
           fi
         done
         echo "[coverage] Summary:"; cat {{.COVERAGE_DIR}}/summary.txt
+
       - |
         set -euo pipefail
         echo "[coverage] Generating HTML reports"


### PR DESCRIPTION
The `task test:unit:coverage` does not run the unit tests and becuase of that the CI does not check for unit test correctness. This PR adds the normal `task test:unit` back to the CI.