### PR TITLE
fix(ci): robust macOS signing and release upload

### DIFF
--- a/.github/workflows/gui-ci.yaml
+++ b/.github/workflows/gui-ci.yaml
@@ -140,8 +140,11 @@ jobs:
 
       - name: Create DMG
         run: |
+          mkdir -p "build/macos/Build/Products/Release/dmg_staging"
+          cp -R "build/macos/Build/Products/Release/AGNTCY Directory.app" "build/macos/Build/Products/Release/dmg_staging/"
+          ln -s /Applications "build/macos/Build/Products/Release/dmg_staging/Applications"
           hdiutil create -volname "AGNTCY Directory" \
-            -srcfolder "build/macos/Build/Products/Release/AGNTCY Directory.app" \
+            -srcfolder "build/macos/Build/Products/Release/dmg_staging" \
             -ov -format UDZO \
             "AGNTCY-Directory.dmg"
 


### PR DESCRIPTION
Updates macOS pipeline to resolve 'App is damaged' and sealing errors:
1. **Clean**: Runs `xattr -cr` to strip quarantine/resource attributes before signing.
2. **Permissions**: Ensures `chmod +x` on the bundled `mcp-server`.
3. **Nested Signing**: Explicitly signs `mcp-server` first to generate a valid CodeDirectory.
4. **Reseal**: Re-signs the full App Bundle with entitlements and runtime options, sealing the valid nested binary.
5. **DMG Structure**: Adds a symlink to `/Applications` in the DMG.
6. **Release Upload**: Uses `gh` CLI for improved reliability.