### PR TITLE
chore(workflows): add envoy version for container image scan configuration

### DIFF
--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -22,6 +22,8 @@ vars:
   REGSYNC_VERSION: "v0.11.2"
   # renovate: datasource=docker depName=docker.io/bitnami/postgresql
   POSTGRESQL_VERSION: "latest@sha256:621359194c6a0f0fd502c1996f40f539c3e5f2da43401b6d52ee5614722b7cba"
+  # renovate: datasource=docker depName=docker.io/envoyproxy/envoy
+  ENVOY_VERSION: "v1.37-latest"
 
   ## Container images for vulnerability scanning
   VULN_SCAN_IMAGES:
@@ -35,6 +37,7 @@ vars:
     - "ghcr.io/spiffe/spire-server:{{.SPIRE_VERSION}}"
     - "ghcr.io/spiffe/spire-agent:{{.SPIRE_VERSION}}"
     - "docker.io/bitnami/postgresql:{{.POSTGRESQL_VERSION}}"
+    - "docker.io/envoyproxy/envoy:{{.ENVOY_VERSION}}"
 
   ## Image config
   BUILD_LDFLAGS: "-s -w -extldflags -static {{.VERSION_LDFLAGS}}"


### PR DESCRIPTION
Add the `envoyproxy/envoy` container image to the security vulnerability scanning list. This third-party image is deployed by the `envoy-authz` Helm chart but was previously not included in Trivy scans.

* Add `ENVOY_VERSION` variable in Taskfile.vars.yml
* Add `docker.io/envoyproxy/envoy` to the `VULN_SCAN_IMAGES` list so it is covered by both local `task deps:vuln:images` and the CI container-security-scan workflow

> Note: The directory is IdP-agnostic. Our testbed uses Zitadel as the identity provider, but users can adopt any OIDC-compliant IdP (Zitadel, Keycloak, Okta, etc.). Zitadel is not a dependency of the directory deployment and is therefore not included in the image scanning list.