### PR TITLE
feat(dir): support constrained wildcard matching for GitHub workflow principals

### DIFF
--- a/auth/authzserver/config.go
+++ b/auth/authzserver/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 )
 
 // GitHub OIDC issuer URL.
@@ -69,9 +70,11 @@ type PrincipalTypeConfig struct {
 // OIDCRole defines permissions and principal assignments.
 // Principals use user:{iss}:{sub}, client:{iss}:{client_id}, or ghwf:...
 type OIDCRole struct {
-	AllowedMethods  []string `yaml:"allowedMethods"`
-	Users           []string `yaml:"users"`
-	Clients         []string `yaml:"clients"`
+	AllowedMethods []string `yaml:"allowedMethods"`
+	Users          []string `yaml:"users"`
+	Clients        []string `yaml:"clients"`
+	// GitHubWorkflows supports exact principals and optional '*' wildcard
+	// for ghwf principals only (e.g. ...:ref:refs/heads/*).
 	GitHubWorkflows []string `yaml:"githubWorkflows"`
 }
 
@@ -157,9 +160,55 @@ func (c *OIDCConfig) validateRoles() error {
 		if len(role.AllowedMethods) == 0 {
 			return fmt.Errorf("role %q has no allowedMethods", roleName)
 		}
+
+		for _, workflowPrincipal := range role.GitHubWorkflows {
+			if strings.Contains(workflowPrincipal, "*") && !isSupportedGitHubWorkflowWildcard(workflowPrincipal) {
+				return fmt.Errorf(
+					"role %q has invalid githubWorkflows wildcard %q: only one '*' is supported, it must be at the end, and only in ghwf ...:ref:refs/heads/<branch>*",
+					roleName,
+					workflowPrincipal,
+				)
+			}
+		}
 	}
 
 	return nil
+}
+
+// isSupportedGitHubWorkflowWildcard enforces a constrained wildcard format:
+// - principal must start with ghwf:repo:
+// - exactly one '*' is allowed
+// - '*' must be the final character
+// - wildcard must be inside :ref:refs/heads/<branch>* segment.
+func isSupportedGitHubWorkflowWildcard(principal string) bool {
+	const branchRefPrefix = ":ref:refs/heads/"
+
+	if !strings.HasPrefix(principal, "ghwf:repo:") {
+		return false
+	}
+
+	if strings.Count(principal, "*") != 1 {
+		return false
+	}
+
+	if !strings.HasSuffix(principal, "*") {
+		return false
+	}
+
+	refIdx := strings.Index(principal, branchRefPrefix)
+	if refIdx < 0 {
+		return false
+	}
+
+	starPos := len(principal) - 1
+	minBranchStart := refIdx + len(branchRefPrefix)
+
+	// The wildcard must be in the branch segment.
+	if starPos < minBranchStart {
+		return false
+	}
+
+	return true
 }
 
 func (c *OIDCConfig) normalizePublicPaths() {

--- a/auth/authzserver/config_test.go
+++ b/auth/authzserver/config_test.go
@@ -181,6 +181,69 @@ func TestOIDCConfig_Validate(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "valid githubWorkflow wildcard in refs heads branch suffix",
+			config: &OIDCConfig{
+				Claims: ClaimsConfig{UserID: "sub"},
+				Roles: map[string]OIDCRole{
+					"ci-oidc-test": {
+						AllowedMethods: []string{"/agntcy.dir.search.v1.SearchService/SearchCIDs"},
+						GitHubWorkflows: []string{
+							"ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/heads/feat/*",
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid githubWorkflow wildcard with multiple stars",
+			config: &OIDCConfig{
+				Claims: ClaimsConfig{UserID: "sub"},
+				Roles: map[string]OIDCRole{
+					"ci-oidc-test": {
+						AllowedMethods: []string{"/agntcy.dir.search.v1.SearchService/SearchCIDs"},
+						GitHubWorkflows: []string{
+							"ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/heads/*/*",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid githubWorkflows wildcard",
+		},
+		{
+			name: "invalid githubWorkflow wildcard not at end",
+			config: &OIDCConfig{
+				Claims: ClaimsConfig{UserID: "sub"},
+				Roles: map[string]OIDCRole{
+					"ci-oidc-test": {
+						AllowedMethods: []string{"/agntcy.dir.search.v1.SearchService/SearchCIDs"},
+						GitHubWorkflows: []string{
+							"ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/heads/*:env:dev",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid githubWorkflows wildcard",
+		},
+		{
+			name: "invalid githubWorkflow wildcard outside refs heads",
+			config: &OIDCConfig{
+				Claims: ClaimsConfig{UserID: "sub"},
+				Roles: map[string]OIDCRole{
+					"ci-oidc-test": {
+						AllowedMethods: []string{"/agntcy.dir.search.v1.SearchService/SearchCIDs"},
+						GitHubWorkflows: []string{
+							"ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/tags/*",
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "invalid githubWorkflows wildcard",
+		},
 	}
 
 	for _, tt := range tests {

--- a/auth/authzserver/rbac.go
+++ b/auth/authzserver/rbac.go
@@ -20,9 +20,10 @@ var modelConf string
 // Principals are user:{iss}:{sub}, client:{iss}:{client_id}, or ghwf:...
 // Roles come only from config; no roles are extracted from JWT claims.
 type OIDCRoleResolver struct {
-	config   *OIDCConfig
-	enforcer *casbin.Enforcer
-	logger   *slog.Logger
+	config                  *OIDCConfig
+	enforcer                *casbin.Enforcer
+	logger                  *slog.Logger
+	githubWorkflowWildcards map[string][]string // role -> wildcard principals (with '*')
 }
 
 // NewOIDCRoleResolver creates a new Casbin-based role resolver for OIDC.
@@ -46,9 +47,10 @@ func NewOIDCRoleResolver(config *OIDCConfig, logger *slog.Logger) (*OIDCRoleReso
 	}
 
 	resolver := &OIDCRoleResolver{
-		config:   config,
-		enforcer: enforcer,
-		logger:   logger,
+		config:                  config,
+		enforcer:                enforcer,
+		logger:                  logger,
+		githubWorkflowWildcards: map[string][]string{},
 	}
 
 	if err := resolver.loadPolicies(); err != nil {
@@ -97,7 +99,66 @@ func (r *OIDCRoleResolver) Authorize(principal, path string) error {
 		return nil
 	}
 
+	// Fallback: wildcard matching for GitHub workflow principals only.
+	// Patterns are configured in roles.*.githubWorkflows with '*' wildcard.
+	if strings.HasPrefix(principal, "ghwf:") {
+		if ok, err := r.authorizeGitHubWorkflowWildcard(principal, path); err != nil {
+			return err
+		} else if ok {
+			return nil
+		}
+	}
+
 	return fmt.Errorf("principal %q is not authorized for %s", principal, path)
+}
+
+func (r *OIDCRoleResolver) authorizeGitHubWorkflowWildcard(principal, path string) (bool, error) {
+	for roleKey, patterns := range r.githubWorkflowWildcards {
+		for _, pattern := range patterns {
+			if !githubWorkflowWildcardMatch(pattern, principal) {
+				continue
+			}
+
+			allowed, err := r.enforcer.Enforce(roleKey, path, "access")
+			if err != nil {
+				r.logger.Error("Casbin wildcard enforcement error",
+					"principal", principal,
+					"path", path,
+					"role", roleKey,
+					"pattern", pattern,
+					"error", err,
+				)
+
+				return false, fmt.Errorf("authorization wildcard check failed: %w", err)
+			}
+
+			if allowed {
+				r.logger.Debug("authorized via github workflow wildcard",
+					"principal", principal,
+					"path", path,
+					"role", roleKey,
+					"pattern", pattern,
+				)
+
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// githubWorkflowWildcardMatch matches '*' wildcards where '*' means any char sequence (including '/').
+func githubWorkflowWildcardMatch(pattern, principal string) bool {
+	if !isSupportedGitHubWorkflowWildcard(pattern) {
+		return false
+	}
+
+	// Validation guarantees exactly one wildcard at the end, so match is simple
+	// prefix comparison against the pattern without trailing '*'.
+	prefix := strings.TrimSuffix(pattern, "*")
+
+	return strings.HasPrefix(principal, prefix)
 }
 
 // isPrincipalDenied checks if the principal is in the deny list.
@@ -136,6 +197,12 @@ func (r *OIDCRoleResolver) loadPolicies() error {
 		}
 
 		for _, g := range role.GitHubWorkflows {
+			if strings.Contains(g, "*") {
+				r.githubWorkflowWildcards[roleKey] = append(r.githubWorkflowWildcards[roleKey], g)
+
+				continue
+			}
+
 			groupings = append(groupings, []string{g, roleKey})
 		}
 	}

--- a/auth/authzserver/rbac_test.go
+++ b/auth/authzserver/rbac_test.go
@@ -101,6 +101,44 @@ func TestOIDCRoleResolver_Authorize(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "GitHub workflow wildcard principal matches any branch",
+			config: &OIDCConfig{
+				Claims: ClaimsConfig{UserID: "sub"},
+				Roles: map[string]OIDCRole{
+					"ci-oidc-test": {
+						AllowedMethods: []string{
+							"/agntcy.dir.search.v1.SearchService/SearchCIDs",
+						},
+						GitHubWorkflows: []string{
+							"ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/heads/*",
+						},
+					},
+				},
+			},
+			principal:   "ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/heads/feat/oidc-auth",
+			path:        "/agntcy.dir.search.v1.SearchService/SearchCIDs",
+			expectError: false,
+		},
+		{
+			name: "GitHub workflow wildcard does not match other workflow file",
+			config: &OIDCConfig{
+				Claims: ClaimsConfig{UserID: "sub"},
+				Roles: map[string]OIDCRole{
+					"ci-oidc-test": {
+						AllowedMethods: []string{
+							"/agntcy.dir.search.v1.SearchService/SearchCIDs",
+						},
+						GitHubWorkflows: []string{
+							"ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/heads/*",
+						},
+					},
+				},
+			},
+			principal:   "ghwf:repo:agntcy/dir:workflow:another.yml:ref:refs/heads/feat/oidc-auth",
+			path:        "/agntcy.dir.search.v1.SearchService/SearchCIDs",
+			expectError: true,
+		},
+		{
 			name: "principal in deny list is blocked",
 			config: &OIDCConfig{
 				Claims:       ClaimsConfig{UserID: "sub"},


### PR DESCRIPTION
Adds support for branch wildcard principals in `githubWorkflows` while keeping matching strict and predictable.
This enables entries like:
`ghwf:repo:agntcy/dir:workflow:oidc-test.yml:ref:refs/heads/*`
so one role can authorize a workflow on any branch without listing every branch explicitly.
