### PR TITLE
feat(dir): add Delve debugger

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -521,6 +521,14 @@ tasks:
     cmds:
       - docker compose up -d --build --wait
 
+  server:start:debug:
+    desc: Start local Directory server stack in debug mode
+    dir: ./install/docker
+    env:
+      DIRECTORY_SERVER_PUBLICATION_SCHEDULER_INTERVAL: 1s
+    cmds:
+      - docker compose -f docker-compose.yml -f docker-compose.debug.yml up -d --build --wait
+
   server:stop:
     desc: Stop local Directory server stack
     dir: ./install/docker

--- a/install/docker/docker-compose.debug.yml
+++ b/install/docker/docker-compose.debug.yml
@@ -1,0 +1,30 @@
+# A set of Compose overrides to run the services in debug mode.
+# It's intended for local development only.
+# Developers may remote debug using Delve by connecting to:
+# - port 2345 for apiserver
+# - port 2346 for reconciler
+services:
+  apiserver:
+    build:
+      target: debug
+      args:
+        BUILD_GCFLAGS: "all=-N -l"
+        BUILD_LDFLAGS: ""
+    ports:
+      - 2345:2345
+    security_opt:
+      - apparmor=unconfined
+    cap_add:
+      - SYS_PTRACE
+  reconciler:
+    build:
+      target: debug
+      args:
+        BUILD_GCFLAGS: "all=-N -l"
+        BUILD_LDFLAGS: ""
+    ports:
+      - 2346:2345
+    security_opt:
+      - apparmor=unconfined
+    cap_add:
+      - SYS_PTRACE

--- a/reconciler/Dockerfile
+++ b/reconciler/Dockerfile
@@ -54,6 +54,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 RUN xx-verify /bin/regsync
 
+# Debug image - includes Delve for remote debugging. For local development only
+FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709 AS debug
+
+WORKDIR /
+
+COPY --from=builder /bin/reconciler ./reconciler
+COPY --from=builder /bin/regsync /usr/local/bin/regsync
+
+RUN xx-go install github.com/go-delve/delve/cmd/dlv@v1.26.0
+
+ENTRYPOINT ["/go/bin/dlv", "--listen=0.0.0.0:2345", "--headless=true", "--accept-multiclient=true", "--api-version=2", "exec", "--continue", "./reconciler"]
+
 # Runtime stage - using Alpine because regsync may need shell/tools
 # https://github.com/docker-library/repo-info/blob/master/repos/alpine/tag-details.md
 FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709

--- a/runtime/server/Dockerfile
+++ b/runtime/server/Dockerfile
@@ -39,6 +39,17 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 RUN xx-verify /bin/runtime-server
 
+# Debug image - includes Delve for remote debugging. For local development only
+FROM builder AS debug
+
+WORKDIR /
+
+COPY --from=builder /bin/runtime-server ./runtime-server
+
+RUN xx-go install github.com/go-delve/delve/cmd/dlv@v1.26.0
+
+ENTRYPOINT ["/go/bin/dlv", "--listen=0.0.0.0:2345", "--headless=true", "--accept-multiclient=true", "--api-version=2", "exec", "--continue", "./runtime-server"]
+
 # Production image - minimal distroless
 FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc AS production
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -38,6 +38,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 RUN xx-verify /bin/apiserver
 
+# Debug image - includes Delve for remote debugging. For local development only
+FROM builder AS debug
+
+WORKDIR /
+
+COPY --from=builder /bin/apiserver ./apiserver
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.38 /ko-app/grpc-health-probe /bin/grpc-health-probe
+
+RUN xx-go install github.com/go-delve/delve/cmd/dlv@v1.26.0
+
+ENTRYPOINT ["/go/bin/dlv", "--listen=0.0.0.0:2345", "--headless=true", "--accept-multiclient=true", "--api-version=2", "exec", "--continue", "./apiserver", "--", "run"]
+
 # Production image - minimal distroless
 FROM gcr.io/distroless/static:nonroot@sha256:c0f429e16b13e583da7e5a6ec20dd656d325d88e6819cafe0adb0828976529dc AS production
 


### PR DESCRIPTION
add the Delve debugger to the `apiserver`, `reconciler`, `runtime` images

modify `task server:start`, so if the `DEBUG=1` environment variable is set, it builds the `apiserver` and `reconciler` with the debugger included. e.g.:

```sh
DEBUG=1 task server:start
```

the debugger ports are exposed at:
- apiserver: 2345
- reconciler: 2346

to use the debugger, start the server in debug mode as described above and use your favorite IDE to create a remote debugging session

for example, to debug the apiserver, connect to 0.0.0.0:2345

instructions for Goland:
https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-3-start-the-debugging-process-on-your-local-computer

it would be good to document this somewhere other than this PR. I would also include screenshots. should I create a README.md for this? where should I put this info?

ALTERNATIVE SOLUTION:

could add a new command instead of the `DEBUG` environment variable:
```
task server:start:debug
```
or pass it as a flag (needs additional parsing logic so I would avoid this):
```
task server:start -- --debug
```