### PR TITLE
fix(ci): include package-lock.json in docker builds to fix sdk e2e tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,5 @@ tmp/
 .DS_Store
 
 **/node_modules
-**/package-lock.json
 **/.venv
 **/uv.lock

--- a/tests/e2e/sdk/Dockerfile
+++ b/tests/e2e/sdk/Dockerfile
@@ -25,7 +25,7 @@ RUN uv sync --all-packages
 RUN apk add --update --no-cache nodejs npm
 
 WORKDIR /tmp/dir-js
-RUN npm install
+RUN npm ci
 
 WORKDIR /tmp
 


### PR DESCRIPTION
The federation E2E test fails with `Could not resolve "./client" from "src/index.ts"` because `.dockerignore` excluded the lockfile. Without it, `npm install` resolves the latest dependencies, pulling `rollup@4.60.0` which has a TypeScript module resolution regression. The pinned `rollup@4.59.0` in the lockfile works correctly.

**Changes**
* Remove `**/package-lock.json` from `.dockerignore` so the JS SDK lockfile is included in Docker builds
* Switch `npm install` to `npm ci` in the SDK test Dockerfile for deterministic installs