### PR TITLE
feat(cli/daemon): peer-ready defaults for routing

### DIFF
--- a/cli/cmd/daemon/config.go
+++ b/cli/cmd/daemon/config.go
@@ -108,6 +108,7 @@ func resolveRelativePaths(cfg *DaemonConfig) {
 	}
 
 	cfg.Server.Store.OCI.LocalDir = resolve(cfg.Server.Store.OCI.LocalDir)
+	cfg.Server.Routing.KeyPath = resolve(cfg.Server.Routing.KeyPath)
 	cfg.Server.Routing.DatastoreDir = resolve(cfg.Server.Routing.DatastoreDir)
 	cfg.Server.Database.SQLite.Path = resolve(cfg.Server.Database.SQLite.Path)
 }

--- a/cli/cmd/daemon/daemon.config.yaml
+++ b/cli/cmd/daemon/daemon.config.yaml
@@ -32,6 +32,7 @@ server:
       enabled: true
   routing:
     listen_address: "/ip4/0.0.0.0/tcp/8999"
+    key_path: "node.key"
     datastore_dir: "routing"
     # bootstrap_peers:
     #   - "/dns4/remote-dir.example.com/tcp/8999/p2p/<peer-id>"

--- a/cli/cmd/daemon/start.go
+++ b/cli/cmd/daemon/start.go
@@ -5,11 +5,13 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
 
+	networkinit "github.com/agntcy/dir/cli/cmd/network/init"
 	reconciler "github.com/agntcy/dir/reconciler/service"
 	"github.com/agntcy/dir/server"
 	ocilib "github.com/agntcy/dir/server/store/oci"
@@ -33,6 +35,7 @@ The daemon blocks until SIGINT or SIGTERM is received.`,
 	RunE: runStart,
 }
 
+//nolint:cyclop
 func runStart(cmd *cobra.Command, _ []string) error {
 	running, pid, err := readPID()
 	if err != nil {
@@ -50,6 +53,12 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	cfg, err := loadConfig()
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if cfg.Server.Routing.KeyPath != "" {
+		if err := ensureKeyFile(cfg.Server.Routing.KeyPath); err != nil {
+			return fmt.Errorf("failed to ensure peer identity key: %w", err)
+		}
 	}
 
 	ctx, cancel := context.WithCancel(cmd.Context())
@@ -106,6 +115,29 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	case <-ctx.Done():
 		logger.Info("Context cancelled, shutting down")
 	}
+
+	return nil
+}
+
+// ensureKeyFile generates a persistent Ed25519 identity key if one does not
+// already exist at path. Uses the same PKCS#8 PEM format as `dirctl network init`.
+func ensureKeyFile(path string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to stat key file: %w", err)
+	}
+
+	_, pemData, err := networkinit.GenerateED25519OpenSSLKey()
+	if err != nil {
+		return fmt.Errorf("failed to generate Ed25519 key: %w", err)
+	}
+
+	if err := os.WriteFile(path, pemData, 0o600); err != nil { //nolint:mnd
+		return fmt.Errorf("failed to write key file: %w", err)
+	}
+
+	logger.Info("Generated persistent peer identity key", "path", path)
 
 	return nil
 }


### PR DESCRIPTION
**Changes**
* Pin the daemon's libp2p routing port to `8999` (was ephemeral `tcp/0`) so the address is deterministic across restarts
* Auto-generate and persist an Ed25519 identity key at `~/.agntcy/dir/node.key` on first start, giving the daemon a stable PeerID
* Add `bootstrap_peers` config hook with env var support (`DIRECTORY_DAEMON_SERVER_ROUTING_BOOTSTRAP_PEERS`) so users can join an external directory network without editing the config file

**Successful Daemon Peer Test**
```bash
# Deploy kind cluster
PUBLICATION_SCHEDULER_INTERVAL=5s task deploy:network

# Build .bin/dirctl` built from branch
task cli:compile

# Port-forward bootstrap routing
kubectl port-forward -n bootstrap svc/agntcy-dir-apiserver-routing 9999:8999

# Start daemon
DIRECTORY_DAEMON_SERVER_ROUTING_BOOTSTRAP_PEERS="/ip4/127.0.0.1/tcp/9999/p2p/$(grep BOOTSTRAP_PEER_ID .env | cut -d= -f2)" \
  .bin/dirctl daemon start

# Push and publish a record on peer1
DIRECTORY_CLIENT_SERVER_ADDRESS=localhost:8890 .bin/dirctl push tests/e2e/shared/testdata/record_100.json
DIRECTORY_CLIENT_SERVER_ADDRESS=localhost:8890 .bin/dirctl routing publish <CID>

# Search from daemon** (wait ~10s for publication)
DIRECTORY_CLIENT_SERVER_ADDRESS=localhost:8888 .bin/dirctl routing search --skill "natural_language_processing/natural_language_understanding/contextual_comprehension"
```

**Note on OCI Sync (out of scope)**
P2P routing (discovery/search) works with the daemon's default local stack. OCI artifact sync (`regsync`) is not yet validated in daemon mode but might be feasible using upstream regsync's `ocidir://` target (https://regclient.org/usage/#image-references) to write directly to the daemon's local OCI store.