### PR TITLE
refactor(ci): remove server build steps from reusable release workflow

### DIFF
--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -62,44 +62,12 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
-  server:
-    name: Server
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Install Task
-        uses: go-task/setup-task@3be4020d41929789a01026e0e427a4321ce0ad44 #v2.0.0
-
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26.2"
-          cache-dependency-path: "**/*.sum"
-          cache: true # NOTE: Default value, just to be explicit
-
-      - name: Build
-        run: |
-          task server:compile:all
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: server-artifacts
-          path: .bin
-          if-no-files-found: error
-          include-hidden-files: true
-
   release:
     name: Release
     needs:
       - image
       - chart
       - cli
-      - server
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -140,21 +108,11 @@ jobs:
           name: cli-artifacts
           path: .bin
 
-      - name: Download Server artifacts
-        if: ${{ !contains(matrix.os, 'windows') }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: server-artifacts
-          path: .bin
-
       - name: Verify file
         if: ${{ !(contains(matrix.os, 'windows') && contains(matrix.arch, 'arm64')) }}
         run: |
           ls -l .bin
           file .bin/dirctl-${{ matrix.os }}-${{ matrix.arch }}
-          if [ "${{ matrix.os }}" != "windows" ]; then
-            file .bin/dir-apiserver-${{ matrix.os }}-${{ matrix.arch }}
-          fi
 
       - name: Upload CLI Release Asset
         if: ${{ !(contains(matrix.os, 'windows') && contains(matrix.arch, 'arm64')) }}
@@ -164,16 +122,5 @@ jobs:
         with:
           tag_name: ${{ inputs.release_tag }}
           files: .bin/dirctl-${{ matrix.os }}-${{ matrix.arch }}
-          append_body: true
-          draft: true
-
-      - name: Upload Server Release Asset
-        if: ${{ !contains(matrix.os, 'windows') }}
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ inputs.release_tag }}
-          files: .bin/dir-apiserver-${{ matrix.os }}-${{ matrix.arch }}
           append_body: true
           draft: true

--- a/server/Taskfile.yml
+++ b/server/Taskfile.yml
@@ -7,28 +7,6 @@ tasks:
   default:
     cmd: echo "Run the main Taskfile instead of this one."
 
-  server:compile:
-    desc: Compile Directory server binaries
-    dir: ./server
-    vars:
-      GOOS: "{{ .GOOS | default OS }}"
-      GOARCH: "{{ .GOARCH | default ARCH }}"
-      BINARY_NAME: '{{ .BINARY_NAME | default "dir-apiserver" }}'
-      OUT_BINARY: '{{ .ROOT_DIR }}/.bin/{{ .BINARY_NAME }}'
-      LDFLAGS: "-s -w -extldflags -static {{ .VERSION_LDFLAGS }}"
-    cmds:
-      - CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} go build -ldflags="{{ .LDFLAGS }}" -o "{{.OUT_BINARY}}" ./cmd/main.go
-
-  server:compile:all:
-    desc: Compile Directory server binaries for multiple platforms
-    cmds:
-      - for:
-          matrix:
-            OS: ["linux", "darwin"]
-            ARCH: ["amd64", "arm64"]
-        cmd: |
-          GOOS={{.ITEM.OS}} GOARCH={{.ITEM.ARCH}} BINARY_NAME=dir-apiserver-{{.ITEM.OS}}-{{.ITEM.ARCH}} task server:compile
-
   server:build:
     desc: Build Directory server image
     cmds:


### PR DESCRIPTION
The release workflow was incorrectly building and attaching `dir-apiserver` binaries as GitHub release assets. Only `dirctl` CLI binaries should be published — the dirctl binary already packages the apiserver, reconciler, and other server components via the dirctl daemon command, making standalone server binaries redundant. The server is also distributed via container images.