### PR TITLE
feat(dir/helm): render routing service annotations

### DIFF
--- a/install/charts/dir/apiserver/templates/routing-service.yaml
+++ b/install/charts/dir/apiserver/templates/routing-service.yaml
@@ -8,6 +8,11 @@ metadata:
   name: {{ include "chart.fullname" . }}-routing
   labels:
     {{- include "chart.labels" . | nindent 4 }}
+  {{- $routingServiceAnnotations := include "chart.routingService.annotations" . }}
+  {{- if $routingServiceAnnotations }}
+  annotations:
+{{ $routingServiceAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if and .Values.routingService .Values.routingService.type }}
   type: {{ .Values.routingService.type }}

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -347,7 +347,8 @@ routingService:
 
   # Cloud provider for automatic annotation configuration
   # Options: "aws", "gcp", "azure", or leave empty for manual configuration
-  # When set, provider-specific annotations are automatically applied
+  # When set, provider-specific annotations are rendered on the routing Service
+  # manifest.
   cloudProvider: ""
 
   # AWS-specific configuration (only used when cloudProvider: "aws")
@@ -382,6 +383,8 @@ routingService:
 
   # Optional: Additional custom annotations (merged with provider annotations)
   # Custom annotations take precedence over provider-generated ones
+  # Example:
+  #   external-dns.alpha.kubernetes.io/hostname: "prod.routing.example.com"
   annotations: {}
 
 serviceAccount:

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -37,14 +37,15 @@ apiserver:
   routingService:
     # Service type for routing/P2P traffic
     # Options: ClusterIP, NodePort, LoadBalancer
-    # Recommended for cloud: LoadBalancer (for stable external IP)
+    # Recommended for cloud: LoadBalancer (for stable external IP/DNS)
     # Default for local/dev: NodePort (inherits from service.type if not set)
-    # Uncomment and set to LoadBalancer for production cloud deployments:
+    # Set to LoadBalancer for production cloud deployments:
     # type: LoadBalancer
 
     # Cloud provider for automatic annotation configuration
     # Options: "aws", "gcp", "azure", or leave empty for no auto-configuration
-    # When set, provider-specific LoadBalancer annotations are automatically applied
+    # When set, provider-specific LoadBalancer annotations are rendered on the
+    # routing Service manifest.
     # Examples:
     #   cloudProvider: "aws"    # Auto-configures AWS NLB with internet-facing scheme
     #   cloudProvider: "gcp"    # Auto-configures GCP External Load Balancer
@@ -77,7 +78,9 @@ apiserver:
 
     # Optional: Additional custom annotations (merged with provider annotations)
     # Custom annotations override provider-generated ones
-    # annotations: {}
+    # Example:
+    # annotations:
+    #   external-dns.alpha.kubernetes.io/hostname: "prod.routing.example.com"
 
   # Authorization policy file content (separate from config)
   # This is written to authz_policies.csv file, not part of the server config struct


### PR DESCRIPTION
- This change updates the Directory apiserver Helm routing service template to render `metadata.annotations `using the existing `chart.routingService.annotations `helper.
- It ensures provider-specific load balancer annotations (for example AWS NLB settings) and user-defined `routingService.annotations` are applied to the routing Service, and also clarifies related comments in chart values.