### PR TITLE
feat(dir): add validation for referrer record CIDs

### DIFF
--- a/client/sign.go
+++ b/client/sign.go
@@ -68,7 +68,7 @@ func (c *Client) pushReferrersToStore(ctx context.Context, recordRef *corev1.Rec
 	}
 
 	// Push public key to store as a referrer
-	err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
+	_, err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
 		RecordRef: recordRef,
 		Referrer:  publicKeyReferrer,
 	})
@@ -83,7 +83,7 @@ func (c *Client) pushReferrersToStore(ctx context.Context, recordRef *corev1.Rec
 	}
 
 	// Push signature to store as a referrer
-	err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
+	_, err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
 		RecordRef: recordRef,
 		Referrer:  signatureReferrer,
 	})

--- a/client/store.go
+++ b/client/store.go
@@ -127,30 +127,30 @@ func (c *Client) PushBatch(ctx context.Context, records []*corev1.Record) ([]*co
 }
 
 // PushReferrer stores a signature using the PushReferrer RPC.
-func (c *Client) PushReferrer(ctx context.Context, req *storev1.PushReferrerRequest) error {
+func (c *Client) PushReferrer(ctx context.Context, req *storev1.PushReferrerRequest) (*storev1.PushReferrerResponse, error) {
 	// Create streaming client
 	stream, err := c.StoreServiceClient.PushReferrer(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create push referrer stream: %w", err)
+		return nil, fmt.Errorf("failed to create push referrer stream: %w", err)
 	}
 
 	// Send the request
 	if err := stream.Send(req); err != nil {
-		return fmt.Errorf("failed to send push referrer request: %w", err)
+		return nil, fmt.Errorf("failed to send push referrer request: %w", err)
 	}
 
 	// Close send stream
 	if err := stream.CloseSend(); err != nil {
-		return fmt.Errorf("failed to close send stream: %w", err)
+		return nil, fmt.Errorf("failed to close send stream: %w", err)
 	}
 
 	// Receive response
-	_, err = stream.Recv()
+	response, err := stream.Recv()
 	if err != nil {
-		return fmt.Errorf("failed to receive push referrer response: %w", err)
+		return nil, fmt.Errorf("failed to receive push referrer response: %w", err)
 	}
 
-	return nil
+	return response, nil
 }
 
 // PullReferrer retrieves all referrers using the PullReferrer RPC.

--- a/server/store/oci/referrers.go
+++ b/server/store/oci/referrers.go
@@ -45,6 +45,12 @@ func (s *store) PushReferrer(ctx context.Context, recordCID string, referrer *co
 		return status.Error(codes.InvalidArgument, "referrer type is required") //nolint:wrapcheck
 	}
 
+	if referrer.GetRecordRef() == nil {
+		referrer.RecordRef = &corev1.RecordRef{Cid: recordCID}
+	} else if referrer.GetRecordRef().GetCid() != recordCID {
+		return status.Error(codes.InvalidArgument, "referrer's record CID must match record CID") //nolint:wrapcheck
+	}
+
 	// Check if record exists before pushing referrer
 	_, err := s.Lookup(ctx, &corev1.RecordRef{Cid: recordCID})
 	if err != nil {

--- a/tests/e2e/local/10_referrers_test.go
+++ b/tests/e2e/local/10_referrers_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	signv1 "github.com/agntcy/dir/api/sign/v1"
@@ -103,7 +104,7 @@ var _ = ginkgo.Describe("Running e2e tests for referrers", func() {
 		var err error
 
 		referrer := generateReferrer()
-		err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
+		_, err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
 			RecordRef: record1,
 			Referrer:  referrer,
 		})
@@ -112,7 +113,7 @@ var _ = ginkgo.Describe("Running e2e tests for referrers", func() {
 
 		referrers := pullReferrers(c, ctx, record1, corev1.PublicKeyReferrerType)
 		gomega.Expect(referrers).To(gomega.HaveLen(1))
-		gomega.Expect(referrers[0].GetRecordRef()).To(gomega.BeNil())
+		gomega.Expect(referrers[0].GetRecordRef().GetCid()).To(gomega.Equal(record1.GetCid()))
 		gomega.Expect(referrers[0].GetType()).To(gomega.Equal(corev1.PublicKeyReferrerType))
 		gomega.Expect(referrers[0].GetAnnotations()).To(gomega.BeNil())
 		gomega.Expect(referrers[0].GetCreatedAt()).To(gomega.Equal(""))
@@ -126,7 +127,7 @@ var _ = ginkgo.Describe("Running e2e tests for referrers", func() {
 		referrer.CreatedAt = "2026-03-09T14:20:00Z"
 		referrer.RecordRef = record1
 		referrer.Annotations = map[string]string{"foo": "bar"}
-		err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
+		_, err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
 			RecordRef: record1,
 			Referrer:  referrer,
 		})
@@ -147,20 +148,25 @@ var _ = ginkgo.Describe("Running e2e tests for referrers", func() {
 
 		referrer := generateReferrer()
 		referrer.RecordRef = record2
-		err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
+		response, err := c.PushReferrer(ctx, &storev1.PushReferrerRequest{
 			RecordRef: record1,
 			Referrer:  referrer,
 		})
 
-		// Should there be an error?
+		// FIXME: make sure to return an error if there's an error
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		gomega.Expect(response.GetSuccess()).To(gomega.BeFalse())
+		gomega.Expect(response.GetErrorMessage()).To(gomega.Equal(
+			fmt.Sprintf("failed to push referrer for record %s: ", record1.GetCid()) +
+				"rpc error: code = InvalidArgument desc = referrer's record CID must match record CID",
+		))
 	})
 
 	ginkgo.It("should fail if empty referrer", func() {
 		var err error
 
 		referrer := &corev1.RecordReferrer{}
-		err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
+		_, err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
 			RecordRef: record1,
 			Referrer:  referrer,
 		})
@@ -174,7 +180,7 @@ var _ = ginkgo.Describe("Running e2e tests for referrers", func() {
 
 		referrer := generateReferrer()
 		referrer.Type = "foo"
-		err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
+		_, err = c.PushReferrer(ctx, &storev1.PushReferrerRequest{
 			RecordRef: record1,
 			Referrer:  referrer,
 		})


### PR DESCRIPTION
**Context**

right now, the PushReferrerRequest looks like this:

https://github.com/agntcy/dir/blob/9958c8dde563eafba48dd2c1f385e783a2af5c5a/proto/agntcy/dir/store/v1/store_service.proto#L47-L53

where both the `referrer` and `record_ref` defines a record CID

https://github.com/agntcy/dir/blob/9958c8dde563eafba48dd2c1f385e783a2af5c5a/proto/agntcy/dir/core/v1/record.proto#L62-L68

https://github.com/agntcy/dir/blob/50fa5e6b68af31acb1374f4363a00b08c6907027/proto/agntcy/dir/core/v1/record.proto#L11-L15

---

**Problems**

what if the referrer doesn't set a record CID? it'll be empty:

https://github.com/agntcy/dir/blob/9958c8dde563eafba48dd2c1f385e783a2af5c5a/tests/e2e/local/10_referrers_test.go#L115

what if the referrer sets a different record CID? it will save it:

https://github.com/agntcy/dir/blob/50fa5e6b68af31acb1374f4363a00b08c6907027/tests/e2e/local/10_referrers_test.go#L145

this PR adresses these 2 concerns:
- if the referrer doesn't set a record CID, set it automatically. the record CID should always be set because we need to calculate the referrer digest based on the content (for referrer CIDs)
- if the referrer sets a different record CID, return an error
