### PR TITLE
refactor(dir): remove unused OCI annotations

### DIFF
--- a/server/store/oci/annotations.go
+++ b/server/store/oci/annotations.go
@@ -4,7 +4,6 @@
 package oci
 
 import (
-	"strconv"
 	"strings"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
@@ -41,10 +40,6 @@ func extractManifestAnnotations(record *corev1.Record) map[string]string {
 		annotations[ManifestKeyVersion] = version
 	}
 
-	if description := recordData.GetDescription(); description != "" {
-		annotations[ManifestKeyDescription] = description
-	}
-
 	// Lifecycle metadata
 	if schemaVersion := recordData.GetSchemaVersion(); schemaVersion != "" {
 		annotations[ManifestKeySchemaVersion] = schemaVersion
@@ -52,10 +47,6 @@ func extractManifestAnnotations(record *corev1.Record) map[string]string {
 
 	if createdAt := recordData.GetCreatedAt(); createdAt != "" {
 		annotations[ManifestKeyCreatedAt] = createdAt
-	}
-
-	if authors := recordData.GetAuthors(); len(authors) > 0 {
-		annotations[ManifestKeyAuthors] = strings.Join(authors, ",")
 	}
 
 	// Versioning (v1 specific)
@@ -108,20 +99,8 @@ func parseManifestAnnotations(annotations map[string]string) *corev1.RecordMeta 
 		recordMeta.Annotations[MetadataKeyVersion] = version
 	}
 
-	if description := annotations[ManifestKeyDescription]; description != "" {
-		recordMeta.Annotations[MetadataKeyDescription] = description
-	}
-
 	if oasfVersion := annotations[ManifestKeyOASFVersion]; oasfVersion != "" {
 		recordMeta.Annotations[MetadataKeyOASFVersion] = oasfVersion
-	}
-
-	// Structured lists (easily parseable by consumers)
-	if authors := annotations[ManifestKeyAuthors]; authors != "" {
-		recordMeta.Annotations[MetadataKeyAuthors] = authors // comma-separated
-		// Also provide parsed count for quick stats
-		authorList := parseCommaSeparated(authors)
-		recordMeta.Annotations[MetadataKeyAuthorsCount] = strconv.Itoa(len(authorList))
 	}
 
 	// Versioning information
@@ -138,27 +117,4 @@ func parseManifestAnnotations(annotations map[string]string) *corev1.RecordMeta 
 	}
 
 	return recordMeta
-}
-
-// parseCommaSeparated splits comma-separated values and trims whitespace.
-func parseCommaSeparated(value string) []string {
-	if value == "" {
-		return nil
-	}
-
-	parts := strings.Split(value, ",")
-	result := make([]string, 0, len(parts))
-
-	for _, part := range parts {
-		if trimmed := strings.TrimSpace(part); trimmed != "" {
-			result = append(result, trimmed)
-		}
-	}
-
-	// Return nil if result is empty after filtering
-	if len(result) == 0 {
-		return nil
-	}
-
-	return result
 }

--- a/server/store/oci/constants.go
+++ b/server/store/oci/constants.go
@@ -17,34 +17,27 @@ const (
 	// Core Identity (simple keys).
 	MetadataKeyName        = "name"
 	MetadataKeyVersion     = "version"
-	MetadataKeyDescription = "description"
 	MetadataKeyOASFVersion = "oasf-version"
 	MetadataKeyCid         = "cid"
 
 	// Lifecycle (simple keys).
 	MetadataKeySchemaVersion = "schema-version"
 	MetadataKeyCreatedAt     = "created-at"
-	MetadataKeyAuthors       = "authors"
 
 	// Versioning (simple keys).
 	MetadataKeyPreviousCid = "previous-cid"
-
-	// Count metadata (simple keys).
-	MetadataKeyAuthorsCount = "authors-count"
 
 	// Derived from MetadataKey constants to ensure consistency.
 
 	// Core Identity (derived from MetadataKey constants).
 	ManifestKeyName        = manifestDirObjectKeyPrefix + "/" + MetadataKeyName
 	ManifestKeyVersion     = manifestDirObjectKeyPrefix + "/" + MetadataKeyVersion
-	ManifestKeyDescription = manifestDirObjectKeyPrefix + "/" + MetadataKeyDescription
 	ManifestKeyOASFVersion = manifestDirObjectKeyPrefix + "/" + MetadataKeyOASFVersion
 	ManifestKeyCid         = manifestDirObjectKeyPrefix + "/" + MetadataKeyCid
 
 	// Lifecycle Metadata (mixed: some derived, some standalone).
 	ManifestKeySchemaVersion = manifestDirObjectKeyPrefix + "/" + MetadataKeySchemaVersion
 	ManifestKeyCreatedAt     = manifestDirObjectKeyPrefix + "/" + MetadataKeyCreatedAt
-	ManifestKeyAuthors       = manifestDirObjectKeyPrefix + "/" + MetadataKeyAuthors
 
 	// Versioning & Linking (standalone - no simple key equivalents).
 	ManifestKeyPreviousCid = manifestDirObjectKeyPrefix + "/" + MetadataKeyPreviousCid


### PR DESCRIPTION
## Problem

Some OCI registries like GHCR enforce a 256-character limit per annotation value, which our comma-separated lists (skills, locators, modules) can easily exceed, preventing OCI sync operations.

## Removed Annotations

### Capability Discovery Annotations
- `skills`
- `locator-types`
- `module-names`

### Security & Integrity Annotations
- `signed`
- `signature-algorithm`
- `signed-at`

### Team-based Annotations
- `team`
- `organization`
- `project`

### Metadata Annotations
- `description`
- `authors`

### Count Metadata Annotations
- `skills-count`
- `locator-types-count`
- `module-names-count`
- `authors-count`

**Total removed: 16 annotation keys**

