### PR TITLE
fix(reconciler): use same auth as set for server

### DIFF
--- a/install/charts/dir/apiserver/templates/configmap.yaml
+++ b/install/charts/dir/apiserver/templates/configmap.yaml
@@ -53,4 +53,7 @@ data:
     {{- end }}
     {{- $_ := set $reconcilerConfig.database.postgres "host" (include "chart.postgres.host" .) }}
     {{- end }}
+    {{- if hasKey $reconcilerConfig "regsync" }}
+    {{- $_ := set $reconcilerConfig.regsync "authn" (deepCopy .Values.config.authn) }}
+    {{- end }}
     {{- $reconcilerConfig | toYaml | nindent 4 }}

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -727,7 +727,7 @@ reconciler:
     # OASF schema URL for validation
     schema_url: "https://schema.oasf.outshift.com"
 
-    # Regsync task configuration
+    # Regsync task configuration (authn copied from config.authn by chart)
     regsync:
       enabled: true
       interval: "1h"

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -563,7 +563,7 @@ apiserver:
       # OASF schema URL for validation
       schema_url: "https://schema.oasf.outshift.com"
 
-      # Regsync task configuration
+      # Regsync task configuration (authn copied from config.authn by chart)
       regsync:
         enabled: true
         interval: "1h"


### PR DESCRIPTION
Sync creation failed because the reconciler’s regsync task didn’t use the same auth as the apiserver when negotiating credentials with remote Directory nodes.