### PR TITLE
chore(dir): fix packages and maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,4 +4,4 @@
 - [muscariello](https://github.com/muscariello), Luca Muscariello
 - [paralta](https://github.com/paralta), Catarina Paralta
 - [adamtagscherer](https://github.com/adamtagscherer), Adam Tagscherer
-- [pbalogh-sa](https://github.com/pbalogh-sa), Peter Balogh
+- [tkircsi](https://github.com/tkircsi), Tibor Kircsi

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -186,6 +186,7 @@ require (
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mark3labs/mcp-filesystem-server v0.11.1 // indirect
 	github.com/mark3labs/mcp-go v0.44.0-beta.2 // indirect
+	github.com/mark3labs/mcphost v0.33.4 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
@@ -226,7 +227,6 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/ramizpolic/mcphost v0.33.5 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -486,6 +486,8 @@ github.com/mark3labs/mcp-filesystem-server v0.11.1 h1:7uKIZRMaKWfgvtDj/uLAvo0+7M
 github.com/mark3labs/mcp-filesystem-server v0.11.1/go.mod h1:xDqJizVYWZ5a31Mt4xuYbVku2AR/kT56H3O0SbpANoQ=
 github.com/mark3labs/mcp-go v0.44.0-beta.2 h1:gfUT0m77E4odfgiHkqV/E+MQVaQ06rbutW7Ln0JRkBA=
 github.com/mark3labs/mcp-go v0.44.0-beta.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
+github.com/mark3labs/mcphost v0.33.4 h1:DEq95tzZJW3yi5x5aH5OtzmvNh1/bTNt2cEprEh0Mbw=
+github.com/mark3labs/mcphost v0.33.4/go.mod h1:Ht4XBzUWVAtlUdLhbCpKogybZRrqxuFGogD7TWxH/6A=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -608,8 +610,6 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/ramizpolic/mcphost v0.33.5 h1:ejp+G67O9yTSfW8Slzv+soqAi+0e4RMfk9/URfGCCwA=
-github.com/ramizpolic/mcphost v0.33.5/go.mod h1:BYYr9aIF4vu0gnpG3+/3KGY3ztx8LB602w1pdsPc+9o=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -186,6 +186,7 @@ require (
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mark3labs/mcp-filesystem-server v0.11.1 // indirect
 	github.com/mark3labs/mcp-go v0.44.0-beta.2 // indirect
+	github.com/mark3labs/mcphost v0.33.4 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
@@ -224,7 +225,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/ramizpolic/mcphost v0.33.5 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -495,6 +495,8 @@ github.com/mark3labs/mcp-filesystem-server v0.11.1 h1:7uKIZRMaKWfgvtDj/uLAvo0+7M
 github.com/mark3labs/mcp-filesystem-server v0.11.1/go.mod h1:xDqJizVYWZ5a31Mt4xuYbVku2AR/kT56H3O0SbpANoQ=
 github.com/mark3labs/mcp-go v0.44.0-beta.2 h1:gfUT0m77E4odfgiHkqV/E+MQVaQ06rbutW7Ln0JRkBA=
 github.com/mark3labs/mcp-go v0.44.0-beta.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
+github.com/mark3labs/mcphost v0.33.4 h1:DEq95tzZJW3yi5x5aH5OtzmvNh1/bTNt2cEprEh0Mbw=
+github.com/mark3labs/mcphost v0.33.4/go.mod h1:Ht4XBzUWVAtlUdLhbCpKogybZRrqxuFGogD7TWxH/6A=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
@@ -621,8 +623,6 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/ramizpolic/mcphost v0.33.5 h1:ejp+G67O9yTSfW8Slzv+soqAi+0e4RMfk9/URfGCCwA=
-github.com/ramizpolic/mcphost v0.33.5/go.mod h1:BYYr9aIF4vu0gnpG3+/3KGY3ztx8LB602w1pdsPc+9o=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/importer/enricher/enricher.go
+++ b/importer/enricher/enricher.go
@@ -15,7 +15,7 @@ import (
 	typesv1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1"
 	typesv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1alpha1"
 	"github.com/agntcy/dir/utils/logging"
-	"github.com/ramizpolic/mcphost/sdk"
+	"github.com/mark3labs/mcphost/sdk"
 	"golang.org/x/time/rate"
 )
 

--- a/importer/go.mod
+++ b/importer/go.mod
@@ -18,10 +18,8 @@ require (
 	github.com/agntcy/dir/client v1.0.0-rc.4
 	github.com/agntcy/dir/utils v1.0.0-rc.4
 	github.com/agntcy/oasf-sdk/pkg v1.0.0
+	github.com/mark3labs/mcphost v0.33.4
 	github.com/modelcontextprotocol/registry v1.4.1
-	// Switch to original repo after the security patch is merged and released.
-	// https://github.com/mark3labs/mcphost/pull/154
-	github.com/ramizpolic/mcphost v0.33.5
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/importer/go.sum
+++ b/importer/go.sum
@@ -470,6 +470,8 @@ github.com/mark3labs/mcp-filesystem-server v0.11.1 h1:7uKIZRMaKWfgvtDj/uLAvo0+7M
 github.com/mark3labs/mcp-filesystem-server v0.11.1/go.mod h1:xDqJizVYWZ5a31Mt4xuYbVku2AR/kT56H3O0SbpANoQ=
 github.com/mark3labs/mcp-go v0.44.0-beta.2 h1:gfUT0m77E4odfgiHkqV/E+MQVaQ06rbutW7Ln0JRkBA=
 github.com/mark3labs/mcp-go v0.44.0-beta.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
+github.com/mark3labs/mcphost v0.33.4 h1:DEq95tzZJW3yi5x5aH5OtzmvNh1/bTNt2cEprEh0Mbw=
+github.com/mark3labs/mcphost v0.33.4/go.mod h1:Ht4XBzUWVAtlUdLhbCpKogybZRrqxuFGogD7TWxH/6A=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -586,8 +588,6 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/ramizpolic/mcphost v0.33.5 h1:ejp+G67O9yTSfW8Slzv+soqAi+0e4RMfk9/URfGCCwA=
-github.com/ramizpolic/mcphost v0.33.5/go.mod h1:BYYr9aIF4vu0gnpG3+/3KGY3ztx8LB602w1pdsPc+9o=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=


### PR DESCRIPTION
Switch forked `github.com/ramizpolic/mcphost` package with original `github.com/mark3labs/mcphost` with resolved security issues. 

Bump maintainers list with latest state.