### PR TITLE
fix(ci): update module extraction command in post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -24,7 +24,7 @@ jobs:
         id: modules
         run: |
           # shellcheck disable=SC2016
-          echo "modules=$(find . -name go.mod -type f -print0 | xargs -0 awk '/module/ {print $2}' | jq -c -R '[.,inputs] | map(sub("^github.com\/agntcy\/dir\/";""))')" >> "$GITHUB_OUTPUT"
+          echo "modules=$(find . -name go.mod -type f -exec awk '/^module / {print $2}' {} \; | jq -c -R '[.,inputs] | map(sub("^github.com\/agntcy\/dir\/";""))')" >> "$GITHUB_OUTPUT"
 
   create-module-tags:
     needs: prepare


### PR DESCRIPTION
Post-Release was failing when creating module tags: [Release v1.0.0-rc.4 (job 63546426204)](https://github.com/agntcy/dir/actions/runs/21993373490/job/63546426204). The step that lists Go modules used a pattern that matched any line containing "module", so the comment `// Replace local modules` in many `go.mod` files was matched too and the word "Replace" was taken as a module name.