### PR TITLE
feat(dir): amend release commit automatically

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -195,6 +195,8 @@ tasks:
       - |
         {{ .MULTIMOD_BIN }} verify
         {{ .MULTIMOD_BIN }} prerelease --all-module-sets --skip-go-mod-tidy=true --commit-to-different-branch=false
+      - |
+        git commit --amend -S --signoff -m "release(dir): prepare release {{.RELEASE_VERSION}}"
       # Push prepared release
       - task: release:push
 


### PR DESCRIPTION
In the `task release:create` command, the `multimod` command creates a commit that doesn't conform to the project standards (incorrect message, no signoff, no signature)

This PR adds a step to automatically amend this commit