### PR TITLE
chore(dir): bump SPIRE to 1.14.2 and unify container scan image list

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -53,26 +53,39 @@ jobs:
             echo "version=${TAG_VERSION}" >> $GITHUB_OUTPUT
           fi
 
+  image-list:
+    name: Resolve image list
+    runs-on: ubuntu-latest
+    needs: [resolve-tag]
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Taskfile
+        shell: bash
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+
+      - name: Get image list from task
+        id: matrix
+        env:
+          IMAGE_TAG: ${{ needs.resolve-tag.outputs.version }}
+          IMAGE_REPO: ghcr.io/${{ github.repository_owner }}
+          PATH: ${{ env.HOME }}/.local/bin:${{ env.PATH }}
+        run: |
+          matrix=$(task --silent deps:vuln:images:list | jq -R -s -c 'split("\n") | map(select(length > 0)) | {image: .}')
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          echo "$matrix" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
   trivy-scan:
     name: Trivy Scan
     runs-on: ubuntu-latest
-    needs: [resolve-tag]
+    needs: [image-list]
     strategy:
       fail-fast: false
-      matrix:
-        # Single source of truth: add/remove images here
-        # Repo images use resolved tag, external images specify version or digest
-        image:
-          - ghcr.io/${{ github.repository_owner }}/dir-apiserver:${{ needs.resolve-tag.outputs.version }}
-          - ghcr.io/${{ github.repository_owner }}/dir-ctl:${{ needs.resolve-tag.outputs.version }}
-          - ghcr.io/${{ github.repository_owner }}/dir-reconciler:${{ needs.resolve-tag.outputs.version }}
-          - ghcr.io/${{ github.repository_owner }}/dir-runtime-discovery:${{ needs.resolve-tag.outputs.version }}
-          - ghcr.io/${{ github.repository_owner }}/dir-runtime-server:${{ needs.resolve-tag.outputs.version }}
-          - ghcr.io/${{ github.repository_owner }}/envoy-authz:${{ needs.resolve-tag.outputs.version }}
-          - ghcr.io/project-zot/zot:v2.1.15
-          - ghcr.io/spiffe/spire-server:1.14.2
-          - ghcr.io/spiffe/spire-agent:1.14.2
-          - docker.io/bitnami/postgresql@sha256:e8b68936d05ee665974430bb4765fedcdc5c9ba399e133e120e2deed77f54dbf
+      matrix: ${{ fromJson(needs.image-list.outputs.matrix) }}
     steps:
       - name: Set image name
         id: image-name

--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -17,6 +17,20 @@ vars:
   ZOT_VERSION: "2.1.15"
   SPIRE_VERSION: "1.14.2"
   REGSYNC_VERSION: "v0.11.1"
+  POSTGRESQL_IMAGE_REF: "docker.io/bitnami/postgresql@sha256:e8b68936d05ee665974430bb4765fedcdc5c9ba399e133e120e2deed77f54dbf"
+
+  ## Container images for vulnerability scanning
+  VULN_SCAN_IMAGES:
+    - "{{.IMAGE_REPO}}/dir-apiserver:{{.IMAGE_TAG}}"
+    - "{{.IMAGE_REPO}}/dir-ctl:{{.IMAGE_TAG}}"
+    - "{{.IMAGE_REPO}}/dir-reconciler:{{.IMAGE_TAG}}"
+    - "{{.IMAGE_REPO}}/dir-runtime-discovery:{{.IMAGE_TAG}}"
+    - "{{.IMAGE_REPO}}/dir-runtime-server:{{.IMAGE_TAG}}"
+    - "{{.IMAGE_REPO}}/envoy-authz:{{.IMAGE_TAG}}"
+    - "ghcr.io/project-zot/zot:v{{.ZOT_VERSION}}"
+    - "ghcr.io/spiffe/spire-server:{{.SPIRE_VERSION}}"
+    - "ghcr.io/spiffe/spire-agent:{{.SPIRE_VERSION}}"
+    - "{{.POSTGRESQL_IMAGE_REF}}"
 
   ## Image config
   BUILD_LDFLAGS: "-s -w -extldflags -static {{.VERSION_LDFLAGS}}"

--- a/bin/Taskfile.yml
+++ b/bin/Taskfile.yml
@@ -269,26 +269,20 @@ tasks:
       {{.TRIVY_BIN}} clean --scan-cache
       {{.TRIVY_BIN}} fs --scanners vuln --severity CRITICAL,HIGH,MEDIUM --ignore-unfixed {{.ROOT_DIR}}
 
-  # TODO: Switch GH actions to use this task instead of trivy action.
-  #
-  # This avoids redundant installations and have more control over scanning parameters.
-  # The TASKFILE should serve as a central source of truth for all dev-related operations.
   deps:vuln:images:
     desc: Run vulnerability check on container images
     deps:
       - deps:trivy
-    vars:
-      IMAGES:
-        - ghcr.io/agntcy/dir-apiserver:{{.IMAGE_TAG}}
-        - ghcr.io/agntcy/dir-ctl:{{.IMAGE_TAG}}
-        - ghcr.io/agntcy/dir-reconciler:{{.IMAGE_TAG}}
-        - ghcr.io/agntcy/dir-runtime-discovery:{{.IMAGE_TAG}}
-        - ghcr.io/agntcy/dir-runtime-server:{{.IMAGE_TAG}}
-        - ghcr.io/agntcy/envoy-authz:{{.IMAGE_TAG}}
     cmds:
       - cmd: |
           {{.TRIVY_BIN}} clean --scan-cache
-      - for: { var: IMAGES }
+      - for: { var: VULN_SCAN_IMAGES }
         cmd: |
           echo "Scanning {{.ITEM}}..."
           {{.TRIVY_BIN}} image --scanners vuln --severity CRITICAL,HIGH,MEDIUM --ignore-unfixed {{.ITEM}}
+
+  deps:vuln:images:list:
+    desc: Output vulnerability-scan image refs (one per line) for CI matrix
+    cmds:
+      - for: { var: VULN_SCAN_IMAGES }
+        cmd: echo "{{.ITEM}}"


### PR DESCRIPTION
Bump SPIRE to v1.14.2 and use a single source of truth for the container security scan image list (Taskfile + workflow).

* Bump SPIRE to v1.14.2
* Add `VULN_SCAN_IMAGES` and `POSTGRESQL_IMAGE_REF` in Taskfile.vars.yml; workflow and `task deps:vuln:images` both use this list
* Add `deps:vuln:images:list` and an image-list job so the workflow gets the matrix from the task instead of a hardcoded list