### PR TITLE
feat(mcp): add name verification mcp tool

### DIFF
--- a/mcp/tools/export_record.go
+++ b/mcp/tools/export_record.go
@@ -31,7 +31,7 @@ type ExportRecordOutput struct {
 // Currently supported formats:
 // - "a2a": Agent-to-Agent (A2A) format.
 // - "ghcopilot": GitHub Copilot MCP configuration format.
-func ExportRecord(ctx context.Context, _ *mcp.CallToolRequest, input ExportRecordInput) (
+func (t *Tools) ExportRecord(ctx context.Context, _ *mcp.CallToolRequest, input ExportRecordInput) (
 	*mcp.CallToolResult,
 	ExportRecordOutput,
 	error,

--- a/mcp/tools/export_record_test.go
+++ b/mcp/tools/export_record_test.go
@@ -16,6 +16,8 @@ func TestExportRecord(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	// Create Tools instance (nil client is fine - ExportRecord doesn't use client)
+	tools := &Tools{Client: nil}
 
 	t.Run("exports record to A2A format", func(t *testing.T) {
 		t.Parallel()
@@ -37,7 +39,7 @@ func TestExportRecord(t *testing.T) {
 			TargetFormat: "a2a",
 		}
 
-		_, output, err := ExportRecord(ctx, nil, input)
+		_, output, err := tools.ExportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		// The export may fail if the record doesn't have the required A2A module data,
@@ -55,7 +57,7 @@ func TestExportRecord(t *testing.T) {
 			TargetFormat: "a2a",
 		}
 
-		_, output, err := ExportRecord(ctx, nil, input)
+		_, output, err := tools.ExportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "record_json is required")
@@ -70,7 +72,7 @@ func TestExportRecord(t *testing.T) {
 			TargetFormat: "",
 		}
 
-		_, output, err := ExportRecord(ctx, nil, input)
+		_, output, err := tools.ExportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "target_format is required")
@@ -90,7 +92,7 @@ func TestExportRecord(t *testing.T) {
 			TargetFormat: "unsupported-format",
 		}
 
-		_, output, err := ExportRecord(ctx, nil, input)
+		_, output, err := tools.ExportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "Unsupported target format")
@@ -106,7 +108,7 @@ func TestExportRecord(t *testing.T) {
 			TargetFormat: "a2a",
 		}
 
-		_, output, err := ExportRecord(ctx, nil, input)
+		_, output, err := tools.ExportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "Failed to parse record JSON")
@@ -126,7 +128,7 @@ func TestExportRecord(t *testing.T) {
 			TargetFormat: "A2A",
 		}
 
-		_, output, err := ExportRecord(ctx, nil, input)
+		_, output, err := tools.ExportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		// The test verifies that case-insensitive format is handled.

--- a/mcp/tools/get_schema.go
+++ b/mcp/tools/get_schema.go
@@ -28,7 +28,7 @@ type GetSchemaOutput struct {
 
 // GetSchema retrieves the OASF schema content for the specified version.
 // This tool provides direct access to the complete OASF schema JSON.
-func GetSchema(ctx context.Context, _ *mcp.CallToolRequest, input GetSchemaInput) (
+func (t *Tools) GetSchema(ctx context.Context, _ *mcp.CallToolRequest, input GetSchemaInput) (
 	*mcp.CallToolResult,
 	GetSchemaOutput,
 	error,

--- a/mcp/tools/get_schema_domains.go
+++ b/mcp/tools/get_schema_domains.go
@@ -37,7 +37,7 @@ type GetSchemaDomainsOutput struct {
 // GetSchemaDomains retrieves domains from the OASF schema for the specified version.
 // If parent_domain is provided, returns only sub-domains under that parent.
 // Otherwise, returns all top-level domains.
-func GetSchemaDomains(ctx context.Context, _ *mcp.CallToolRequest, input GetSchemaDomainsInput) (
+func (t *Tools) GetSchemaDomains(ctx context.Context, _ *mcp.CallToolRequest, input GetSchemaDomainsInput) (
 	*mcp.CallToolResult,
 	GetSchemaDomainsOutput,
 	error,

--- a/mcp/tools/get_schema_domains_test.go
+++ b/mcp/tools/get_schema_domains_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestGetSchemaDomains(t *testing.T) {
 	ctx := context.Background()
+	// Create Tools instance (nil client is fine - GetSchemaDomains doesn't use client)
+	tools := &Tools{Client: nil}
 
 	tests := []struct {
 		name          string
@@ -116,7 +118,7 @@ func TestGetSchemaDomains(t *testing.T) {
 			t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
 			// Note: t.Setenv cannot be used with t.Parallel(), so we run tests sequentially
 
-			result, output, err := GetSchemaDomains(ctx, nil, tt.input)
+			result, output, err := tools.GetSchemaDomains(ctx, nil, tt.input)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/mcp/tools/get_schema_skills.go
+++ b/mcp/tools/get_schema_skills.go
@@ -37,7 +37,7 @@ type GetSchemaSkillsOutput struct {
 // GetSchemaSkills retrieves skills from the OASF schema for the specified version.
 // If parent_skill is provided, returns only sub-skills under that parent.
 // Otherwise, returns all top-level skills.
-func GetSchemaSkills(ctx context.Context, _ *mcp.CallToolRequest, input GetSchemaSkillsInput) (
+func (t *Tools) GetSchemaSkills(ctx context.Context, _ *mcp.CallToolRequest, input GetSchemaSkillsInput) (
 	*mcp.CallToolResult,
 	GetSchemaSkillsOutput,
 	error,

--- a/mcp/tools/get_schema_skills_test.go
+++ b/mcp/tools/get_schema_skills_test.go
@@ -16,6 +16,8 @@ func TestGetSchemaSkills(t *testing.T) {
 	t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
 
 	ctx := context.Background()
+	// Create Tools instance (nil client is fine - GetSchemaSkills doesn't use client)
+	tools := &Tools{Client: nil}
 
 	tests := []struct {
 		name          string
@@ -118,7 +120,7 @@ func TestGetSchemaSkills(t *testing.T) {
 			t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
 			// Note: t.Setenv cannot be used with t.Parallel(), so we run tests sequentially
 
-			result, output, err := GetSchemaSkills(ctx, nil, tt.input)
+			result, output, err := tools.GetSchemaSkills(ctx, nil, tt.input)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/mcp/tools/get_schema_test.go
+++ b/mcp/tools/get_schema_test.go
@@ -14,11 +14,14 @@ import (
 func TestGetSchema(t *testing.T) {
 	t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
 
+	// Create Tools instance (nil client is fine - GetSchema doesn't use client)
+	tools := &Tools{Client: nil}
+
 	t.Run("should return schema for valid version", func(t *testing.T) {
 		ctx := context.Background()
 		input := GetSchemaInput{Version: "0.7.0"}
 
-		_, output, err := GetSchema(ctx, nil, input)
+		_, output, err := tools.GetSchema(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Empty(t, output.ErrorMessage)
@@ -32,7 +35,7 @@ func TestGetSchema(t *testing.T) {
 		ctx := context.Background()
 		input := GetSchemaInput{Version: "99.99.99"}
 
-		_, output, err := GetSchema(ctx, nil, input)
+		_, output, err := tools.GetSchema(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, output.ErrorMessage)
@@ -44,7 +47,7 @@ func TestGetSchema(t *testing.T) {
 		ctx := context.Background()
 		input := GetSchemaInput{Version: ""}
 
-		_, output, err := GetSchema(ctx, nil, input)
+		_, output, err := tools.GetSchema(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, output.ErrorMessage)

--- a/mcp/tools/import_record.go
+++ b/mcp/tools/import_record.go
@@ -30,7 +30,7 @@ type ImportRecordOutput struct {
 // Currently supported formats:
 // - "mcp": Model Context Protocol format.
 // - "a2a": Agent-to-Agent (A2A) format.
-func ImportRecord(ctx context.Context, _ *mcp.CallToolRequest, input ImportRecordInput) (
+func (t *Tools) ImportRecord(ctx context.Context, _ *mcp.CallToolRequest, input ImportRecordInput) (
 	*mcp.CallToolResult,
 	ImportRecordOutput,
 	error,

--- a/mcp/tools/import_record_test.go
+++ b/mcp/tools/import_record_test.go
@@ -16,6 +16,8 @@ func TestImportRecord(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
+	// Create Tools instance (nil client is fine - ImportRecord doesn't use client)
+	tools := &Tools{Client: nil}
 
 	t.Run("imports A2A format to OASF record", func(t *testing.T) {
 		t.Parallel()
@@ -36,7 +38,7 @@ func TestImportRecord(t *testing.T) {
 			SourceFormat: "a2a",
 		}
 
-		_, output, err := ImportRecord(ctx, nil, input)
+		_, output, err := tools.ImportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		// The import may fail if the source data doesn't have the required A2A structure,
@@ -54,7 +56,7 @@ func TestImportRecord(t *testing.T) {
 			SourceFormat: "a2a",
 		}
 
-		_, output, err := ImportRecord(ctx, nil, input)
+		_, output, err := tools.ImportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "source_data is required")
@@ -69,7 +71,7 @@ func TestImportRecord(t *testing.T) {
 			SourceFormat: "",
 		}
 
-		_, output, err := ImportRecord(ctx, nil, input)
+		_, output, err := tools.ImportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "source_format is required")
@@ -88,7 +90,7 @@ func TestImportRecord(t *testing.T) {
 			SourceFormat: "unsupported-format",
 		}
 
-		_, output, err := ImportRecord(ctx, nil, input)
+		_, output, err := tools.ImportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "Unsupported source format")
@@ -104,7 +106,7 @@ func TestImportRecord(t *testing.T) {
 			SourceFormat: "a2a",
 		}
 
-		_, output, err := ImportRecord(ctx, nil, input)
+		_, output, err := tools.ImportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.ErrorMessage, "Failed to parse source data JSON")
@@ -124,7 +126,7 @@ func TestImportRecord(t *testing.T) {
 			SourceFormat: "A2A",
 		}
 
-		_, output, err := ImportRecord(ctx, nil, input)
+		_, output, err := tools.ImportRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		// The test verifies that case-insensitive format is handled.

--- a/mcp/tools/list_versions.go
+++ b/mcp/tools/list_versions.go
@@ -25,7 +25,7 @@ type ListVersionsOutput struct {
 
 // ListVersions retrieves the list of available OASF schema versions.
 // This tool provides a simple way to discover what schema versions are supported.
-func ListVersions(ctx context.Context, _ *mcp.CallToolRequest, _ ListVersionsInput) (
+func (t *Tools) ListVersions(ctx context.Context, _ *mcp.CallToolRequest, _ ListVersionsInput) (
 	*mcp.CallToolResult,
 	ListVersionsOutput,
 	error,

--- a/mcp/tools/list_versions_test.go
+++ b/mcp/tools/list_versions_test.go
@@ -20,11 +20,14 @@ func TestListVersions(t *testing.T) {
 	// ListVersions doesn't require schema URL, but set it for consistency
 	t.Setenv("OASF_API_VALIDATION_SCHEMA_URL", "https://schema.oasf.outshift.com")
 
+	// Create Tools instance (nil client is fine - ListVersions doesn't use client)
+	tools := &Tools{Client: nil}
+
 	t.Run("should return available versions", func(t *testing.T) {
 		ctx := context.Background()
 		input := ListVersionsInput{}
 
-		_, output, err := ListVersions(ctx, nil, input)
+		_, output, err := tools.ListVersions(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Empty(t, output.ErrorMessage)
@@ -40,7 +43,7 @@ func TestListVersions(t *testing.T) {
 		ctx := context.Background()
 		input := ListVersionsInput{}
 
-		_, output, err := ListVersions(ctx, nil, input)
+		_, output, err := tools.ListVersions(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Contains(t, output.AvailableVersions, "0.7.0")

--- a/mcp/tools/pull.go
+++ b/mcp/tools/pull.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
-	"github.com/agntcy/dir/client"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -25,7 +24,7 @@ type PullRecordOutput struct {
 }
 
 // PullRecord pulls a record from the Directory by its CID.
-func PullRecord(ctx context.Context, _ *mcp.CallToolRequest, input PullRecordInput) (
+func (t *Tools) PullRecord(ctx context.Context, _ *mcp.CallToolRequest, input PullRecordInput) (
 	*mcp.CallToolResult,
 	PullRecordOutput,
 	error,
@@ -37,25 +36,8 @@ func PullRecord(ctx context.Context, _ *mcp.CallToolRequest, input PullRecordInp
 		}, nil
 	}
 
-	// Load client configuration
-	config, err := client.LoadConfig()
-	if err != nil {
-		return nil, PullRecordOutput{
-			ErrorMessage: fmt.Sprintf("Failed to load client configuration: %v", err),
-		}, nil
-	}
-
-	// Create Directory client
-	c, err := client.New(ctx, client.WithConfig(config))
-	if err != nil {
-		return nil, PullRecordOutput{
-			ErrorMessage: fmt.Sprintf("Failed to create Directory client: %v", err),
-		}, nil
-	}
-	defer c.Close()
-
 	// Pull the record
-	record, err := c.Pull(ctx, &corev1.RecordRef{
+	record, err := t.Client.Pull(ctx, &corev1.RecordRef{
 		Cid: input.CID,
 	})
 	if err != nil {

--- a/mcp/tools/push_record_test.go
+++ b/mcp/tools/push_record_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestPushRecord(t *testing.T) {
+	// Create Tools instance with nil client (tests only validate input parsing)
+	tools := &Tools{Client: nil}
+
 	tests := []struct {
 		name           string
 		input          PushRecordInput
@@ -51,7 +54,7 @@ func TestPushRecord(t *testing.T) {
 			ctx := context.Background()
 			req := &mcp.CallToolRequest{}
 
-			_, output, err := PushRecord(ctx, req, tt.input)
+			_, output, err := tools.PushRecord(ctx, req, tt.input)
 
 			if tt.wantError {
 				require.NoError(t, err) // PushRecord returns nil error, error in output
@@ -72,6 +75,9 @@ func TestPushRecord(t *testing.T) {
 }
 
 func TestPushRecord_InvalidRecord(t *testing.T) {
+	// Create Tools instance with nil client (tests only validate input parsing)
+	tools := &Tools{Client: nil}
+
 	// Test with a record that will fail validation (missing required fields)
 	invalidRecordJSON := `{
 		"schema_version": "0.7.0",
@@ -81,7 +87,7 @@ func TestPushRecord_InvalidRecord(t *testing.T) {
 	ctx := context.Background()
 	req := &mcp.CallToolRequest{}
 
-	_, output, err := PushRecord(ctx, req, PushRecordInput{
+	_, output, err := tools.PushRecord(ctx, req, PushRecordInput{
 		RecordJSON: invalidRecordJSON,
 	})
 

--- a/mcp/tools/search.go
+++ b/mcp/tools/search.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	searchv1 "github.com/agntcy/dir/api/search/v1"
-	"github.com/agntcy/dir/client"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -47,7 +46,7 @@ const (
 // SearchLocal searches for agent records on the local directory node.
 //
 //nolint:cyclop
-func SearchLocal(ctx context.Context, _ *mcp.CallToolRequest, input SearchLocalInput) (
+func (t *Tools) SearchLocal(ctx context.Context, _ *mcp.CallToolRequest, input SearchLocalInput) (
 	*mcp.CallToolResult,
 	SearchLocalOutput,
 	error,
@@ -84,29 +83,12 @@ func SearchLocal(ctx context.Context, _ *mcp.CallToolRequest, input SearchLocalI
 		}, nil
 	}
 
-	// Load client configuration
-	config, err := client.LoadConfig()
-	if err != nil {
-		return nil, SearchLocalOutput{
-			ErrorMessage: fmt.Sprintf("Failed to load client configuration: %v", err),
-		}, nil
-	}
-
-	// Create Directory client
-	c, err := client.New(ctx, client.WithConfig(config))
-	if err != nil {
-		return nil, SearchLocalOutput{
-			ErrorMessage: fmt.Sprintf("Failed to create Directory client: %v", err),
-		}, nil
-	}
-	defer c.Close()
-
 	// Execute search
 	// Safe conversions: limit is capped at 1000, offset is validated by client
 	limit32 := uint32(limit)   // #nosec G115
 	offset32 := uint32(offset) // #nosec G115
 
-	result, err := c.SearchCIDs(ctx, &searchv1.SearchCIDsRequest{
+	result, err := t.Client.SearchCIDs(ctx, &searchv1.SearchCIDsRequest{
 		Limit:   &limit32,
 		Offset:  &offset32,
 		Queries: queries,

--- a/mcp/tools/tools.go
+++ b/mcp/tools/tools.go
@@ -1,0 +1,48 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agntcy/dir/client"
+)
+
+// Tools provides Directory client-dependent tool implementations.
+// Create with NewTools and use the methods as MCP tool handlers.
+type Tools struct {
+	Client        *client.Client
+	ServerAddress string
+}
+
+// NewTools creates a new Tools instance with a Directory client.
+// The caller is responsible for calling Close() when done.
+func NewTools(ctx context.Context) (*Tools, error) {
+	config, err := client.LoadConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client configuration: %w", err)
+	}
+
+	c, err := client.New(ctx, client.WithConfig(config))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Directory client: %w", err)
+	}
+
+	return &Tools{
+		Client:        c,
+		ServerAddress: config.ServerAddress,
+	}, nil
+}
+
+// Close releases the client resources.
+func (t *Tools) Close() error {
+	if t.Client != nil {
+		if err := t.Client.Close(); err != nil {
+			return fmt.Errorf("failed to close client: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/mcp/tools/validate_record.go
+++ b/mcp/tools/validate_record.go
@@ -26,7 +26,7 @@ type ValidateRecordOutput struct {
 
 // ValidateRecord validates an agent record against the OASF schema.
 // This performs full OASF schema validation and returns detailed errors.
-func ValidateRecord(ctx context.Context, _ *mcp.CallToolRequest, input ValidateRecordInput) (
+func (t *Tools) ValidateRecord(ctx context.Context, _ *mcp.CallToolRequest, input ValidateRecordInput) (
 	*mcp.CallToolResult,
 	ValidateRecordOutput,
 	error,

--- a/mcp/tools/validate_record_test.go
+++ b/mcp/tools/validate_record_test.go
@@ -19,6 +19,9 @@ func TestValidateRecord(t *testing.T) {
 		t.Fatalf("Failed to initialize validator: %v", err)
 	}
 
+	// Create Tools instance (nil client is fine - ValidateRecord doesn't use client)
+	tools := &Tools{Client: nil}
+
 	validRecord := `{
 		"schema_version": "0.7.0",
 		"name": "test-agent",
@@ -43,7 +46,7 @@ func TestValidateRecord(t *testing.T) {
 		ctx := context.Background()
 		input := ValidateRecordInput{RecordJSON: validRecord}
 
-		_, output, err := ValidateRecord(ctx, nil, input)
+		_, output, err := tools.ValidateRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Empty(t, output.ErrorMessage)
@@ -57,7 +60,7 @@ func TestValidateRecord(t *testing.T) {
 		ctx := context.Background()
 		input := ValidateRecordInput{RecordJSON: "not valid json"}
 
-		_, output, err := ValidateRecord(ctx, nil, input)
+		_, output, err := tools.ValidateRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, output.ErrorMessage)
@@ -70,7 +73,7 @@ func TestValidateRecord(t *testing.T) {
 		invalidRecord := `{"schema_version": "0.7.0"}`
 		input := ValidateRecordInput{RecordJSON: invalidRecord}
 
-		_, output, err := ValidateRecord(ctx, nil, input)
+		_, output, err := tools.ValidateRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.Empty(t, output.ErrorMessage)
@@ -82,7 +85,7 @@ func TestValidateRecord(t *testing.T) {
 		ctx := context.Background()
 		input := ValidateRecordInput{RecordJSON: ""}
 
-		_, output, err := ValidateRecord(ctx, nil, input)
+		_, output, err := tools.ValidateRecord(ctx, nil, input)
 
 		require.NoError(t, err)
 		assert.NotEmpty(t, output.ErrorMessage)

--- a/mcp/tools/verify_name.go
+++ b/mcp/tools/verify_name.go
@@ -1,0 +1,97 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	namingv1 "github.com/agntcy/dir/api/naming/v1"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// VerifyNameInput defines the input parameters for verifying a record's name ownership.
+type VerifyNameInput struct {
+	CID     string `json:"cid,omitempty"     jsonschema:"Content Identifier (CID) of the record to verify"`
+	Name    string `json:"name,omitempty"    jsonschema:"Human-readable name of the record (e.g., 'example.com/my-agent')"`
+	Version string `json:"version,omitempty" jsonschema:"Optional version to verify (e.g., 'v1.0.0'). If omitted, verifies the latest version."`
+}
+
+// DomainVerificationDetail provides details about the domain verification.
+type DomainVerificationDetail struct {
+	Domain       string `json:"domain"                   jsonschema:"The domain that was verified"`
+	Method       string `json:"method"                   jsonschema:"Verification method used (e.g., 'wellknown')"`
+	MatchedKeyID string `json:"matched_key_id,omitempty" jsonschema:"The key ID that matched from the domain's well-known file"`
+	VerifiedAt   string `json:"verified_at,omitempty"    jsonschema:"Timestamp when verification occurred"`
+}
+
+// VerifyNameOutput defines the output of name verification.
+type VerifyNameOutput struct {
+	Verified           bool                      `json:"verified"                      jsonschema:"Whether the name ownership was verified"`
+	DomainVerification *DomainVerificationDetail `json:"domain_verification,omitempty" jsonschema:"Details about the domain verification (only present if verified)"`
+	ErrorMessage       string                    `json:"error_message,omitempty"       jsonschema:"Error message if verification failed"`
+}
+
+// VerifyName verifies that a record's name is owned by the domain it claims.
+// This checks that the record was signed with a key published in the domain's well-known JWKS file.
+func (t *Tools) VerifyName(ctx context.Context, _ *mcp.CallToolRequest, input VerifyNameInput) (
+	*mcp.CallToolResult,
+	VerifyNameOutput,
+	error,
+) {
+	// Validate input - need either CID or Name
+	if input.CID == "" && input.Name == "" {
+		return nil, VerifyNameOutput{
+			ErrorMessage: "Either 'cid' or 'name' is required",
+		}, nil
+	}
+
+	// Call the appropriate verification method
+	var resp *namingv1.GetVerificationInfoResponse
+
+	var err error
+
+	if input.CID != "" {
+		// Verify by CID
+		resp, err = t.Client.GetVerificationInfo(ctx, input.CID)
+		if err != nil {
+			return nil, VerifyNameOutput{
+				ErrorMessage: fmt.Sprintf("Failed to verify name: %v", err),
+			}, nil
+		}
+	} else {
+		// Verify by name (and optional version)
+		resp, err = t.Client.GetVerificationInfoByName(ctx, input.Name, input.Version)
+		if err != nil {
+			return nil, VerifyNameOutput{
+				ErrorMessage: fmt.Sprintf("Failed to verify name: %v", err),
+			}, nil
+		}
+	}
+
+	// Build output
+	output := VerifyNameOutput{
+		Verified: resp.GetVerified(),
+	}
+
+	if !resp.GetVerified() && resp.GetErrorMessage() != "" {
+		output.ErrorMessage = resp.GetErrorMessage()
+	}
+
+	// Add domain verification details if available
+	if v := resp.GetVerification(); v != nil {
+		if dv := v.GetDomain(); dv != nil {
+			output.DomainVerification = &DomainVerificationDetail{
+				Domain:       dv.GetDomain(),
+				Method:       dv.GetMethod(),
+				MatchedKeyID: dv.GetKeyId(),
+			}
+			if dv.GetVerifiedAt() != nil {
+				output.DomainVerification.VerifiedAt = dv.GetVerifiedAt().AsTime().String()
+			}
+		}
+	}
+
+	return nil, output, nil
+}

--- a/mcp/tools/verify_name_test.go
+++ b/mcp/tools/verify_name_test.go
@@ -1,0 +1,133 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyNameInputValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       VerifyNameInput
+		expectError bool
+		description string
+	}{
+		{
+			name: "valid input with CID",
+			input: VerifyNameInput{
+				CID: "bafkreiabcd1234567890",
+			},
+			expectError: false,
+			description: "CID alone should be valid",
+		},
+		{
+			name: "valid input with name",
+			input: VerifyNameInput{
+				Name: "example.com/my-agent",
+			},
+			expectError: false,
+			description: "Name alone should be valid",
+		},
+		{
+			name: "valid input with name and version",
+			input: VerifyNameInput{
+				Name:    "example.com/my-agent",
+				Version: "v1.0.0",
+			},
+			expectError: false,
+			description: "Name with version should be valid",
+		},
+		{
+			name:        "missing both CID and name",
+			input:       VerifyNameInput{},
+			expectError: true,
+			description: "Either CID or name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test that marshaling works
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+
+			// Test that unmarshaling works
+			var decoded VerifyNameInput
+
+			err = json.Unmarshal(data, &decoded)
+			require.NoError(t, err)
+
+			// Validate that either CID or Name is present
+			hasInput := decoded.CID != "" || decoded.Name != ""
+			if tt.expectError {
+				assert.False(t, hasInput, tt.description)
+			} else {
+				assert.True(t, hasInput, tt.description)
+			}
+		})
+	}
+}
+
+func TestVerifyNameOutputSerialization(t *testing.T) {
+	tests := []struct {
+		name   string
+		output VerifyNameOutput
+	}{
+		{
+			name: "verified output",
+			output: VerifyNameOutput{
+				Verified: true,
+				DomainVerification: &DomainVerificationDetail{
+					Domain:       "example.com",
+					Method:       "wellknown",
+					MatchedKeyID: "key-123",
+					VerifiedAt:   "2025-01-21T12:00:00Z",
+				},
+			},
+		},
+		{
+			name: "not verified output",
+			output: VerifyNameOutput{
+				Verified:     false,
+				ErrorMessage: "no valid signature found for domain",
+			},
+		},
+		{
+			name: "error output",
+			output: VerifyNameOutput{
+				ErrorMessage: "Failed to connect to server",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test that marshaling works
+			data, err := json.Marshal(tt.output)
+			require.NoError(t, err)
+
+			// Test that unmarshaling works
+			var decoded VerifyNameOutput
+
+			err = json.Unmarshal(data, &decoded)
+			require.NoError(t, err)
+
+			// Verify fields are preserved
+			assert.Equal(t, tt.output.Verified, decoded.Verified)
+			assert.Equal(t, tt.output.ErrorMessage, decoded.ErrorMessage)
+
+			if tt.output.DomainVerification != nil {
+				require.NotNil(t, decoded.DomainVerification)
+				assert.Equal(t, tt.output.DomainVerification.Domain, decoded.DomainVerification.Domain)
+				assert.Equal(t, tt.output.DomainVerification.Method, decoded.DomainVerification.Method)
+				assert.Equal(t, tt.output.DomainVerification.MatchedKeyID, decoded.DomainVerification.MatchedKeyID)
+			}
+		})
+	}
+}

--- a/mcp/tools/verify_record.go
+++ b/mcp/tools/verify_record.go
@@ -9,7 +9,6 @@ import (
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	signv1 "github.com/agntcy/dir/api/sign/v1"
-	"github.com/agntcy/dir/client"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -33,7 +32,7 @@ type VerifyRecordOutput struct {
 }
 
 // VerifyRecord verifies the signature of a record in the Directory by its CID.
-func VerifyRecord(ctx context.Context, _ *mcp.CallToolRequest, input VerifyRecordInput) (
+func (t *Tools) VerifyRecord(ctx context.Context, _ *mcp.CallToolRequest, input VerifyRecordInput) (
 	*mcp.CallToolResult,
 	VerifyRecordOutput,
 	error,
@@ -54,25 +53,8 @@ func VerifyRecord(ctx context.Context, _ *mcp.CallToolRequest, input VerifyRecor
 		}, nil
 	}
 
-	// Load client configuration
-	config, err := client.LoadConfig()
-	if err != nil {
-		return nil, VerifyRecordOutput{
-			Error: fmt.Sprintf("Failed to load client configuration: %v", err),
-		}, nil
-	}
-
-	// Create Directory client
-	c, err := client.New(ctx, client.WithConfig(config))
-	if err != nil {
-		return nil, VerifyRecordOutput{
-			Error: fmt.Sprintf("Failed to create client: %v", err),
-		}, nil
-	}
-	defer c.Close()
-
 	// Verify record
-	resp, err := c.Verify(ctx, &signv1.VerifyRequest{
+	resp, err := t.Client.Verify(ctx, &signv1.VerifyRequest{
 		RecordRef: &corev1.RecordRef{
 			Cid: input.CID,
 		},


### PR DESCRIPTION
This PR:
- adds a new MCP tool to verify a record's name
- refactors the MCP server to not parse the client config and create the client instance multiple times

<img width="605" height="578" alt="Screenshot 2026-02-24 at 13 57 25" src="https://github.com/user-attachments/assets/5bdfa463-c6bd-4ca1-a07d-2dd96dc27a24" />
