### PR TITLE
feat(helm): topology-aware StorageClass support for Zot config

### DIFF
--- a/install/charts/dir/apiserver/templates/zot-config-pvc.yaml
+++ b/install/charts/dir/apiserver/templates/zot-config-pvc.yaml
@@ -15,6 +15,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- if .Values.zot.configPvcStorageClassName }}
+  storageClassName: {{ .Values.zot.configPvcStorageClassName }}
+  {{- end }}
   resources:
     requests:
       storage: 100Mi

--- a/install/charts/dir/apiserver/templates/zot-config-storageclass.yaml
+++ b/install/charts/dir/apiserver/templates/zot-config-storageclass.yaml
@@ -1,0 +1,23 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# Optional StorageClass with topology constraints for Zot config PVC
+# Only created when zot.configPvcStorageClass is defined
+# Use this to ensure config PVC is created in the same AZ as data PVC
+{{- if and .Values.zot.enabled .Values.zot.configPvcStorageClass }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.zot.configPvcStorageClass.name }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+provisioner: {{ .Values.zot.configPvcStorageClass.provisioner | default "ebs.csi.aws.com" }}
+parameters:
+  {{- toYaml .Values.zot.configPvcStorageClass.parameters | nindent 2 }}
+volumeBindingMode: {{ .Values.zot.configPvcStorageClass.volumeBindingMode | default "WaitForFirstConsumer" }}
+allowVolumeExpansion: {{ .Values.zot.configPvcStorageClass.allowVolumeExpansion | default true }}
+{{- if .Values.zot.configPvcStorageClass.allowedTopologies }}
+allowedTopologies:
+{{- toYaml .Values.zot.configPvcStorageClass.allowedTopologies | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/install/charts/envoy-authz/values.yaml
+++ b/install/charts/envoy-authz/values.yaml
@@ -128,12 +128,9 @@ authServer:
     #   - /agntcy.dir.search.v1.SearchService/SearchCIDs       # Search by CID
     #   - /agntcy.dir.search.v1.SearchService/SearchRecords    # Search records
     #
-    # SignService (Cryptographic Signing):
-    #   - /agntcy.dir.sign.v1.SignService/Sign                 # Sign data
-    #   - /agntcy.dir.sign.v1.SignService/Verify               # Verify signature
-    #
     # NamingService (Name Resolution):
     #   - /agntcy.dir.naming.v1.NamingService/GetVerificationInfo  # Get verification info
+    #   - /agntcy.dir.naming.v1.NamingService/Resolve              # Resolve name to CID
     #
     # EventService (Event Streaming):
     #   - /agntcy.dir.events.v1.EventService/Listen            # Listen to events


### PR DESCRIPTION
## Add topology-aware StorageClass support for Zot config PVC

### Problem
When deploying Directory with dynamic Zot sync config (`mountConfig: false`), two PVCs are created:
- Zot data PVC (100Gi) - managed by Zot chart
- Zot config PVC (100Mi) - our custom template

In managed Kubernetes clusters (EKS/AKS), these PVCs can be created in different availability zones, causing pod scheduling to fail with `volume node affinity conflict`.

### Solution
Add optional topology-aware StorageClass support for the Zot config PVC to ensure both PVCs are created in the same AZ.

**New template:**
- `templates/zot-config-storageclass.yaml` - Creates custom StorageClass when `zot.configPvcStorageClass` is defined

**Modified template:**
- `templates/zot-config-pvc.yaml` - Add support for `zot.configPvcStorageClassName` parameter

### Other:
- small documentation change in API list