### PR TITLE
feat(mcp): add signature verification tool

### DIFF
--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -173,6 +173,18 @@ Use this tool to retrieve agent records by their CID for inspection or validatio
 		`),
 	}, tools.PullRecord)
 
+	// Add tool for verifying record signatures
+	mcp.AddTool(server, &mcp.Tool{
+		Name: "agntcy_dir_verify_record",
+		Description: strings.TrimSpace(`
+Verifies the digital signature of a record in the Directory by its CID.
+This tool performs a server-side verification of the record's integrity and authenticity.
+Returns the verification status (trusted/not trusted).
+
+Use this tool to ensure a record has been properly signed and hasn't been tampered with.
+		`),
+	}, tools.VerifyRecord)
+
 	// Add tool for exporting OASF records to other formats
 	mcp.AddTool(server, &mcp.Tool{
 		Name: "agntcy_oasf_export_record",

--- a/mcp/tools/verify_record.go
+++ b/mcp/tools/verify_record.go
@@ -1,0 +1,79 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	signv1 "github.com/agntcy/dir/api/sign/v1"
+	"github.com/agntcy/dir/client"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// VerifyRecordInput defines the input parameters for verifying a record signature.
+type VerifyRecordInput struct {
+	CID string `json:"cid" jsonschema:"Content Identifier (CID) of the record to verify (required)"`
+}
+
+// VerifyRecordOutput defines the output of verifying a record signature.
+type VerifyRecordOutput struct {
+	Success bool   `json:"success"         jsonschema:"Whether the signature verification was successful"`
+	Message string `json:"message"         jsonschema:"Status message indicating trust level"`
+	Error   string `json:"error,omitempty" jsonschema:"Error message if verification request failed"`
+}
+
+// VerifyRecord verifies the signature of a record in the Directory by its CID.
+func VerifyRecord(ctx context.Context, _ *mcp.CallToolRequest, input VerifyRecordInput) (
+	*mcp.CallToolResult,
+	VerifyRecordOutput,
+	error,
+) {
+	// Validate input
+	if input.CID == "" {
+		return nil, VerifyRecordOutput{
+			Error: "CID is required",
+		}, nil
+	}
+
+	// Load client configuration
+	config, err := client.LoadConfig()
+	if err != nil {
+		return nil, VerifyRecordOutput{
+			Error: fmt.Sprintf("Failed to load client configuration: %v", err),
+		}, nil
+	}
+
+	// Create Directory client
+	c, err := client.New(ctx, client.WithConfig(config))
+	if err != nil {
+		return nil, VerifyRecordOutput{
+			Error: fmt.Sprintf("Failed to create client: %v", err),
+		}, nil
+	}
+	defer c.Close()
+
+	// Verify record
+	resp, err := c.Verify(ctx, &signv1.VerifyRequest{
+		RecordRef: &corev1.RecordRef{
+			Cid: input.CID,
+		},
+	})
+	if err != nil {
+		return nil, VerifyRecordOutput{
+			Error: fmt.Sprintf("Failed to verify record: %v", err),
+		}, nil
+	}
+
+	message := "trusted"
+	if !resp.GetSuccess() {
+		message = "not trusted"
+	}
+
+	return nil, VerifyRecordOutput{
+		Success: resp.GetSuccess(),
+		Message: message,
+	}, nil
+}

--- a/mcp/tools/verify_record_test.go
+++ b/mcp/tools/verify_record_test.go
@@ -1,0 +1,50 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyRecordInputValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       VerifyRecordInput
+		expectError bool
+	}{
+		{
+			name: "valid input",
+			input: VerifyRecordInput{
+				CID: "bafkreiabcd1234567890",
+			},
+			expectError: false,
+		},
+		{
+			name: "missing CID",
+			input: VerifyRecordInput{
+				CID: "",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Just test that marshaling works
+			_, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+
+			// Validate CID requirement
+			if tt.expectError {
+				assert.Empty(t, tt.input.CID)
+			} else {
+				assert.NotEmpty(t, tt.input.CID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new tool to the MCP server, `agntcy_dir_verify_record`, which allows verifying the signature of a record by its CID. This mirrors the functionality of `dirctl verify`. 
Fixes #905.