### PR TITLE
test(dir): add E2E tests for remote name resolution

### DIFF
--- a/e2e/network/05_name_resolution_test.go
+++ b/e2e/network/05_name_resolution_test.go
@@ -1,0 +1,144 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/agntcy/dir/e2e/shared/config"
+	"github.com/agntcy/dir/e2e/shared/testdata"
+	"github.com/agntcy/dir/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Running dirctl end-to-end tests for name resolution across nodes", func() {
+	var cli *utils.CLI
+	var syncID string
+
+	// Setup temp files for CLI commands
+	tempDir := os.Getenv("E2E_COMPILE_OUTPUT_DIR")
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
+	recordPath := filepath.Join(tempDir, "record_070_name_resolution_test.json")
+
+	// Create directory and write record data
+	_ = os.MkdirAll(filepath.Dir(recordPath), 0o755)
+	_ = os.WriteFile(recordPath, testdata.ExpectedRecordV070SyncV4JSON, 0o600)
+
+	ginkgo.BeforeEach(func() {
+		if cfg.DeploymentMode != config.DeploymentModeNetwork {
+			ginkgo.Skip("Skipping test, not in network mode")
+		}
+
+		utils.ResetCLIState()
+		cli = utils.NewCLI()
+	})
+
+	ginkgo.Context("name resolution after sync", ginkgo.Ordered, func() {
+		var cid string
+		const recordName = "directory.agntcy.org/cisco/marketing-strategy-v4"
+		const recordVersion = "v4.0.0"
+
+		ginkgo.It("should push record to peer 1", func() {
+			cid = cli.Push(recordPath).WithArgs("--output", "raw").OnServer(utils.Peer1Addr).ShouldSucceed()
+
+			// Track CID for cleanup
+			RegisterCIDForCleanup(cid, "name_resolution")
+
+			// Validate CID
+			utils.LoadAndValidateCID(cid, recordPath)
+		})
+
+		ginkgo.It("should fail to resolve by name from peer 2 before sync", func() {
+			// Name resolution should fail because peer2 doesn't have the record
+			_ = cli.Info(recordName).OnServer(utils.Peer2Addr).ShouldFail()
+		})
+
+		ginkgo.It("should fail to pull by name from peer 2 before sync", func() {
+			// Pull by name should fail because peer2 doesn't have the record indexed
+			_ = cli.Pull(recordName).OnServer(utils.Peer2Addr).ShouldFail()
+		})
+
+		ginkgo.It("should create sync from peer 1 to peer 2", func() {
+			output := cli.Sync().Create(utils.Peer1InternalAddr).OnServer(utils.Peer2Addr).ShouldSucceed()
+
+			gomega.Expect(output).To(gomega.ContainSubstring("Sync created with ID: "))
+			syncID = strings.TrimPrefix(output, "Sync created with ID: ")
+		})
+
+		ginkgo.It("should wait for sync to complete", func() {
+			// Poll sync status until it changes to IN_PROGRESS
+			output := cli.Sync().Status(syncID).OnServer(utils.Peer2Addr).ShouldEventuallyContain("IN_PROGRESS", 120*time.Second)
+			ginkgo.GinkgoWriter.Printf("Current sync status: %s\n", output)
+
+			// Wait for sync to fully complete
+			time.Sleep(60 * time.Second)
+		})
+
+		ginkgo.It("should resolve by name from peer 2 after sync", func() {
+			// Info by name should work - this tests the naming resolution
+			output := cli.Info(recordName).WithArgs("--output", "json").OnServer(utils.Peer2Addr).ShouldEventuallySucceed(120 * time.Second)
+
+			// Verify the output contains the expected CID
+			gomega.Expect(output).To(gomega.ContainSubstring(cid))
+		})
+
+		ginkgo.It("should resolve by name:version from peer 2 after sync", func() {
+			// Info by name:version should work
+			output := cli.Info(recordName+":"+recordVersion).WithArgs("--output", "json").OnServer(utils.Peer2Addr).ShouldSucceed()
+
+			// Verify the output contains the expected CID
+			gomega.Expect(output).To(gomega.ContainSubstring(cid))
+		})
+
+		ginkgo.It("should pull by name from peer 2 after sync", func() {
+			// Pull by name should now work
+			output := cli.Pull(recordName).WithArgs("--output", "json").OnServer(utils.Peer2Addr).ShouldSucceed()
+
+			// Compare the output with the expected JSON
+			equal, err := utils.CompareOASFRecords([]byte(output), testdata.ExpectedRecordV070SyncV4JSON)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(equal).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should pull by name:version from peer 2 after sync", func() {
+			// Pull by name:version should work
+			output := cli.Pull(recordName+":"+recordVersion).WithArgs("--output", "json").OnServer(utils.Peer2Addr).ShouldSucceed()
+
+			// Compare the output with the expected JSON
+			equal, err := utils.CompareOASFRecords([]byte(output), testdata.ExpectedRecordV070SyncV4JSON)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(equal).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should pull by name@cid from peer 2 after sync with hash verification", func() {
+			// Pull by name@cid should work and verify the hash
+			output := cli.Pull(recordName+"@"+cid).WithArgs("--output", "json").OnServer(utils.Peer2Addr).ShouldSucceed()
+
+			// Compare the output with the expected JSON
+			equal, err := utils.CompareOASFRecords([]byte(output), testdata.ExpectedRecordV070SyncV4JSON)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(equal).To(gomega.BeTrue())
+		})
+
+		ginkgo.It("should delete sync from peer 2", func() {
+			cli.Sync().Delete(syncID).OnServer(utils.Peer2Addr).ShouldSucceed()
+		})
+
+		ginkgo.It("should wait for delete to complete", func() {
+			output := cli.Sync().Status(syncID).OnServer(utils.Peer2Addr).ShouldEventuallyContain("DELETED", 120*time.Second)
+			ginkgo.GinkgoWriter.Printf("Current sync status: %s\n", output)
+
+			// Cleanup
+			ginkgo.DeferCleanup(func() {
+				CleanupNetworkRecords(nameResolutionTestCIDs, "name resolution tests")
+			})
+		})
+	})
+})

--- a/e2e/network/cleanup.go
+++ b/e2e/network/cleanup.go
@@ -10,10 +10,11 @@ import (
 
 // Package-level variables for tracking CIDs across all network tests.
 var (
-	deployTestCIDs       []string
-	syncTestCIDs         []string
-	remoteSearchTestCIDs []string
-	gossipsubTestCIDs    []string
+	deployTestCIDs         []string
+	syncTestCIDs           []string
+	remoteSearchTestCIDs   []string
+	gossipsubTestCIDs      []string
+	nameResolutionTestCIDs []string
 )
 
 // This ensures clean state between different test files (Describe blocks).
@@ -65,6 +66,8 @@ func RegisterCIDForCleanup(cid, testFile string) {
 		remoteSearchTestCIDs = append(remoteSearchTestCIDs, cid)
 	case "gossipsub":
 		gossipsubTestCIDs = append(gossipsubTestCIDs, cid)
+	case "name_resolution":
+		nameResolutionTestCIDs = append(nameResolutionTestCIDs, cid)
 	default:
 		ginkgo.GinkgoWriter.Printf("Warning: Unknown test file %s for CID %s", testFile, cid)
 	}
@@ -77,6 +80,7 @@ func CleanupAllNetworkTests() {
 	allCIDs = append(allCIDs, syncTestCIDs...)
 	allCIDs = append(allCIDs, remoteSearchTestCIDs...)
 	allCIDs = append(allCIDs, gossipsubTestCIDs...)
+	allCIDs = append(allCIDs, nameResolutionTestCIDs...)
 
 	CleanupNetworkRecords(allCIDs, "all network tests")
 }


### PR DESCRIPTION
This PR adds E2E tests for the name resolution on remote peers feature.

**What the test does:**
1. Push a record with name directory.agntcy.org/cisco/marketing-strategy-v4 to peer1
2. Verify that peer2 cannot resolve by name before sync (expected failure)
3. Create sync from peer1 → peer2
4. Wait for sync to complete
5. Verify that peer2 can now:
  - info \<name\> - resolve by name
  - info \<name\>:\<version\> - resolve by name:version
  - pull \<name\> - pull by name
  - pull \<name\>:\<version\> - pull by name:version
  - pull \<name\>@\<cid\> - pull by name with hash verification
6. Clean up sync and records