### PR TITLE
feat(importer): add allowed tools to MCP server configuration

### DIFF
--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -119,7 +119,12 @@ jobs:
                 ],
                 "env": {
                   "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com"
-                }
+                },
+                "allowedTools": [
+                  "agntcy_oasf_get_schema",
+                  "agntcy_oasf_get_schema_skills",
+                  "agntcy_oasf_get_schema_domains"
+                ]
               }
             },
             "model": "azure:gpt-4o",

--- a/importer/enricher/mcphost.json
+++ b/importer/enricher/mcphost.json
@@ -8,7 +8,12 @@
       ],
       "env": {
         "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com"
-      }
+      },
+      "allowedTools": [
+        "agntcy_oasf_get_schema",
+        "agntcy_oasf_get_schema_skills",
+        "agntcy_oasf_get_schema_domains"
+      ]
     }
   },
   "model": "azure:gpt-4o",


### PR DESCRIPTION
Restrict list of allowed tools in importer pipeline.

This PR aims to address recent failures in the importer action https://github.com/agntcy/dir/actions/runs/23049999811/job/66948498932#step:7:81 related to MCP tool validation. The following tools are problematic: `agntcy_dir_search_local`, `agntcy_dir_verify_name` and `agntcy_oasf_list_versions`. Investigation on these failures will be addressed in a future PR.

Test run successful ✅  https://github.com/agntcy/dir/actions/runs/23053861024