### PR TITLE
refactor(dir): refactor the Dockerfile's build arguments

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,14 +22,15 @@ vars:
   REGSYNC_VERSION: "v0.11.1"
 
   ## Image config
+  BUILD_LDFLAGS: "-s -w -extldflags -static {{.VERSION_LDFLAGS}}"
   IMAGE_REPO: '{{ .IMAGE_REPO | default "ghcr.io/agntcy" }}'
   IMAGE_TAG: "{{ .IMAGE_TAG | default .COMMIT_SHA }}"
   IMAGE_BAKE_ENV: "IMAGE_REPO={{.IMAGE_REPO}} IMAGE_TAG={{.IMAGE_TAG}} REGSYNC_VERSION={{.REGSYNC_VERSION}}"
   IMAGE_BAKE_OPTS: '{{ .IMAGE_BAKE_OPTS | default "" }}'
-  BAKE_ENV: '{{ .IMAGE_BAKE_ENV }} EXTRA_LDFLAGS="{{.VERSION_LDFLAGS}}"'
+  BAKE_ENV: '{{ .IMAGE_BAKE_ENV }} BUILD_LDFLAGS="{{.BUILD_LDFLAGS}}"'
   COVERAGE_IMAGE_TAG: "{{ .IMAGE_TAG | default .COMMIT_SHA }}-coverage"
   COVERAGE_IMAGE_BAKE_ENV: "IMAGE_REPO={{.IMAGE_REPO}} IMAGE_TAG={{.COVERAGE_IMAGE_TAG}}"
-  COVERAGE_BAKE_ENV: '{{ .COVERAGE_IMAGE_BAKE_ENV }} EXTRA_LDFLAGS="{{.VERSION_LDFLAGS}}"'
+  COVERAGE_BAKE_ENV: '{{ .COVERAGE_IMAGE_BAKE_ENV }} BUILD_LDFLAGS="{{.BUILD_LDFLAGS}}"'
   COVERAGE_PKGS: '{{ .COVERAGE_PKGS | default "github.com/agntcy/dir/api/...,github.com/agntcy/dir/cli/...,github.com/agntcy/dir/client/...,github.com/agntcy/dir/importer/...,github.com/agntcy/dir/utils/..." }}'
 
   ## Dependency config

--- a/auth/cmd/envoy-authz/Dockerfile
+++ b/auth/cmd/envoy-authz/Dockerfile
@@ -23,14 +23,15 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     xx-go mod download -x
 
 ARG BUILD_OPTS
-ARG EXTRA_LDFLAGS
+ARG BUILD_GCFLAGS
+ARG BUILD_LDFLAGS
 
 ENV CGO_ENABLED=0
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=.,target=/build,ro \
-    xx-go build ${BUILD_OPTS} -ldflags="-s -w -extldflags -static ${EXTRA_LDFLAGS}" \
+    xx-go build ${BUILD_OPTS} -gcflags="${BUILD_GCFLAGS}" -ldflags="${BUILD_LDFLAGS}" \
     -o /bin/envoy-authz ./main.go
 
 RUN xx-verify /bin/envoy-authz

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -23,7 +23,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     xx-go mod download -x
 
 ARG BUILD_OPTS
-ARG EXTRA_LDFLAGS
+ARG BUILD_GCFLAGS
+ARG BUILD_LDFLAGS
 
 # TODO(adamtagscherer): Currently we don't need C libraries but in the future we may need to turn this on once we add
 # security libraries, etc.
@@ -32,7 +33,7 @@ ENV CGO_ENABLED=0
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=.,target=/build,ro \
-    xx-go build ${BUILD_OPTS} -ldflags="-s -w -extldflags -static ${EXTRA_LDFLAGS}" \
+    xx-go build ${BUILD_OPTS} -gcflags="${BUILD_GCFLAGS}" -ldflags="${BUILD_LDFLAGS}" \
     -o /bin/dirctl ./cli.go
 
 RUN xx-verify /bin/dirctl

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -6,7 +6,7 @@
 # Docker build args
 variable "IMAGE_REPO" { default = "ghcr.io/agntcy" }
 variable "IMAGE_TAG" { default = "v0.1.0-rc" }
-variable "EXTRA_LDFLAGS" { default = "" }
+variable "BUILD_LDFLAGS" { default = "-s -w -extldflags -static" }
 variable "IMAGE_NAME_SUFFIX" { default = "" }
 variable "REGSYNC_VERSION" { default = "v0.11.1" }
 
@@ -42,7 +42,7 @@ target "_common" {
     "linux/amd64",
   ]
   args = {
-    EXTRA_LDFLAGS = "${EXTRA_LDFLAGS}"
+    BUILD_LDFLAGS = "${BUILD_LDFLAGS}"
   }
 }
 

--- a/reconciler/Dockerfile
+++ b/reconciler/Dockerfile
@@ -26,14 +26,15 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     xx-go mod download -x
 
 ARG BUILD_OPTS
-ARG EXTRA_LDFLAGS
+ARG BUILD_GCFLAGS
+ARG BUILD_LDFLAGS
 
 ENV CGO_ENABLED=0
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=.,target=/build,ro \
-    xx-go build ${BUILD_OPTS} -ldflags="-s -w -extldflags -static ${EXTRA_LDFLAGS}" \
+    xx-go build ${BUILD_OPTS} -gcflags="${BUILD_GCFLAGS}" -ldflags="${BUILD_LDFLAGS}" \
     -o /bin/reconciler .
 
 RUN xx-verify /bin/reconciler

--- a/runtime/discovery/Dockerfile
+++ b/runtime/discovery/Dockerfile
@@ -23,14 +23,15 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     xx-go mod download -x
 
 ARG BUILD_OPTS
-ARG EXTRA_LDFLAGS
+ARG BUILD_GCFLAGS
+ARG BUILD_LDFLAGS
 
 ENV CGO_ENABLED=0
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=.,target=/build,ro \
-    xx-go build ${BUILD_OPTS} -ldflags="-s -w -extldflags -static ${EXTRA_LDFLAGS}" \
+    xx-go build ${BUILD_OPTS} -gcflags="${BUILD_GCFLAGS}" -ldflags="${BUILD_LDFLAGS}" \
     -o /bin/discovery ./cmd/main.go
 
 RUN xx-verify /bin/discovery

--- a/runtime/server/Dockerfile
+++ b/runtime/server/Dockerfile
@@ -26,14 +26,15 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     xx-go mod download -x
 
 ARG BUILD_OPTS
-ARG EXTRA_LDFLAGS
+ARG BUILD_GCFLAGS
+ARG BUILD_LDFLAGS
 
 ENV CGO_ENABLED=0
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=.,target=/build,ro \
-    xx-go build ${BUILD_OPTS} -ldflags="-s -w -extldflags -static ${EXTRA_LDFLAGS}" \
+    xx-go build ${BUILD_OPTS} -gcflags="${BUILD_GCFLAGS}" -ldflags="${BUILD_LDFLAGS}" \
     -o /bin/runtime-server ./cmd/main.go
 
 RUN xx-verify /bin/runtime-server

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -23,7 +23,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     xx-go mod download -x
 
 ARG BUILD_OPTS
-ARG EXTRA_LDFLAGS
+ARG BUILD_GCFLAGS
+ARG BUILD_LDFLAGS
 
 # TODO(adamtagscherer): Currently we don't need C libraries but in the future we may need to turn this on once we add
 # security libraries, etc.
@@ -32,7 +33,7 @@ ENV CGO_ENABLED=0
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,source=.,target=/build,ro \
-    xx-go build ${BUILD_OPTS} -ldflags="-s -w -extldflags -static ${EXTRA_LDFLAGS}" \
+    xx-go build ${BUILD_OPTS} -gcflags="${BUILD_GCFLAGS}" -ldflags="${BUILD_LDFLAGS}" \
     -o /bin/apiserver ./cmd/main.go
 
 RUN xx-verify /bin/apiserver


### PR DESCRIPTION
for debugging purposes, we need to override the `go build`'s `-ldflags` (and we also need to provide `-gcflags`)

to support this, we need to refactor the build arguments
