### PR TITLE
fix(runtime): enable oasf resolvers with annotations

### DIFF
--- a/runtime/discovery/resolver/oasf/resolver.go
+++ b/runtime/discovery/resolver/oasf/resolver.go
@@ -74,7 +74,7 @@ func (r *resolver) CanResolve(workload *runtimev1.Workload) bool {
 // Resolve fetches OASF record for the workload.
 func (r *resolver) Resolve(ctx context.Context, workload *runtimev1.Workload) (any, error) {
 	// Get the name of the OASF record from the workload labels
-	name, version := recordNameVersion(workload)
+	name, version := r.getRecordNameVersion(workload)
 	nameVersion := name + ":" + version
 
 	logger.Info("started resolving", "workload", workload.GetId(), "record", nameVersion)
@@ -136,7 +136,7 @@ func (r *resolver) Apply(ctx context.Context, workload *runtimev1.Workload, resu
 }
 
 //nolint:mnd
-func (r *resolver) recordNameVersion(workload *runtimev1.Workload) (string, string) {
+func (r *resolver) getRecordNameVersion(workload *runtimev1.Workload) (string, string) {
 	// Get the record FQDN from the workload labels or annotations
 	var recordFQDN string
 	if val, hasLabel := workload.GetLabels()[r.labelKey]; hasLabel {


### PR DESCRIPTION
Marking an agent record in K8s like `my-agent.com/example/helper:v1.0.0` does not work via labels since labels cannot be DNS-styled with multiple paths. Only annotations can be used. This enables usage of both labels and annotations for marking workloads for OASF resolution.