### PR TITLE
fix(dir): bump postgres version in docker compose

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -72,7 +72,7 @@ jobs:
           - ghcr.io/project-zot/zot:v2.1.14
           - ghcr.io/spiffe/spire-server:1.14.1
           - ghcr.io/spiffe/spire-agent:1.14.1
-          - docker.io/bitnami/postgresql@sha256:1ce1f97f3fd21366731ef29460bc210fc64355cbfc8ded68875892f75f026945
+          - docker.io/bitnami/postgresql@sha256:e8b68936d05ee665974430bb4765fedcdc5c9ba399e133e120e2deed77f54dbf
     steps:
       - name: Set image name
         id: image-name

--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       start_period: 15s
 
   postgres:
-    image: docker.io/bitnami/postgresql@sha256:1ce1f97f3fd21366731ef29460bc210fc64355cbfc8ded68875892f75f026945
+    image: docker.io/bitnami/postgresql@sha256:e8b68936d05ee665974430bb4765fedcdc5c9ba399e133e120e2deed77f54dbf
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
https://github.com/bitnami/containers/blob/main/bitnami/postgresql/18/debian-12/Dockerfile

I investigated a little bit, but I am not sure what causes this error. I'm pretty sure something is wrong with the release on Bitnami's side

It seems to work with the `latest` tag. It also works with the previous release

We can either bump it to `latest`, or roll it back to the previous release. I would say rolling back is the more prudent option
