### PR TITLE
fix(dir): add cleanup and sudo to spire task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1246,6 +1246,7 @@ tasks:
     desc: Run end-to-end tests for SPIRE deployment
     cmds:
       # Run SPIRE deployment
+      - defer: { task: test:spire:cleanup }
       - task: test:spire
       # Run SDK tests
       - task: sdk:deps:javascript
@@ -1272,7 +1273,14 @@ tasks:
       # Start cloud provider for LoadBalancer support
       - |
         echo "Starting Kind cloud provider for LoadBalancer support..."
-        go run sigs.k8s.io/cloud-provider-kind@latest > /dev/null 2>&1 &
+        if [[ {{OS}} == "darwin" ]]; then
+          sudo go run sigs.k8s.io/cloud-provider-kind@latest > /dev/null 2>&1 &
+        elif [[ {{OS}} == "linux" ]]; then
+          go run sigs.k8s.io/cloud-provider-kind@latest > /dev/null 2>&1 &
+        else
+          echo "Unknown OS"
+          exit 1
+        fi
         echo "Cloud provider started in background"
 
       # Deploy SPIRE on DIR cluster


### PR DESCRIPTION
This PR is fixing build and cleanup issues with the spire task and also provide a solution to reduce the evalated permission scope by using sudo only for the kind cloud loadbalancer on MacOS.

Source:
https://github.com/kubernetes-sigs/cloud-provider-kind/blob/506a3b224a53c7dec2608584958714b1efa606b1/cmd/app.go#L80-L83