### PR TITLE
feat(importer): implement file fetcher

### DIFF
--- a/cli/cmd/import/import.go
+++ b/cli/cmd/import/import.go
@@ -19,40 +19,41 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const cidOutputFilePerm = 0o600
-
 var Command = &cobra.Command{
 	Use:   "import",
-	Short: "Import records from external registries",
-	Long: `Import records from external registries into DIR.
+	Short: "Import MCP records into DIR from a registry or a JSON file",
+	Long: `Import MCP server records into DIR. Records are transformed, enriched, optionally
+scanned, then pushed. The same pipeline runs for every source.
 
-Supported registries:
-  - mcp: Model Context Protocol registry v0.1
+Sources:
+  --type=mcp --url       HTTP MCP registry (e.g. v0.1 list API)
+  --type=file --file-path   Local JSON: one bare server object or a JSON array of servers
 
-The import command fetches records from the specified registry and pushes
-them to DIR.
+Examples (registry):
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --filter=search=analytics --limit=50
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --force --debug
 
-Examples:
-  # Import from MCP registry with default enrichment configuration
-  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io
+Examples (file):
+  dirctl import --type=file --file-path=./servers.json
+  dirctl import --type=file --file-path=./server.json --force --debug
 
-  # Import with filters
-  # Available filters: https://registry.modelcontextprotocol.io/docs#/operations/list-servers-v0.1#Query-Parameters
-  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io --filter=updated_since=2025-08-07T13:15:04.280Z
+Preview and output:
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --dry-run
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --output-cids=./imported.cids
 
-  # Preview without importing
-  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io --dry-run
+Enrichment (MCPHost / LLM):
+  dirctl import --type=file --file-path=./server.json --enrich-config=./mcphost.json
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --enrich-skills-prompt=./skills.md --enrich-domains-prompt=./domains.md --enrich-rate-limit=5
 
-  # Use custom MCPHost configuration and prompt templates
-  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io \
-    --enrich-skills-prompt=/path/to/custom-skills-prompt.md \
-    --enrich-domains-prompt=/path/to/custom-domains-prompt.md
+Scanner (mcp-scanner):
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --scanner-enabled --scanner-timeout=5m --scanner-cli-path=/usr/local/bin/mcp-scanner
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --scanner-enabled --scanner-fail-on-error --scanner-fail-on-warning
 
-  # Import and sign records with OIDC (opens browser for authentication)
-  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io --sign
-
-  # Import and sign records with a private key
-  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io --sign --key=/path/to/cosign.key
+Signing (after push; same flags as dirctl sign):
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --sign --key=./cosign.key
+  dirctl import --type=file --file-path=./server.json --sign --key=env://COSIGN_PRIVATE_KEY --fulcio-url=https://fulcio.sigstore.dev --rekor-url=https://rekor.sigstore.dev --timestamp-url=https://timestamp.sigstore.dev
+  dirctl import --type=mcp --url=https://registry.modelcontextprotocol.io/v0.1 --sign --key=./cosign.key --skip-tlog --oidc-token="$OIDC_TOKEN"
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runImport(cmd)
@@ -60,35 +61,37 @@ Examples:
 }
 
 func runImport(cmd *cobra.Command) error {
-	// Get the client from the context
 	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
 	if !ok {
 		return errors.New("failed to get client from context")
 	}
 
-	// Set the registry type from the string flag
 	opts.Config.RegistryType = config.RegistryType(opts.RegistryType)
+	opts.Config.FilePath = opts.FilePath
 
-	// Set up signing function if enabled
 	if opts.Sign {
 		opts.SignFunc = func(ctx context.Context, cid string) error {
 			return signcmd.Sign(ctx, c, cid)
 		}
 	}
 
-	// Validate configuration
 	if err := opts.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	// Create importer instance from pre-initialized factory
 	importer, err := factory.Create(cmd.Context(), c, opts.Config)
 	if err != nil {
 		return fmt.Errorf("failed to create importer: %w", err)
 	}
 
-	// Run import with progress reporting
-	presenter.Printf(cmd, "Starting import from %s registry at %s...\n", opts.Config.RegistryType, opts.RegistryURL)
+	switch opts.Config.RegistryType {
+	case config.RegistryTypeMCP:
+		presenter.Printf(cmd, "Starting import from %s registry at %s...\n", opts.Config.RegistryType, opts.RegistryURL)
+	case config.RegistryTypeFile:
+		presenter.Printf(cmd, "Importing MCP server(s) from file: %s\n", opts.Config.FilePath)
+	default:
+		presenter.Printf(cmd, "Starting import from %s registry at %s...\n", opts.Config.RegistryType, opts.RegistryURL)
+	}
 
 	if opts.DryRun {
 		presenter.Printf(cmd, "Mode: DRY RUN (preview only)\n")
@@ -110,11 +113,10 @@ func runImport(cmd *cobra.Command) error {
 
 	printSummary(cmd, result)
 
-	// Write CIDs to output file if specified
 	if opts.OutputCIDFile != "" && len(result.ImportedCIDs) > 0 {
 		content := strings.Join(result.ImportedCIDs, "\n") + "\n"
 
-		if err := os.WriteFile(opts.OutputCIDFile, []byte(content), cidOutputFilePerm); err != nil {
+		if err := os.WriteFile(opts.OutputCIDFile, []byte(content), 0o600); err != nil { //nolint:mnd
 			return fmt.Errorf("failed to write CIDs to file: %w", err)
 		}
 
@@ -137,7 +139,7 @@ func printSummary(cmd *cobra.Command, result *types.ImportResult) {
 		presenter.Printf(cmd, "\n=== Errors ===\n")
 
 		for i, err := range result.Errors {
-			if i < maxErrors { // Show only first 10 errors
+			if i < maxErrors {
 				presenter.Printf(cmd, "  - %v\n", err)
 			}
 		}

--- a/cli/cmd/import/options.go
+++ b/cli/cmd/import/options.go
@@ -15,21 +15,22 @@ var opts = &options{}
 type options struct {
 	config.Config
 	RegistryType  string
-	Sign          bool   // Sign records after pushing (flag binding)
-	OutputCIDFile string // File to write imported CIDs to (for deferred signing)
+	Sign          bool
+	OutputCIDFile string
+	FilePath      string
 }
 
 func init() {
 	flags := Command.Flags()
 
+	// File flags
+	flags.StringVar(&opts.FilePath, "file-path", "", "Path to JSON file with MCP server definition(s) (required when --type=file)")
+
 	// Registry flags
-	flags.StringVar(&opts.RegistryType, "type", "", "Registry type (mcp, a2a)")
-	flags.StringVar(&opts.RegistryURL, "url", "", "Registry base URL")
+	flags.StringVar(&opts.RegistryType, "type", "", "Registry type: mcp, a2a, or file (local JSON)")
+	flags.StringVar(&opts.RegistryURL, "url", "", "Registry base URL (required for mcp and a2a)")
 	flags.StringToStringVar(&opts.Filters, "filter", nil, "Filters (key=value)")
 	flags.IntVar(&opts.Limit, "limit", 0, "Maximum number of records to import (0 = no limit)")
-	flags.BoolVar(&opts.DryRun, "dry-run", false, "Preview without importing")
-	flags.BoolVar(&opts.Force, "force", false, "Force push even if record already exists")
-	flags.BoolVar(&opts.Debug, "debug", false, "Enable debug output for deduplication and validation failures")
 
 	// Enrichment flags
 	flags.StringVar(&opts.Enricher.ConfigFile, "enrich-config", enricherconfig.DefaultConfigFile, "Path to MCPHost configuration file (mcphost.json)")
@@ -49,7 +50,10 @@ func init() {
 	flags.StringVar(&opts.OutputCIDFile, "output-cids", "", "File to write imported CIDs (one per line, for deferred signing)")
 	signcmd.AddSigningFlags(flags)
 
-	// Mark required flags
+	// Common flags
+	flags.BoolVar(&opts.DryRun, "dry-run", false, "Preview without importing")
+	flags.BoolVar(&opts.Force, "force", false, "Force push even if record already exists")
+	flags.BoolVar(&opts.Debug, "debug", false, "Enable debug output for deduplication and validation failures")
+
 	Command.MarkFlagRequired("type") //nolint:errcheck
-	Command.MarkFlagRequired("url")  //nolint:errcheck
 }

--- a/importer/config/config.go
+++ b/importer/config/config.go
@@ -21,6 +21,8 @@ type RegistryType string
 const (
 	// RegistryTypeMCP represents the Model Context Protocol registry.
 	RegistryTypeMCP RegistryType = "mcp"
+	// RegistryTypeFile imports MCP server definitions from a local JSON file.
+	RegistryTypeFile RegistryType = "file"
 )
 
 // ClientInterface defines the interface for the DIR client used by importers.
@@ -37,7 +39,8 @@ type SignFunc func(ctx context.Context, cid string) error
 // Config contains configuration for an import operation.
 type Config struct {
 	RegistryType RegistryType      // Registry type identifier
-	RegistryURL  string            // Base URL of the registry
+	RegistryURL  string            // Base URL of the registry (MCP registry)
+	FilePath     string            // Path to JSON file (when RegistryType is file)
 	Filters      map[string]string // Registry-specific filters
 	Limit        int               // Number of records to import (default: 0 for all)
 	DryRun       bool              // If true, preview without actually importing
@@ -56,8 +59,17 @@ func (c *Config) Validate() error {
 		return errors.New("registry type is required")
 	}
 
-	if c.RegistryURL == "" {
-		return errors.New("registry URL is required")
+	switch c.RegistryType {
+	case RegistryTypeMCP:
+		if c.RegistryURL == "" {
+			return errors.New("registry URL is required when registry type is mcp")
+		}
+	case RegistryTypeFile:
+		if c.FilePath == "" {
+			return errors.New("file path is required when registry type is file")
+		}
+	default:
+		return fmt.Errorf("unsupported registry type: %s", c.RegistryType)
 	}
 
 	if err := c.Enricher.Validate(); err != nil {

--- a/importer/config/config_test.go
+++ b/importer/config/config_test.go
@@ -30,6 +30,55 @@ func TestConfig_Validate_MissingURL(t *testing.T) {
 	}
 }
 
+func TestConfig_Validate_FileMissingPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	cfgPath := filepath.Join(dir, "mcphost.json")
+	if err := os.WriteFile(cfgPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := Config{
+		RegistryType: RegistryTypeFile,
+		Enricher: enricherconfig.Config{
+			ConfigFile:        cfgPath,
+			RequestsPerMinute: 1,
+		},
+		Scanner: scannerconfig.Config{Enabled: false},
+	}
+
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected error for empty FilePath")
+	}
+}
+
+func TestConfig_Validate_FileOK(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	cfgPath := filepath.Join(dir, "mcphost.json")
+	if err := os.WriteFile(cfgPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := Config{
+		RegistryType: RegistryTypeFile,
+		FilePath:     filepath.Join(dir, "server.json"),
+		Enricher: enricherconfig.Config{
+			ConfigFile:        cfgPath,
+			RequestsPerMinute: 1,
+		},
+		Scanner: scannerconfig.Config{Enabled: false},
+	}
+
+	if err := c.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
 func TestConfig_Validate_OK(t *testing.T) {
 	t.Parallel()
 

--- a/importer/factory/factory.go
+++ b/importer/factory/factory.go
@@ -15,6 +15,7 @@ import (
 
 func init() {
 	Register(config.RegistryTypeMCP, importer.New)
+	Register(config.RegistryTypeFile, importer.New)
 }
 
 // ImporterFunc is a function that creates an Importer instance.

--- a/importer/fetcher/file.go
+++ b/importer/fetcher/file.go
@@ -1,0 +1,123 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package fetcher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	mcpapiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+)
+
+// fileFetcher reads MCP registry-style server definitions from a local JSON file.
+type fileFetcher struct {
+	path string
+}
+
+// NewFileFetcher creates a fetcher that reads one or more MCP servers from a file.
+// Supported formats:
+//   - A JSON array of ServerResponse
+//   - A single bare ServerJSON object (wrapped as ServerResponse)
+func NewFileFetcher(path string) (*fileFetcher, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("file path is empty")
+	}
+
+	return &fileFetcher{path: path}, nil
+}
+
+// Fetch reads the file and sends each decoded server to the output channel.
+func (f *fileFetcher) Fetch(ctx context.Context) (<-chan mcpapiv0.ServerResponse, <-chan error) {
+	outputCh := make(chan mcpapiv0.ServerResponse, 8) //nolint:mnd
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(outputCh)
+		defer close(errCh)
+
+		raw, err := os.ReadFile(f.path)
+		if err != nil {
+			select {
+			case errCh <- fmt.Errorf("read file: %w", err):
+			case <-ctx.Done():
+			}
+
+			return
+		}
+
+		raw = bytes.TrimPrefix(raw, []byte("\xef\xbb\xbf")) // UTF-8 BOM
+
+		servers, err := decodeServerResponses(raw)
+		if err != nil {
+			select {
+			case errCh <- err:
+			case <-ctx.Done():
+			}
+
+			return
+		}
+
+		if len(servers) == 0 {
+			select {
+			case errCh <- errors.New("no MCP servers found in file"):
+			case <-ctx.Done():
+			}
+
+			return
+		}
+
+		for _, srv := range servers {
+			select {
+			case <-ctx.Done():
+				return
+			case outputCh <- srv:
+			}
+		}
+	}()
+
+	return outputCh, errCh
+}
+
+func decodeServerResponses(raw []byte) ([]mcpapiv0.ServerResponse, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return nil, errors.New("file is empty")
+	}
+
+	// JSON array of ServerResponse
+	if raw[0] == '[' {
+		var batch []mcpapiv0.ServerResponse
+		if err := json.Unmarshal(raw, &batch); err != nil {
+			return nil, fmt.Errorf("decode JSON array: %w", err)
+		}
+
+		out := make([]mcpapiv0.ServerResponse, 0, len(batch))
+		for _, item := range batch {
+			if item.Server.Name == "" {
+				continue
+			}
+
+			out = append(out, item)
+		}
+
+		if len(out) == 0 {
+			return nil, errors.New("no valid servers in JSON array (missing server.name)")
+		}
+
+		return out, nil
+	}
+
+	// Single JSON object: bare ServerJSON only (registry server.json shape)
+	var bare mcpapiv0.ServerJSON
+	if err := json.Unmarshal(raw, &bare); err == nil && bare.Name != "" {
+		return []mcpapiv0.ServerResponse{{Server: bare}}, nil
+	}
+
+	return nil, errors.New("could not parse file as JSON array of servers or bare server.json")
+}

--- a/importer/fetcher/file_test.go
+++ b/importer/fetcher/file_test.go
@@ -1,0 +1,52 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package fetcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileFetcher_Fetch_bareServerJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "one.json")
+
+	json := `{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.example/test",
+  "description": "Test server for unit tests",
+  "version": "1.0.0",
+  "remotes": [{"type": "streamable-http", "url": "https://example.com/mcp"}]
+}`
+	if err := os.WriteFile(path, []byte(json), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := NewFileFetcher(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	outCh, errCh := f.Fetch(context.Background())
+
+	var got int
+
+	for range outCh {
+		got++
+	}
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	}
+
+	if got != 1 {
+		t.Fatalf("got %d servers, want 1", got)
+	}
+}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -35,9 +35,22 @@ type Importer struct {
 	pusher      types.Pusher
 }
 
-// New creates a new MCP importer instance.
+// New creates a new MCP importer instance (registry HTTP or local JSON file).
 func New(ctx context.Context, client config.ClientInterface, cfg config.Config) (types.Importer, error) {
-	fetcher, err := fetcher.NewFetcher(cfg.RegistryURL, cfg.Filters, cfg.Limit)
+	var (
+		fetch types.Fetcher
+		err   error
+	)
+
+	switch cfg.RegistryType {
+	case config.RegistryTypeMCP:
+		fetch, err = fetcher.NewFetcher(cfg.RegistryURL, cfg.Filters, cfg.Limit)
+	case config.RegistryTypeFile:
+		fetch, err = fetcher.NewFileFetcher(cfg.FilePath)
+	default:
+		return nil, fmt.Errorf("unsupported registry type: %s", cfg.RegistryType)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fetcher: %w", err)
 	}
@@ -60,7 +73,7 @@ func New(ctx context.Context, client config.ClientInterface, cfg config.Config) 
 	return &Importer{
 		cfg:         cfg,
 		client:      client,
-		fetcher:     fetcher,
+		fetcher:     fetch,
 		dedup:       d,
 		transformer: transformer.NewTransformer(),
 		enricher:    e,


### PR DESCRIPTION
This PR adds the capability to import an MCP server from a file besides the registry.
There is a new flag option for `--type` called `file`, and there is also a new flag called `--file-path`.
The JSON file can contain a simple MCP server or an array of MCP servers in the same format as in the official Anthropic registry: https://github.com/modelcontextprotocol/registry/blob/main/pkg/api/v0/types.go#L22-L24

Local run example:
```bash
➜  dir git:(feat/file-fetcher) .bin/dirctl import --type=file --file-path=tmp/import-sample-bare-server.json --scanner-enabled --debug
time=2026-03-31T18:23:54.684+02:00 level=DEBUG msg="No auto-detected credentials found, using insecure connection" component=client.auth
[DEDUP] Processed integration/mcp batch: 18 records (total: 18)
[DEDUP] Cache built with 12 existing MCP records
Importing MCP server(s) from file: tmp/import-sample-bare-server.json

time=2026-03-31T18:24:00.153+02:00 level=DEBUG msg="Added skills" component=importer/enricher name=retrieval_augmented_generation/retrieval_of_information id=601 confidence=0.95 reasoning="The agent manages server responses and fetches data, suggesting a strong alignment with information retrieval capabilities."
...
time=2026-03-31T18:24:28.129+02:00 level=INFO msg="Scan skipped" component=importer/scanner record=io.example/bare-server-json@1.1.0 reason="no source-code locator found"

=== Import Summary ===
Total records:   1
Imported:        1
Skipped:         0
Failed:          0
```