### PR TITLE
chore(dir): add dir-demo-bot

### DIFF
--- a/.github/workflows/demo-dir.yaml
+++ b/.github/workflows/demo-dir.yaml
@@ -14,7 +14,7 @@ on:
       server_addr:
         required: true
         type: string
-        default: dev.gateway.ads.outshift.io:443
+        default: prod.gateway.ads.outshift.io:443
         description: "server address to use"
 
 permissions:


### PR DESCRIPTION
Use `dir-demo-bot` user instead of `mcp-bot` in the demo dir workflow.