### PR TITLE
fix(dir): fix reconciler debug image

### DIFF
--- a/reconciler/Dockerfile
+++ b/reconciler/Dockerfile
@@ -55,7 +55,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 RUN xx-verify /bin/regsync
 
 # Debug image - includes Delve for remote debugging. For local development only
-FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709 AS debug
+FROM builder AS debug
 
 WORKDIR /
 


### PR DESCRIPTION
sorry, I only noticed after merging. the reconciler debug image needs to be built from the builder as base. I'm not so familiar with the regsync utility but I think it should work just as well with Debian (which the builder image is based on)