### PR TITLE
ci(dir): bump codecov reusable action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -231,7 +231,7 @@ jobs:
           path: .coverage
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           codecov_yml_path: codecov.yml
           files: "**/*.out"

--- a/.github/workflows/gui-ci.yaml
+++ b/.github/workflows/gui-ci.yaml
@@ -64,7 +64,7 @@ jobs:
         run: flutter test --coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           use_oidc: true
           files: ./gui/coverage/lcov.info


### PR DESCRIPTION
This PR bumps the codecov reusable action by a major version to keep up the latest changes and receive security patches in the future (by renovatebot).