### PR TITLE
chore(deps/renovate): group postgresql bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -202,7 +202,8 @@
       "groupSlug": "zot",
       "matchPackageNames": [
         "github.com/project-zot/zot",
-        "ghcr.io/project-zot/zot"
+        "ghcr.io/project-zot/zot",
+        "zot"
       ],
       "description": ["Group zot version bumps into a single PR."]
     },
@@ -221,6 +222,7 @@
       "groupSlug": "spire",
       "matchPackageNames": [
         "github.com/spiffe/spire",
+        "github.com/spiffe/go-spiffe{/,}**",
         "ghcr.io/spiffe/spire-server",
         "ghcr.io/spiffe/spire-agent"
       ],


### PR DESCRIPTION
Currently when bumping postgresql a PR is created for helm https://github.com/agntcy/dir/pull/1255 and another for docker https://github.com/agntcy/dir/pull/1251, we should group all version bumps for this package