### PR TITLE
feat(dir): add integration tests for server

### DIFF
--- a/.github/workflows/reusable-test-e2e.yaml
+++ b/.github/workflows/reusable-test-e2e.yaml
@@ -30,6 +30,8 @@ jobs:
             label: "Network"
           - task: e2e:test:daemon:external
             label: "Daemon External"
+          - task: e2e:test:integration-server:default
+            label: "Integration Server"
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Taskfile.deps.yml
+++ b/Taskfile.deps.yml
@@ -299,6 +299,15 @@ tasks:
     status:
       - test -f {{.PRE_COMMIT_PYZ}}
 
+  deps:ginkgo:
+    desc: Install ginkgo
+    run: once
+    cmds:
+      - GOBIN="{{ .BIN_DIR }}" go install github.com/onsi/ginkgo/v2/ginkgo@v{{ .GINKGO_VERSION }}
+      - mv "{{ .BIN_DIR }}/ginkgo" "{{ .GINKGO_BIN }}"
+    status:
+      - test -f "{{ .GINKGO_BIN }}"
+
   ##
   ## Dependency management
   ##

--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -74,6 +74,8 @@ vars:
   TRIVY_BIN: "{{ .BIN_DIR }}/trivy-{{.TRIVY_VERSION}}"
   PRE_COMMIT_VERSION: "4.5.1"
   PRE_COMMIT_PYZ: "{{ .BIN_DIR }}/pre-commit-{{.PRE_COMMIT_VERSION}}.pyz"
+  GINKGO_VERSION: "2.28.1"
+  GINKGO_BIN: "{{ .BIN_DIR }}/ginkgo-{{ .GINKGO_VERSION }}"
 
   ## Coverage related values
   COVERAGE_DIR: '{{ .COVERAGE_DIR | default (print .ROOT_DIR "/.coverage") }}'

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -288,17 +288,37 @@ func (c ConnectionConfig) WithDefaults() ConnectionConfig {
 	return c
 }
 
-//nolint:maintidx
-func LoadConfig() (*Config, error) {
+type ConfigOptions struct {
+	file string
+}
+
+type ConfigOption func(*ConfigOptions)
+
+func WithFile(file string) ConfigOption {
+	return func(opts *ConfigOptions) {
+		opts.file = file
+	}
+}
+
+func LoadConfig(opts ...ConfigOption) (*Config, error) {
+	var options ConfigOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	v := viper.NewWithOptions(
 		viper.KeyDelimiter("."),
 		viper.EnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_")),
 	)
 
-	v.SetConfigName(DefaultConfigName)
+	if options.file != "" {
+		v.SetConfigFile(options.file)
+	} else {
+		v.SetConfigName(DefaultConfigName)
+	}
+
 	v.SetConfigType(DefaultConfigType)
 	v.AddConfigPath(DefaultConfigPath)
-
 	v.SetEnvPrefix(DefaultEnvPrefix)
 	v.AllowEmptyEnv(true)
 	v.AutomaticEnv()

--- a/server/database/database.go
+++ b/server/database/database.go
@@ -107,6 +107,20 @@ func newSQLite(cfg config.SQLiteConfig) (*gormdb.DB, error) {
 
 // newPostgres creates a new database connection using PostgreSQL driver.
 func newPostgres(cfg config.PostgresConfig) (*gormdb.DB, error) {
+	db, err := NewPostgresGormDb(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to PostgreSQL database: %w", err)
+	}
+
+	gdb, err := gormdb.New(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize PostgreSQL database: %w", err)
+	}
+
+	return gdb, nil
+}
+
+func NewPostgresGormDb(cfg config.PostgresConfig) (*gorm.DB, error) {
 	host := cfg.Host
 	if host == "" {
 		host = config.DefaultPostgresHost
@@ -130,17 +144,7 @@ func newPostgres(cfg config.PostgresConfig) (*gormdb.DB, error) {
 	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
 		host, port, cfg.Username, cfg.Password, database, sslMode)
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+	return gorm.Open(postgres.Open(dsn), &gorm.Config{ //nolint:wrapcheck
 		Logger: newCustomLogger(),
 	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to PostgreSQL database: %w", err)
-	}
-
-	gdb, err := gormdb.New(db)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize PostgreSQL database: %w", err)
-	}
-
-	return gdb, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -154,9 +154,26 @@ func newOASFValidator(cfg *config.Config) (corev1.Validator, error) {
 	return v, nil
 }
 
+type ServerOptions struct {
+	database types.DatabaseAPI
+}
+
+type ServerOption func(*ServerOptions)
+
+func WithDatabase(database types.DatabaseAPI) ServerOption {
+	return func(opts *ServerOptions) {
+		opts.database = database
+	}
+}
+
 //nolint:cyclop // This function has been at the limit; refactoring is out of scope.
-func New(ctx context.Context, cfg *config.Config) (*Server, error) {
+func New(ctx context.Context, cfg *config.Config, opts ...ServerOption) (*Server, error) {
 	logger.Debug("Creating server with config", "config", cfg, "version", version.String())
+
+	var o ServerOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
 
 	oasfValidator, err := newOASFValidator(cfg)
 	if err != nil {
@@ -230,9 +247,12 @@ func New(ctx context.Context, cfg *config.Config) (*Server, error) {
 		return nil, fmt.Errorf("failed to create routing: %w", err)
 	}
 
-	databaseAPI, err := database.New(cfg.Database)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create database API: %w", err)
+	databaseAPI := o.database
+	if databaseAPI == nil {
+		databaseAPI, err = database.New(cfg.Database)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create database API: %w", err)
+		}
 	}
 
 	// Create JWT authentication service if enabled

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -34,6 +34,10 @@ includes:
     taskfile: "./e2e/network/testenv/local/Taskfile.testenv.yml"
     internal: true
 
+  e2e:internal:testenv:integration-server:default:
+    taskfile: "./integration/server/testenv/Taskfile.testenv.yml"
+    internal: true
+
 vars:
   #
   # Reusable test matrix defining test cases and their associated test environments.
@@ -47,13 +51,13 @@ vars:
   #       <env_name>: <testenv configuration>
   #
   # Extending matrix:
-  #   - When adding a new test case, simply add a new entry under TEST_MATRIX 
-  #     with the appropriate testenv configurations. 
+  #   - When adding a new test case, simply add a new entry under TEST_MATRIX
+  #     with the appropriate testenv configurations.
   #   - When adding a new test environment for an existing test case,
   #     add a new entry under the "envs" section for that test case.
-  #   - If your test environment requires specific setup/teardown logic, 
+  #   - If your test environment requires specific setup/teardown logic,
   #     import the corresponding Taskfile with the necessary "up" and "down" tasks.
-  # 
+  #
   # Notes:
   #   - Each test case can have multiple environments, and the test execution logic will
   #     run the appropriate setup and tests based on user input.
@@ -82,6 +86,11 @@ vars:
         envs:
           kind: "{{.ROOT_DIR}}/tests/e2e/network/testenv/kind/test-config.yaml"
           local: "{{.ROOT_DIR}}/tests/e2e/network/testenv/local/test-config.yaml"
+
+      integration-server:
+        go_test_suite: "{{.ROOT_DIR}}/tests/integration/server"
+        envs:
+          default: "{{.ROOT_DIR}}/tests/integration/server/testenv/test-config.yaml"
 
   # Set GOCOVERDIR for supported testenv coverage collection.
   # This relies on the convention that testenv tasks will pass
@@ -214,7 +223,7 @@ tasks:
           -i={{.GOCOVERDIR}} \
           -pkg={{.COVERAGE_PKGS}} \
           -o={{.MERGE_GOCOVERDIR}} || exit 0
-      
+
       # Generate combined coverage report
       - |
         go tool covdata textfmt \

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/agntcy/dir-runtime/store v1.3.0 // indirect
 	github.com/agntcy/dir-runtime/utils v1.3.0 // indirect
 	github.com/agntcy/dir/reconciler v1.3.0 // indirect
-	github.com/agntcy/dir/server v1.3.0 // indirect
+	github.com/agntcy/dir/server v1.3.0
 	github.com/agntcy/dir/utils v1.3.0 // indirect
 	github.com/agntcy/oasf-sdk/pkg v1.0.5 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
@@ -143,6 +143,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/briandowns/spinner v1.23.2 // indirect
+	github.com/brianvoe/gofakeit/v7 v7.14.1
 	github.com/carabiner-dev/attestation v0.2.1 // indirect
 	github.com/casbin/casbin/v2 v2.135.0 // indirect
 	github.com/casbin/govaluate v1.10.0 // indirect
@@ -437,7 +438,7 @@ require (
 	github.com/open-policy-agent/opa v1.16.1 // indirect
 	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20260422183030-ed885fa76559 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/openvex/discovery v0.1.1-0.20240802171711-7c54efc57553 // indirect
 	github.com/openvex/go-vex v0.2.8 // indirect
@@ -624,7 +625,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/postgres v1.6.0 // indirect
-	gorm.io/gorm v1.31.1 // indirect
+	gorm.io/gorm v1.31.1
 	helm.sh/helm/v3 v3.20.2 // indirect
 	k8s.io/api v0.36.0 // indirect
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
@@ -643,7 +644,7 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.50.0 // indirect
 	mvdan.cc/sh/v3 v3.13.1 // indirect
-	oras.land/oras-go/v2 v2.6.0 // indirect
+	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/controller-runtime v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -378,6 +378,8 @@ github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2
 github.com/briandowns/spinner v1.23.2/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=
 github.com/brianvoe/gofakeit/v6 v6.28.0/go.mod h1:Xj58BMSnFqcn/fAQeSK+/PLtC5kSb7FJIq4JyGa8vEs=
+github.com/brianvoe/gofakeit/v7 v7.14.1 h1:a7fe3fonbj0cW3wgl5VwIKfZtiH9C3cLnwcIXWT7sow=
+github.com/brianvoe/gofakeit/v7 v7.14.1/go.mod h1:QXuPeBw164PJCzCUZVmgpgHJ3Llj49jSLVkKPMtxtxA=
 github.com/bshuster-repo/logrus-logstash-hook v1.1.0 h1:o2FzZifLg+z/DN1OFmzTWzZZx/roaqt8IPZCIVco8r4=
 github.com/bshuster-repo/logrus-logstash-hook v1.1.0/go.mod h1:Q2aXOe7rNuPgbBtPCOzYyWDvKX7+FpxE5sRdvcPoui0=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,28 @@
+# Integration tests
+
+An integration test is similar to an end-to-end test in that they
+both test the software with dependencies included (e.g. with Postgres, Zot running)
+
+The difference between an integration test and an end-to-end test is that:
+- E2E tests use black-box testing to test workflows (higher level)
+- Integration tests use white-box testing to test side effects (lower level)
+
+E2E tests are higher level than integration tests:
+- E2E tests may include more dependencies, the setup may be more complex
+- Integration tests may include less dependencies, the setup may be less complex
+
+Ideally, integration tests are more isolated than E2E tests
+
+For example:
+- Each test has their own OCI repository to avoid conflicts in Zot
+- Each test is executed in a database transaction to avoid conflicts in Postgres
+
+As a result, integration tests can be executed in parallel so they scale better
+than E2E tests
+
+Note: executing each test in a database transaction is standard practice.
+Many web frameworks do the same - see *Django*'s [TransactionTestCase][1]
+or *Laravel*'s [RefreshDatabase][2]
+
+[1]: https://docs.djangoproject.com/en/6.0/topics/testing/tools/#django.test.TransactionTestCase
+[2]: https://laravel.com/docs/13.x/database-testing

--- a/tests/integration/server/README.md
+++ b/tests/integration/server/README.md
@@ -1,0 +1,3 @@
+# Integration tests for the API server
+
+This suite runs the integration tests for the API server

--- a/tests/integration/server/integration_server_suite_test.go
+++ b/tests/integration/server/integration_server_suite_test.go
@@ -1,0 +1,18 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"testing"
+
+	"github.com/agntcy/dir/tests/test_utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+func TestIntegrationServer(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	test_utils.InitGofakeit()
+	ginkgo.RunSpecs(t, "Integration Test Suite")
+}

--- a/tests/integration/server/push_test.go
+++ b/tests/integration/server/push_test.go
@@ -1,0 +1,163 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"sort"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	storev1 "github.com/agntcy/dir/api/store/v1"
+	gormmodels "github.com/agntcy/dir/server/database/gorm"
+	"github.com/agntcy/dir/tests/test_utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"gorm.io/gorm"
+)
+
+var _ = ginkgo.Describe("Push", func() {
+	ginkgo.It("record", func(ctx ginkgo.SpecContext) {
+		record := test_utils.FakeRecord()
+		sort.Slice(record.Skills, func(i, j int) bool { return record.Skills[i].Id < record.Skills[j].Id })
+		sort.Slice(record.Modules, func(i, j int) bool { return record.Modules[i].Name < record.Modules[j].Name })
+
+		c := storev1.NewStoreServiceClient(t.conn)
+		stream, err := c.Push(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = stream.Send(&corev1.Record{Data: record.PbStruct()})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = stream.CloseSend()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		response, err := stream.Recv()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		cid := response.GetCid()
+		gomega.Expect(cid).NotTo(gomega.BeEmpty())
+		gomega.Expect(cid).NotTo(gomega.BeNil())
+
+		// ORAS assertions
+		manifestDesc, err := t.repository.Resolve(ctx, cid)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(manifestDesc.MediaType).To(gomega.Equal(ociv1.MediaTypeImageManifest))
+		gomega.Expect(manifestDesc.Size).To(gomega.BeNumerically(">", 0))
+		gomega.Expect(manifestDesc.Digest).To(gomega.HavePrefix("sha256:"))
+
+		manifestReader, err := t.repository.Fetch(ctx, manifestDesc)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer manifestReader.Close()
+
+		manifestData, err := io.ReadAll(manifestReader)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(manifestData).NotTo(gomega.BeEmpty())
+
+		var manifest ociv1.Manifest
+
+		err = json.Unmarshal(manifestData, &manifest)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(manifest.Versioned.SchemaVersion).To(gomega.Equal(2))
+		gomega.Expect(manifest.MediaType).To(gomega.Equal(ociv1.MediaTypeImageManifest))
+		gomega.Expect(manifest.ArtifactType).To(gomega.Equal(ociv1.MediaTypeImageManifest))
+		gomega.Expect(manifest.Config.MediaType).To(gomega.Equal(ociv1.MediaTypeEmptyJSON))
+
+		annotations := manifest.Annotations
+		gomega.Expect(annotations).To(gomega.HaveKey("org.agntcy.dir/cid"))
+		gomega.Expect(annotations).To(gomega.HaveKey("org.agntcy.dir/created-at"))
+		gomega.Expect(annotations).To(gomega.HaveKey("org.agntcy.dir/name"))
+		gomega.Expect(annotations).To(gomega.HaveKey("org.agntcy.dir/oasf-version"))
+		gomega.Expect(annotations).To(gomega.HaveKey("org.agntcy.dir/schema-version"))
+		gomega.Expect(annotations).To(gomega.HaveKey("org.agntcy.dir/type"))
+		gomega.Expect(annotations).To(gomega.HaveKey("org.agntcy.dir/version"))
+		gomega.Expect(annotations).To(gomega.HaveKey("org.opencontainers.image.created"))
+		gomega.Expect(annotations["org.agntcy.dir/cid"]).To(gomega.Equal(cid))
+		gomega.Expect(annotations["org.agntcy.dir/created-at"]).To(gomega.Equal(record.CreatedAt))
+		gomega.Expect(annotations["org.agntcy.dir/name"]).To(gomega.Equal(record.Name))
+		gomega.Expect(annotations["org.agntcy.dir/oasf-version"]).To(gomega.Equal("1.0.0"))
+		gomega.Expect(annotations["org.agntcy.dir/schema-version"]).To(gomega.Equal(record.SchemaVersion))
+		gomega.Expect(annotations["org.agntcy.dir/type"]).To(gomega.Equal("record"))
+		gomega.Expect(annotations["org.agntcy.dir/version"]).To(gomega.Equal(record.Version))
+		gomega.Expect(annotations["org.opencontainers.image.created"]).ToNot(gomega.BeEmpty())
+		gomega.Expect(annotations["org.opencontainers.image.created"]).ToNot(gomega.BeNil())
+		gomega.Expect(annotations["org.opencontainers.image.created"]).ToNot(gomega.Equal(record.CreatedAt))
+
+		gomega.Expect(manifest.Layers).To(gomega.HaveLen(1))
+		layerDesc := manifest.Layers[0]
+		layerReader, err := t.repository.Fetch(ctx, layerDesc)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer layerReader.Close()
+
+		layerData, err := io.ReadAll(layerReader)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(layerData).NotTo(gomega.BeEmpty())
+
+		r, err := json.Marshal(record)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(layerData).To(gomega.MatchJSON(r))
+
+		layerDigest, err := corev1.CalculateDigest(layerData)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(layerDigest).To(gomega.Equal(layerDesc.Digest))
+		expectedCID, err := corev1.ConvertDigestToCID(layerDesc.Digest)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(cid).To(gomega.Equal(expectedCID))
+
+		// GORM assertions
+		recordModel, err := gorm.G[gormmodels.Record](t.db).Where("record_cid = ?", cid).Take(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(recordModel.RecordCID).To(gomega.Equal(cid))
+		gomega.Expect(recordModel.Name).To(gomega.Equal(record.Name))
+		gomega.Expect(recordModel.SchemaVersion).To(gomega.Equal(record.SchemaVersion))
+		gomega.Expect(recordModel.Version).To(gomega.Equal(record.Version))
+		gomega.Expect(recordModel.OASFCreatedAt).To(gomega.Equal(record.CreatedAt))
+		gomega.Expect(recordModel.Authors).To(gomega.Equal(record.Authors))
+		gomega.Expect(recordModel.Signed).To(gomega.BeFalse())
+		gomega.Expect(recordModel.CreatedAt).ToNot(gomega.BeNil())
+		gomega.Expect(recordModel.UpdatedAt).ToNot(gomega.BeNil())
+
+		skillModels, err := gorm.G[gormmodels.Skill](t.db).Where("record_cid = ?", cid).Order("skill_id").Find(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(skillModels).To(gomega.HaveLen(len(record.Skills)))
+
+		for idx, skillModel := range skillModels {
+			skill := record.Skills[idx]
+			gomega.Expect(skillModel.Name).To(gomega.Equal(skill.Name))
+			gomega.Expect(skillModel.SkillID).To(gomega.Equal(uint64(skill.Id)))
+			gomega.Expect(skillModel.RecordCID).To(gomega.Equal(cid))
+			gomega.Expect(skillModel.CreatedAt).ToNot(gomega.BeNil())
+			gomega.Expect(skillModel.UpdatedAt).ToNot(gomega.BeNil())
+			gomega.Expect(skillModel.ID).To(gomega.BeNumerically(">", 0))
+		}
+
+		moduleModels, err := gorm.G[gormmodels.Module](t.db).Where("record_cid = ?", cid).Order("name").Find(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(moduleModels).To(gomega.HaveLen(len(record.Modules)))
+
+		for idx, moduleModel := range moduleModels {
+			module := record.Modules[idx]
+			gomega.Expect(moduleModel.Name).To(gomega.Equal(module.Name))
+			gomega.Expect(moduleModel.RecordCID).To(gomega.Equal(cid))
+			gomega.Expect(moduleModel.CreatedAt).ToNot(gomega.BeNil())
+			gomega.Expect(moduleModel.UpdatedAt).ToNot(gomega.BeNil())
+			gomega.Expect(moduleModel.ID).To(gomega.BeNumerically(">", 0))
+		}
+
+		locatorModels, err := gorm.G[gormmodels.Locator](t.db).Where("record_cid = ?", cid).Find(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(locatorModels).To(gomega.HaveLen(len(record.Locators)))
+
+		for idx, locatorModel := range locatorModels {
+			locator := record.Locators[idx]
+
+			gomega.Expect(locatorModel.RecordCID).To(gomega.Equal(cid))
+			gomega.Expect(locatorModel.Type).To(gomega.Equal(locator.LocatorType))
+			gomega.Expect(locatorModel.URL).To(gomega.Equal(locator.Urls[0]))
+			gomega.Expect(locatorModel.CreatedAt).ToNot(gomega.BeNil())
+			gomega.Expect(locatorModel.UpdatedAt).ToNot(gomega.BeNil())
+			gomega.Expect(locatorModel.ID).To(gomega.BeNumerically(">", 0))
+		}
+	})
+})

--- a/tests/integration/server/setup.go
+++ b/tests/integration/server/setup.go
@@ -1,0 +1,213 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"context"
+	"crypto/sha1" //nolint:gosec
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"net"
+	"path/filepath"
+	"runtime"
+
+	"github.com/agntcy/dir/server"
+	"github.com/agntcy/dir/server/config"
+	"github.com/agntcy/dir/server/database" //nolint:typecheck
+	gormdb "github.com/agntcy/dir/server/database/gorm"
+	"github.com/agntcy/dir/server/events"
+	"github.com/agntcy/dir/server/store/oci"
+	"github.com/agntcy/dir/server/types"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"gorm.io/gorm"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+const DefaultConfig = "./testenv/test-config.yaml"
+
+const (
+	bufSize = 1024 * 1024
+)
+
+type TestVars struct {
+	options    types.APIOptions
+	repository *remote.Repository
+	db         *gorm.DB
+	server     *server.Server
+	conn       *grpc.ClientConn
+}
+
+var (
+	conf *config.Config
+	t    TestVars
+)
+
+var _ = ginkgo.BeforeSuite(func() {
+	conf = loadConfig()
+})
+
+func init() {
+	flag.String("test-config", "", "Absolute path to test configuration file (optional)")
+}
+
+func loadConfig() *config.Config {
+	configFile := getConfigFile()
+	c, err := config.LoadConfig(config.WithFile(configFile))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return c
+}
+
+func getConfigFile() string {
+	f := flag.Lookup("test-config")
+	if f != nil && f.Value.String() != "" {
+		return f.Value.String()
+	} else {
+		_, filename, _, _ := runtime.Caller(0)
+		base := filepath.Dir(filename)
+
+		return filepath.Join(base, DefaultConfig)
+	}
+}
+
+var _ = ginkgo.BeforeEach(func(ctx ginkgo.SpecContext) {
+	t = TestVars{}
+	t.options = getOptions()
+	t.repository = newRepository(t.options)
+
+	// Wrap the spec in a database transaction.
+	db := newDb(t.options)
+	tx := db.Begin()
+	t.db = tx
+
+	t.server, t.conn = startServer(ctx, t.options, t.db)
+})
+
+var _ = ginkgo.AfterEach(func(ctx ginkgo.SpecContext) {
+	errors := []error{}
+
+	err := t.conn.Close()
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	t.server.Close(ctx)
+
+	t.db.Rollback()
+
+	if t.db.Error != nil {
+		errors = append(errors, t.db.Error)
+	}
+
+	err = deleteSpecRepository(ctx)
+	if err != nil {
+		errors = append(errors, err)
+	}
+
+	if 0 < len(errors) {
+		ginkgo.Fail(fmt.Sprintf("AfterEach errors: %v", errors))
+	}
+})
+
+func newRepository(options types.APIOptions) *remote.Repository {
+	repository, err := oci.NewORASRepository(options.Config().Store.OCI)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return repository
+}
+
+func newDb(options types.APIOptions) *gorm.DB {
+	db, err := database.NewPostgresGormDb(options.Config().Database.Postgres)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return db
+}
+
+// startServer starts a gRPC server in the background for the current spec.
+func startServer(ctx context.Context, options types.APIOptions, db *gorm.DB) (*server.Server, *grpc.ClientConn) {
+	databaseAPI, err := gormdb.New(db)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	s, err := server.New(ctx, options.Config(), server.WithDatabase(databaseAPI))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	grpcServer := s.GRPCServer()
+	listener := bufconn.Listen(bufSize)
+
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil {
+			panic(err)
+		}
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(bufDialer(listener)),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return s, conn
+}
+
+func bufDialer(listener *bufconn.Listener) func(context.Context, string) (net.Conn, error) {
+	return func(ctx context.Context, _ string) (net.Conn, error) {
+		return listener.DialContext(ctx)
+	}
+}
+
+// getOptions generates the options for the current spec.
+// It's assumed the environment variables are already loaded at this stage.
+func getOptions() types.APIOptions {
+	c := conf
+	c.Store.OCI.RepositoryName = fmt.Sprintf(
+		"%s-%d-%s",
+		c.Store.OCI.RepositoryName,
+		ginkgo.GinkgoParallelProcess(),
+		getCurrentSpecID(),
+	)
+
+	options := types.NewOptions(c)
+	eventBus := events.NewSafeEventBus(nil)
+
+	return options.WithEventBus(eventBus)
+}
+
+// getCurrentSpecID calculates the unique ID of the current spec.
+// The ID is an 8 character long hexadecimal string.
+func getCurrentSpecID() string {
+	report := ginkgo.CurrentSpecReport()
+	fullText := report.FullText()
+	checksum := sha1.Sum([]byte(fullText)) //nolint:gosec
+	encoded := hex.EncodeToString(checksum[:])
+
+	return encoded[:8]
+}
+
+// deleteSpecRepository deletes the repository associated with the current spec.
+func deleteSpecRepository(ctx context.Context) error {
+	// Unfortunately, there's no ORAS operation or Zot endpoint to delete a repository.
+	// So, the only way to delete a repository is to delete its contents.
+	return t.repository.Tags(ctx, "", func(tags []string) error { //nolint:wrapcheck
+		for _, tag := range tags {
+			desc, err := t.repository.Resolve(ctx, tag)
+			if err != nil {
+				return fmt.Errorf("failed to resolve tag %s: %w", tag, err)
+			}
+
+			err = t.repository.Delete(ctx, desc)
+			if err != nil {
+				return fmt.Errorf("failed to delete content %s: %w", tag, err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/tests/integration/server/testenv/Taskfile.testenv.yml
+++ b/tests/integration/server/testenv/Taskfile.testenv.yml
@@ -1,0 +1,19 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+version: "3"
+
+tasks:
+  up:
+    vars:
+      COMPOSE_PATH: "{{.ROOT_DIR}}/tests/integration/server/testenv/docker-compose.yml"
+    cmds:
+      - |
+        docker compose -f {{.COMPOSE_PATH}} up --wait -d
+
+  down:
+    vars:
+      COMPOSE_PATH: "{{.ROOT_DIR}}/tests/integration/server/testenv/docker-compose.yml"
+    cmds:
+      - |
+        docker compose -f {{.COMPOSE_PATH}} down

--- a/tests/integration/server/testenv/docker-compose.yml
+++ b/tests/integration/server/testenv/docker-compose.yml
@@ -1,0 +1,41 @@
+name: dir-integration-tests-for-server
+services:
+  zot:
+    image: ghcr.io/project-zot/zot:v2.1.15
+    ports:
+      - 5556:5000
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+  postgres:
+    image: docker.io/bitnami/postgresql@sha256:e8b68936d05ee665974430bb4765fedcdc5c9ba399e133e120e2deed77f54dbf
+    environment:
+      POSTGRES_USER: ditfs_user
+      POSTGRES_PASSWORD: ditfs_pass
+      POSTGRES_DB: ditfs_db
+    ports:
+      - 5433:5432
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    healthcheck:
+      test: pg_isready -U ditfs_user -d ditfs_pass || exit 1
+      interval: 10s
+      retries: 60
+      start_period: 10s
+  oasf:
+    image: ghcr.io/agntcy/oasf-server:latest
+    ports:
+      - 8092:8080
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+networks:
+  default:
+    name: dir-integration-tests-for-server-network

--- a/tests/integration/server/testenv/test-config.yaml
+++ b/tests/integration/server/testenv/test-config.yaml
@@ -1,0 +1,64 @@
+listen_address: "0.0.0.0:8888"
+oasf_api_validation:
+  schema_url: localhost:8092
+logging:
+  verbose: false
+authn:
+  enabled: false
+  mode: x509
+  socket_path:
+  audiences:
+authz:
+  enabled: false
+  enforcer_policy_file_path: /etc/agntcy/dir/authz_policies.csv
+store:
+  provider: oci
+  oci:
+    local_dir:
+    cache_dir:
+    registry_address: localhost:5556
+    repository_name: dir
+    auth_config:
+      insecure: true
+      username:
+      password:
+      access_token:
+      refresh_token:
+routing:
+  listen_address: /ip4/0.0.0.0/tcp/8999
+  directory_api_address:
+  bootstrap_peers:
+  key_path:
+  datastore_dir:
+  gossipsub:
+    enabled: true
+database:
+  type: postgres
+  postgres:
+    host: localhost
+    port: 5433
+    database: ditfs_db
+    username: ditfs_user
+    password: ditfs_pass
+    ssl_mode: disable
+sync:
+  auth_config:
+    username:
+    password:
+publication:
+  scheduler_interval: 1h
+  worker_count: 1
+  worker_timeout: 30m
+events:
+  subscriber_buffer_size: 100
+  log_slow_consumers: true
+  log_published_events: false
+metrics:
+  enabled: true
+  address: :9090
+ratelimit:
+  enabled: false
+  global_rps: 0
+  global_burst: 0
+  per_client_rps: 100
+  per_client_burst: 200

--- a/tests/test_utils/gofakeit.go
+++ b/tests/test_utils/gofakeit.go
@@ -1,0 +1,34 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package test_utils
+
+import (
+	"time"
+
+	"github.com/brianvoe/gofakeit/v7"
+)
+
+var GofakeitGenericLookups = map[string]gofakeit.Info{
+	"pastdaterfc3339": {
+		Display:     "PastDateRFC3339",
+		Category:    "datetime",
+		Description: "PastDateRFC3339 is the same as PastDate but in RFC-3339 format",
+		Example:     "2024-09-10T23:20:50.520Z",
+		Output:      "string",
+		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
+			return f.PastDate().Format(time.RFC3339), nil
+		},
+	},
+}
+
+func InitGofakeit() {
+	AddFuncLookups(GofakeitGenericLookups)
+	AddFuncLookups(GofakeitOASF100Lookups)
+}
+
+func AddFuncLookups(lookups map[string]gofakeit.Info) {
+	for functionName, info := range lookups {
+		gofakeit.AddFuncLookup(functionName, info)
+	}
+}

--- a/tests/test_utils/oasf_100.go
+++ b/tests/test_utils/oasf_100.go
@@ -1,0 +1,225 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package test_utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"github.com/brianvoe/gofakeit/v7"
+	"github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var modules = []Module{
+	{
+		Name: "integration/mcp",
+		Data: MCPData{
+			Name: "github-mcp-server",
+			Connections: []MCPServerConnection{
+				{
+					Type:    "stdio",
+					Command: "docker",
+					Args: []string{
+						"run",
+						"-i",
+						"--rm",
+						"-e",
+						"GITHUB_PERSONAL_ACCESS_TOKEN",
+						"ghcr.io/github/github-mcp-server",
+					},
+					EnvVars: []EnvironmentVariable{
+						{
+							Name:         "GITHUB_PERSONAL_ACCESS_TOKEN",
+							DefaultValue: "",
+							Description:  "Secret value for GITHUB_PERSONAL_ACCESS_TOKEN",
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		Name: "integration/a2a",
+		Data: A2AData{
+			CardSchemaVersion: "v1.0.0",
+			// TODO: Add A2A Card faker
+			CardData: map[string]any{
+				"protocolVersions": []string{"0.2.6"},
+				"name":             "burger_seller_agent",
+				"description":      "Helps with creating burger orders",
+			},
+		},
+	},
+}
+
+var skills = []Skill{
+	{Id: 101, Name: "natural_language_processing/natural_language_understanding"},                            //nolint:mnd
+	{Id: 10101, Name: "natural_language_processing/natural_language_understanding/contextual_comprehension"}, //nolint:mnd
+	{Id: 10102, Name: "natural_language_processing/natural_language_understanding/semantic_understanding"},   //nolint:mnd
+	{Id: 108, Name: "natural_language_processing/ethical_interaction"},                                       //nolint:mnd
+	{Id: 201, Name: "images_computer_vision/image_segmentation"},                                             //nolint:mnd
+	{Id: 1504, Name: "advanced_reasoning_planning/hypothesis_generation"},                                    //nolint:mnd
+}
+
+var GofakeitOASF100Lookups = map[string]gofakeit.Info{
+	"oasf100skills": {
+		Display:     "OASF100Skills",
+		Category:    "oasf",
+		Description: "OASF 1.0.0 skills (a slice of 1 to 5 skills)",
+		Output:      "Skills",
+		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
+			skillsCopy := make(Skills, len(skills))
+			copy(skillsCopy, skills)
+
+			n := f.Number(1, 5) //nolint:mnd
+			f.ShuffleAnySlice(skillsCopy)
+
+			return skillsCopy[:n], nil
+		},
+	},
+	"oasf100modules": {
+		Display:     "OASF100Modules",
+		Category:    "oasf",
+		Description: "OASF 1.0.0 modules (a slice of 1 to 2 modules)",
+		Output:      "Modules",
+		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
+			modulesCopy := make(Modules, len(modules))
+			copy(modulesCopy, modules)
+
+			n := f.Number(1, 2) //nolint:mnd
+			f.ShuffleAnySlice(modulesCopy)
+
+			return modulesCopy[:n], nil
+		},
+	},
+	"oasf100recordname": {
+		Display:     "OASF100RecordName",
+		Category:    "oasf",
+		Description: "OASF 1.0.0 record name",
+		Example:     "Marketing Strategy Agent",
+		Output:      "string",
+		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
+			return fmt.Sprintf("%s Agent", gofakeit.JobTitle()), nil
+		},
+	},
+	"oasf100authors": {
+		Display:     "OASF100Authors",
+		Category:    "oasf",
+		Description: "OASF 1.0.0 authors",
+		Output:      "[]string",
+		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
+			n := f.Number(1, 5) //nolint:mnd
+			authors := []string{}
+
+			for range n {
+				author := f.Company()
+				if !slices.Contains(authors, author) {
+					authors = append(authors, author)
+				}
+			}
+
+			return authors, nil
+		},
+	},
+}
+
+// Skill represents an OASF 1.0.0 Skill category
+// https://schema.oasf.outshift.com/1.0.0/skill_categories
+type Skill struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// The Skills type alias is necessary for Gofakeit to work
+// (Gofakeit doesn't work with anonymous slices).
+type Skills []Skill
+
+// Locator represents an OASF 1.0.0 Locator object
+// https://schema.oasf.outshift.com/1.0.0/objects/locator
+type Locator struct {
+	LocatorType string   `fake:"{randomstring:[binary,container_image,helm_chart,package,source_code,unspecified,url]}" json:"type"`
+	Urls        []string `fake:"{url}"                                                                                  json:"urls"`
+}
+
+// Module represents an OASF 1.0.0 Module category
+// https://schema.oasf.outshift.com/1.0.0/module_categories
+type Module struct {
+	Name string `json:"name"`
+	Data any    `json:"data"`
+}
+
+// The Modules type alias is necessary for Gofakeit to work
+// (Gofakeit doesn't work with anonymous slices).
+type Modules []Module
+
+// MCPData represents an OASF 1.0.0 MCP Data object
+// https://schema.oasf.outshift.com/1.0.0/objects/mcp_data
+type MCPData struct {
+	Name        string                `json:"name"`
+	Connections []MCPServerConnection `json:"connections"`
+}
+
+// MCPServerConnection represents an OASF 1.0.0 MCP Server Connection object
+// https://schema.oasf.outshift.com/1.0.0/objects/mcp_server_connection
+type MCPServerConnection struct {
+	Type    string                `fake:"{randomstring:[sse,stdio,streamable-http]}" json:"type"`
+	Args    []string              `json:"args"`
+	EnvVars []EnvironmentVariable `json:"env_vars"`
+	Headers map[string]string     `json:"headers"`
+	Command string                `json:"command,omitempty"`
+	Url     string                `json:"url,omitempty"`
+}
+
+// EnvironmentVariable represents an OASF 1.0.0 Environment Variable object
+// https://schema.oasf.outshift.com/1.0.0/objects/env_var
+type EnvironmentVariable struct {
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	DefaultValue string `json:"default_value"`
+	Required     bool   `json:"required"`
+}
+
+// A2AData represents an OASF 1.0.0 A2A Data object
+// https://schema.oasf.outshift.com/1.0.0/objects/a2a_data
+type A2AData struct {
+	CardData          any    `json:"card_data"`
+	CardSchemaVersion string `fake:"{appversion}" json:"card_schema_version"`
+}
+
+// Record represents an OASF 1.0.0 Record object
+// https://schema.oasf.outshift.com/1.0.0/objects/record
+type Record struct {
+	Name          string    `fake:"{oasf100recordname}"  json:"name"`
+	SchemaVersion string    `fake:"1.0.0"                json:"schema_version"`
+	Version       string    `fake:"{appversion}"         json:"version"`
+	Description   string    `fake:"{productdescription}" json:"description"`
+	Authors       []string  `fake:"{oasf100authors}"     json:"authors"`
+	CreatedAt     string    `fake:"{pastdaterfc3339}"    json:"created_at"`
+	Skills        Skills    `fake:"{oasf100skills}"      json:"skills"`
+	Locators      []Locator `fakesize:"1"                json:"locators"`
+	Modules       Modules   `fake:"{oasf100modules}"     json:"modules"`
+}
+
+func FakeRecord() *Record {
+	var record Record
+
+	err := gofakeit.Struct(&record)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	return &record
+}
+
+func (r *Record) PbStruct() *structpb.Struct {
+	bytes, err := json.Marshal(r)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	var record map[string]*structpb.Value
+
+	err = json.Unmarshal(bytes, &record)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return &structpb.Struct{Fields: record}
+}


### PR DESCRIPTION
Add a suite of integration tests for testing the API server. The main benefits are:

- white-box testing
- better isolation than E2E tests:
  - separate OCI repositroy per test to avoid conflicts in Zot
  - tests are executed in a database transaction to avoid conflicts in Postgres
- parallel execution

For more info see `README.md`:

https://github.com/agntcy/dir/pull/1093/changes#diff-26b30a17d0427f4dac432205fb815e5303f32f5d61851792cb9d6d9adaef0d52R1
