### PR TITLE
feat(tests): add production-like E2E test suite and update Taskfile

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Test suites
+
+This folder contains the Directory test suites. The main distinction is **environment**: synthetic (fast, PR-gating) vs production-like (realistic infrastructure, broader coverage).
+
+## Layout and differences
+
+| Directory | Infrastructure | Scope | CI | Run |
+|-----------|----------------|-------|-----|-----|
+| [**e2e/**](./e2e/) | Single Kind cluster, in-cluster Zot, peers as namespaces, port-forward. | Local CLI, client library, multi-peer (network), MCP. Routing, sync, search within one cluster. | PR-gating | `task test:e2e` |
+| [**e2e-production/**](./e2e-production/) | Multi-cluster or multi-node; **external** OCI registries (GHCR, Docker Hub, etc.). | Cross-cluster routing and sync; push/pull and discovery against real backends; auth for external registries. | Scheduled; not required for merge | `task test:e2e:production` |

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -15,6 +15,12 @@ tasks:
       - task: test:e2e:network
       - task: test:e2e:mcp
 
+  test:e2e-production:
+    desc: Run E2E tests in production-like environments (multi-node, external OCI)
+    dir: "{{ .ROOT_DIR }}/tests"
+    cmds:
+      - go test -C ./e2e-production . -v -ginkgo.v
+
   test:e2e:local:cli:
     desc: Run only local CLI tests (with dedicated infrastructure)
     aliases: [e2e:local:cli]

--- a/tests/e2e-production/README.md
+++ b/tests/e2e-production/README.md
@@ -1,0 +1,3 @@
+# E2E tests in production-like environments
+
+This suite runs **end-to-end tests** against **production-like** infrastructure: multi-node or multi-cluster directory deployments and nodes backed by **external OCI registries** (e.g. GHCR, Docker Hub), rather than the single Kind cluster and in-cluster Zot used by [tests/e2e/](../e2e/).

--- a/tests/e2e-production/e2e_production_suite_test.go
+++ b/tests/e2e-production/e2e_production_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_production
+
+import (
+	"testing"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestE2EProduction(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "E2E Production (production-like) Test Suite")
+}

--- a/tests/e2e-production/placeholder_test.go
+++ b/tests/e2e-production/placeholder_test.go
@@ -1,0 +1,15 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_production
+
+import (
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("E2E production suite", func() {
+	ginkgo.It("is configured and runnable", func() {
+		gomega.Expect(true).To(gomega.BeTrue())
+	})
+})


### PR DESCRIPTION
Add production E2E test suite

**Changes**
* New E2E production suite under tests/e2e-production/ (Ginkgo suite + placeholder test).
* tests/README.md and tests/Taskfile.yml updated for the new suite.