### PR TITLE
refactor(ci/import): handle command execution errors in import workflow

### DIFF
--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -169,8 +169,15 @@ jobs:
           fi
 
           echo "Running: ${CMD[*]}"
+          set +e
           OUTPUT=$("${CMD[@]}" 2>&1)
+          EXIT=$?
+          set -e
           echo "$OUTPUT"
+          if [ "$EXIT" -ne 0 ]; then
+            echo "--- Import failed with exit code $EXIT ---"
+            exit "$EXIT"
+          fi
 
           # Print jsonl output (dry-run mode)
           JSONL_FILE=$(echo "$OUTPUT" | grep 'Records saved to:' | sed 's/.*Records saved to: //')


### PR DESCRIPTION
Previously, when the Import MCP Records step failed (e.g. [run #33](https://github.com/agntcy/dir/actions/runs/21928558896/job/63326999105#step:7:62)), the job exited before echoing the captured output, so only "Process completed with exit code 1" appeared. The step now uses `set +e` and always prints the command output before exiting, so failed runs show the full dirctl import logs.