### PR TITLE
fix(dir): test file instead of directory

### DIFF
--- a/Taskfile.deps.yml
+++ b/Taskfile.deps.yml
@@ -324,4 +324,4 @@ tasks:
       - curl -sL "https://github.com/pre-commit/pre-commit/releases/download/v{{.PRE_COMMIT_VERSION}}/pre-commit-{{.PRE_COMMIT_VERSION}}.pyz" -o {{.PRE_COMMIT_PYZ}}
       - python3 {{.PRE_COMMIT_PYZ}} install
     status:
-      - test -d {{.PRE_COMMIT_PYZ}}
+      - test -f {{.PRE_COMMIT_PYZ}}


### PR DESCRIPTION
The status command for testing of pre-commit existence used `-d` instead of `-f`, which does not pass even if the file is there. The `-f` flag is fix for this to check the file instead of a directory type.