### PR TITLE
chore(ci): add helm linting to lint task

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,13 +50,9 @@ jobs:
           restore-keys: |
             lint-cache-${{ runner.os }}-
 
-      - name: Lint Go
+      - name: Run linters
         run: |
-          task lint:go
-
-      - name: Lint Buf
-        run: |
-          task lint:buf
+          task lint
 
   license:
     name: License

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1617,11 +1617,26 @@ tasks:
     cmds:
       - "{{.BUFBUILD_BIN}} lint"
 
+  lint:helm:
+    desc: Run Helm linters
+    deps:
+      - task: deps:helm
+    vars:
+      HELM_CHARTS:
+        sh: find ./install/charts -maxdepth 1 -mindepth 1 -type d -exec basename {} \;
+    cmds:
+      - for: { var: HELM_CHARTS }
+        cmd: |
+          echo "Running helm lint on {{.ITEM}}"
+          {{.HELM_BIN}} dependency update ./install/charts/{{.ITEM}}
+          {{.HELM_BIN}} lint ./install/charts/{{.ITEM}} --with-subcharts
+
   lint:
     desc: Run all linters
     deps:
       - lint:go
       - lint:buf
+      - lint:helm
 
   ##
   ## License


### PR DESCRIPTION
This PR adds helm linting to the CI pipeline to detect failures before running the release pipeline.