### PR TITLE
ci(paths): optimize workflow paths to skip non-backend changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,17 @@ on:
       - main
     tags:
       - "v*.*.*"
+    paths-ignore:
+      - "gui/**"
+      - "docs/**"
+      - "**.md"
+      - ".gitignore"
   pull_request:
+    paths-ignore:
+      - "gui/**"
+      - "docs/**"
+      - "**.md"
+      - ".gitignore"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Description
This PR optimizes the CI workflow by using `paths-ignore` to skip full CI execution for changes that do not affect the backend logic or build artifacts.

## Changes
- Updated `.github/workflows/ci.yaml` to ignore changes in:
    - `gui/**`
    - `docs/**`
    - `**.md`
    - `.gitignore`
