### PR TITLE
ci(dir): reduce e2e test artifact scope

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,20 +188,15 @@ jobs:
         include:
           - artifact_name: coverage-unit
             codecov_flag: unit
-            artifact_path: .coverage/unit
           - artifact_name: coverage-e2e-Local
             codecov_flag: e2e-Local
-            artifact_path: .coverage
           - artifact_name: coverage-e2e-Network
             codecov_flag: e2e-Network
-            artifact_path: .coverage
           # NOTE: Currently MCP and Federation coverage is excluded within Upload E2E coverage artifact job
           # - artifact_name: coverage-e2e-MCP
           #   codecov_flag: e2e-MCP
-          #   coverage_path: .coverage
           # - artifact_name: coverage-e2e-Federation
           #   codecov_flag: e2e-Federation
-          #   coverage_path: .coverage
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -212,7 +207,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.artifact_path }} # NOTE: Image artifacts are store in separate directory than coverage
+          path: .coverage
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3

--- a/.github/workflows/reusable-test-e2e.yaml
+++ b/.github/workflows/reusable-test-e2e.yaml
@@ -118,7 +118,6 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-e2e-${{ matrix.label }}
-          path: |
-            .coverage/**/*.out
+          path: .coverage/**/*.out
           include-hidden-files: true
           retention-days: 1

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -47,7 +47,8 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-unit
-          path: .coverage/unit
+          path: .coverage/**/*.out
+          include-hidden-files: true
           retention-days: 1
 
       - name: Run unit tests


### PR DESCRIPTION
This PR try to reduce the `download-artifact` action failure after tests by skipping packaging not necessary files to the artifacts.

Fixes: https://github.com/agntcy/dir/issues/1151