### PR TITLE
feat(dir/cli): add export command

### DIFF
--- a/cli/cmd/export/export.go
+++ b/cli/cmd/export/export.go
@@ -1,0 +1,94 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:wrapcheck
+package export
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/cmd/export/format"
+	"github.com/agntcy/dir/cli/presenter"
+	ctxUtils "github.com/agntcy/dir/cli/util/context"
+	"github.com/agntcy/dir/cli/util/reference"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:   "export <cid-or-name[:version][@digest]>",
+	Short: "Export a record from the Directory to a local file or stdout",
+	Long: `Export pulls a record from the Directory, transforms it to the requested format,
+and writes the result to a file or stdout.
+
+The --format flag selects the output format. The built-in "oasf" format outputs the raw OASF
+record JSON.
+
+Usage examples:
+
+  # Export raw OASF JSON to stdout
+  dirctl export bafyreib...
+
+  # Export to a file
+  dirctl export my-agent:1.0 --output-file=./record.json
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runExport(cmd, args[0])
+	},
+}
+
+func runExport(cmd *cobra.Command, input string) error {
+	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
+	if !ok {
+		return errors.New("failed to get client from context")
+	}
+
+	formatter, err := format.GetFormatter(opts.Format)
+	if err != nil {
+		return err
+	}
+
+	recordCID, err := reference.ResolveToCID(cmd.Context(), c, input)
+	if err != nil {
+		return err
+	}
+
+	record, err := c.Pull(cmd.Context(), &corev1.RecordRef{
+		Cid: recordCID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to pull record: %w", err)
+	}
+
+	output, err := formatter.Format(record)
+	if err != nil {
+		return fmt.Errorf("failed to format record as %s: %w", opts.Format, err)
+	}
+
+	if opts.OutputFile != "" {
+		outPath := opts.OutputFile
+		if filepath.Ext(outPath) == "" {
+			outPath += formatter.FileExtension()
+		}
+
+		return writeFile(cmd, outPath, output)
+	}
+
+	presenter.Print(cmd, string(output))
+
+	return nil
+}
+
+func writeFile(cmd *cobra.Command, path string, data []byte) error {
+	if err := os.WriteFile(path, data, 0o600); err != nil { //nolint:mnd
+		return fmt.Errorf("failed to write file %s: %w", path, err)
+	}
+
+	presenter.PrintSmartf(cmd, "Exported to: %s\n", path)
+
+	return nil
+}

--- a/cli/cmd/export/format/format.go
+++ b/cli/cmd/export/format/format.go
@@ -1,0 +1,46 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package format
+
+import (
+	"fmt"
+	"sync"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+)
+
+// Formatter converts an OASF record into a target format.
+type Formatter interface {
+	// Format transforms the OASF record into the target representation.
+	Format(record *corev1.Record) ([]byte, error)
+
+	// FileExtension returns the default file extension for this format (e.g. ".json", ".md").
+	FileExtension() string
+}
+
+var (
+	registryMu sync.RWMutex
+	formatters = map[string]Formatter{}
+)
+
+// RegisterFormatter registers a named formatter. It is safe for concurrent use.
+func RegisterFormatter(name string, f Formatter) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	formatters[name] = f
+}
+
+// GetFormatter returns the formatter registered under name, or an error if not found.
+func GetFormatter(name string) (Formatter, error) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	f, ok := formatters[name]
+	if !ok {
+		return nil, fmt.Errorf("unsupported export format %q", name)
+	}
+
+	return f, nil
+}

--- a/cli/cmd/export/format/format_test.go
+++ b/cli/cmd/export/format/format_test.go
@@ -1,0 +1,71 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package format_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	oasfv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1alpha1"
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/cmd/export/format"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRecord() *corev1.Record {
+	return corev1.New(&oasfv1alpha1.Record{
+		Name:          "test-agent",
+		SchemaVersion: "v0.5.0",
+		Description:   "A test agent for export formatting",
+		Version:       "1.0.0",
+	})
+}
+
+func TestGetFormatter(t *testing.T) {
+	t.Run("returns oasf formatter", func(t *testing.T) {
+		f, err := format.GetFormatter("oasf")
+		require.NoError(t, err)
+		assert.NotNil(t, f)
+	})
+
+	t.Run("returns error for unknown format", func(t *testing.T) {
+		f, err := format.GetFormatter("nonexistent")
+		assert.Nil(t, f)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported export format")
+	})
+}
+
+func TestOASFFormatter_Format(t *testing.T) {
+	f, err := format.GetFormatter("oasf")
+	require.NoError(t, err)
+
+	t.Run("formats a valid record as JSON", func(t *testing.T) {
+		record := newTestRecord()
+
+		output, err := f.Format(record)
+		require.NoError(t, err)
+		assert.NotEmpty(t, output)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(output, &parsed))
+		assert.Equal(t, "test-agent", parsed["name"])
+		assert.Equal(t, "A test agent for export formatting", parsed["description"])
+	})
+
+	t.Run("returns error for record with nil data", func(t *testing.T) {
+		record := &corev1.Record{}
+
+		_, err := f.Format(record)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "record contains no data")
+	})
+}
+
+func TestOASFFormatter_FileExtension(t *testing.T) {
+	f, err := format.GetFormatter("oasf")
+	require.NoError(t, err)
+	assert.Equal(t, ".json", f.FileExtension())
+}

--- a/cli/cmd/export/format/oasf.go
+++ b/cli/cmd/export/format/oasf.go
@@ -1,0 +1,40 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package format
+
+import (
+	"fmt"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func init() {
+	RegisterFormatter("oasf", &oasfFormatter{})
+}
+
+type oasfFormatter struct{}
+
+func (f *oasfFormatter) Format(record *corev1.Record) ([]byte, error) {
+	data := record.GetData()
+	if data == nil {
+		return nil, fmt.Errorf("record contains no data")
+	}
+
+	raw, err := protojson.MarshalOptions{
+		Multiline: true,
+		Indent:    "  ",
+	}.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal OASF record: %w", err)
+	}
+
+	raw = append(raw, '\n')
+
+	return raw, nil
+}
+
+func (f *oasfFormatter) FileExtension() string {
+	return ".json"
+}

--- a/cli/cmd/export/options.go
+++ b/cli/cmd/export/options.go
@@ -1,0 +1,21 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package export
+
+import "github.com/agntcy/dir/cli/presenter"
+
+var opts = &options{}
+
+type options struct {
+	Format     string
+	OutputFile string
+}
+
+func init() {
+	flags := Command.Flags()
+	flags.StringVar(&opts.Format, "format", "oasf", "Export format (extensible; built-in: oasf)")
+	flags.StringVar(&opts.OutputFile, "output-file", "", "File path to write the exported data (default: stdout)")
+
+	presenter.AddOutputFlags(Command)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agntcy/dir/cli/cmd/daemon"
 	"github.com/agntcy/dir/cli/cmd/delete"
 	"github.com/agntcy/dir/cli/cmd/events"
+	"github.com/agntcy/dir/cli/cmd/export"
 	importcmd "github.com/agntcy/dir/cli/cmd/import"
 	"github.com/agntcy/dir/cli/cmd/info"
 	"github.com/agntcy/dir/cli/cmd/mcp"
@@ -74,8 +75,9 @@ func init() {
 		pull.Command,
 		push.Command,
 		delete.Command,
-		// import commands
+		// import/export commands
 		importcmd.Command,
+		export.Command,
 		// routing commands (all under routing subcommand)
 		routing.Command, // Contains: publish, unpublish, list, search
 		network.Command,

--- a/tests/e2e/local/11_export_test.go
+++ b/tests/e2e/local/11_export_test.go
@@ -1,0 +1,109 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/agntcy/dir/tests/e2e/shared/config"
+	"github.com/agntcy/dir/tests/e2e/shared/testdata"
+	"github.com/agntcy/dir/tests/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command", func() {
+	var cli *utils.CLI
+
+	ginkgo.BeforeEach(func() {
+		if cfg.DeploymentMode != config.DeploymentModeLocal {
+			ginkgo.Skip("Skipping test, not in local mode")
+		}
+
+		utils.ResetCLIState()
+
+		cli = utils.NewCLI()
+	})
+
+	ginkgo.Context("Export with default oasf format", ginkgo.Ordered, ginkgo.Serial, func() {
+		var cid string
+
+		tempDir, err := os.MkdirTemp("", "export-e2e-*")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.AfterAll(func() {
+			os.RemoveAll(tempDir)
+		})
+
+		ginkgo.It("should push a record to set up test data", func() {
+			pushPath := filepath.Join(tempDir, "push_record.json")
+			err := os.WriteFile(pushPath, testdata.ExpectedRecordV100JSON, 0o600)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			cid = cli.Push(pushPath).WithArgs("--output", "raw").ShouldSucceed()
+			gomega.Expect(cid).NotTo(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should export a record to stdout by CID", func() {
+			output := cli.Export(cid).ShouldSucceed()
+			gomega.Expect(output).NotTo(gomega.BeEmpty())
+
+			var parsed map[string]any
+
+			err := json.Unmarshal([]byte(output), &parsed)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "stdout output should be valid JSON")
+			gomega.Expect(parsed).To(gomega.HaveKey("name"))
+		})
+
+		ginkgo.It("should export a record to a file with explicit extension", func() {
+			outPath := filepath.Join(tempDir, "exported_record.json")
+
+			cli.Export(cid).WithArgs("--output-file", outPath).ShouldSucceed()
+
+			data, err := os.ReadFile(outPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(data).NotTo(gomega.BeEmpty())
+
+			var parsed map[string]any
+
+			err = json.Unmarshal(data, &parsed)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "file content should be valid JSON")
+			gomega.Expect(parsed).To(gomega.HaveKey("name"))
+		})
+
+		ginkgo.It("should auto-append file extension when omitted", func() {
+			outPath := filepath.Join(tempDir, "no_ext_record")
+			expectedPath := outPath + ".json"
+
+			cli.Export(cid).WithArgs("--output-file", outPath).ShouldSucceed()
+
+			_, err := os.Stat(expectedPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"file with auto-appended .json extension should exist")
+
+			data, err := os.ReadFile(expectedPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			var parsed map[string]any
+
+			err = json.Unmarshal(data, &parsed)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "file content should be valid JSON")
+		})
+
+		ginkgo.It("should fail with an unsupported format", func() {
+			err := cli.Export(cid).WithArgs("--format", "nonexistent").ShouldFail()
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("unsupported export format"))
+		})
+
+		ginkgo.It("should fail for a non-existent CID", func() {
+			_ = cli.Export("non-existent-CID").ShouldFail()
+		})
+
+		ginkgo.It("should clean up the test record", func() {
+			cli.Delete(cid).ShouldSucceed()
+		})
+	})
+})

--- a/tests/e2e/shared/utils/cli.go
+++ b/tests/e2e/shared/utils/cli.go
@@ -100,6 +100,10 @@ func (c *CLI) SearchRecords() *SearchBuilder {
 	}
 }
 
+func (c *CLI) Export(cidOrName string) *CommandBuilder {
+	return c.Command("export").WithArgs(cidOrName)
+}
+
 func (c *CLI) Sign(recordCID, keyPath string) *CommandBuilder {
 	return c.Command("sign").WithArgs(recordCID, "--key", keyPath)
 }


### PR DESCRIPTION
Adds a new `dirctl export` command that pulls a record from the Directory, transforms it to a requested format, and writes the result to stdout or a file. The format system uses a pluggable registry, shipping with a built-in `oasf` formatter that outputs pretty-printed JSON.

**Changes**
* Add `export` command with `--format` and `--output-file` flags, auto-appending file extension when omitted
* Introduce pluggable `Formatter` interface and registry with a default `oasf` JSON formatter
* Add e2e test
