### PR TITLE
feat(release): publish dir-apiserver binary for multiple platforms

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -61,12 +61,43 @@ jobs:
           path: .bin
           if-no-files-found: error
 
+  server:
+    name: Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install Task
+        uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 #v2.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: "1.26.1"
+          cache-dependency-path: "**/*.sum"
+          cache: true # NOTE: Default value, just to be explicit
+
+      - name: Build
+        run: |
+          task server:compile:all
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: server-artifacts
+          path: .bin
+          if-no-files-found: error
+
   release:
     name: Release
     needs:
       - image
       - chart
       - cli
+      - server
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -107,20 +138,40 @@ jobs:
           name: cli-artifacts
           path: .bin
 
+      - name: Download Server artifacts
+        if: ${{ !contains(matrix.os, 'windows') }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: server-artifacts
+          path: .bin
+
       - name: Verify file
         if: ${{ !(contains(matrix.os, 'windows') && contains(matrix.arch, 'arm64')) }}
         run: |
           ls -l .bin
           file .bin/dirctl-${{ matrix.os }}-${{ matrix.arch }}
+          if [ "${{ matrix.os }}" != "windows" ]; then
+            file .bin/dir-apiserver-${{ matrix.os }}-${{ matrix.arch }}
+          fi
 
-      - name: Upload Release Asset
+      - name: Upload CLI Release Asset
         if: ${{ !(contains(matrix.os, 'windows') && contains(matrix.arch, 'arm64')) }}
-        id: upload-release-asset
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ inputs.release_tag }}
           files: .bin/dirctl-${{ matrix.os }}-${{ matrix.arch }}
+          append_body: true
+          draft: true
+
+      - name: Upload Server Release Asset
+        if: ${{ !contains(matrix.os, 'windows') }}
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          files: .bin/dir-apiserver-${{ matrix.os }}-${{ matrix.arch }}
           append_body: true
           draft: true

--- a/server/Taskfile.yml
+++ b/server/Taskfile.yml
@@ -7,6 +7,28 @@ tasks:
   default:
     cmd: echo "Run the main Taskfile instead of this one."
 
+  server:compile:
+    desc: Compile Directory server binaries
+    dir: ./server
+    vars:
+      GOOS: "{{ .GOOS | default OS }}"
+      GOARCH: "{{ .GOARCH | default ARCH }}"
+      BINARY_NAME: '{{ .BINARY_NAME | default "dir-apiserver" }}'
+      OUT_BINARY: '{{ .ROOT_DIR }}/.bin/{{ .BINARY_NAME }}'
+      LDFLAGS: "-s -w -extldflags -static {{ .VERSION_LDFLAGS }}"
+    cmds:
+      - CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -ldflags="{{ .LDFLAGS }}" -o "{{.OUT_BINARY}}" ./cmd/main.go
+
+  server:compile:all:
+    desc: Compile Directory server binaries for multiple platforms
+    cmds:
+      - for:
+          matrix:
+            OS: ["linux", "darwin"]
+            ARCH: ["amd64", "arm64"]
+        cmd: |
+          GOOS={{.ITEM.OS}} GOARCH={{.ITEM.ARCH}} BINARY_NAME=dir-apiserver-{{.ITEM.OS}}-{{.ITEM.ARCH}} task server:compile
+
   server:build:
     desc: Build Directory server image
     cmds:


### PR DESCRIPTION
## Summary

Publish `dir-apiserver` as pre-built multi-platform binaries in GitHub Releases, matching what is already done for `dirctl`.

## Changes

### `server/Taskfile.yml`
- **`server:compile`** — Compiles a single `dir-apiserver` binary (static, CGO disabled, version ldflags)
- **`server:compile:all`** — Cross-compiles for linux/darwin x amd64/arm64 (4 binaries)

### `.github/workflows/reusable-release.yaml`
- New **`server`** job — builds all server binaries and uploads as artifacts
- **`release`** job now depends on `server` in addition to `image`, `chart`, `cli`
- **`upload`** job — downloads server artifacts and attaches `dir-apiserver-{os}-{arch}` to the GitHub Release (linux + darwin only)

## Release assets after this change

| Binary | Platforms |
|--------|-----------|
| `dirctl-{os}-{arch}` | linux, darwin, windows x amd64/arm64 (excl. windows/arm64) |
| `dir-apiserver-{os}-{arch}` | linux, darwin x amd64/arm64 |

Closes #1178
