### PR TITLE
fix(cli): update stale auth command help text

### DIFF
--- a/cli/cmd/auth/auth.go
+++ b/cli/cmd/auth/auth.go
@@ -16,7 +16,7 @@ var Command = &cobra.Command{
 This command group provides OIDC-based authentication for the Directory server.
 
 Examples:
-  # Login with OAuth (opens browser)
+  # Login with OIDC (opens browser)
   dirctl auth login
 
   # Login with device flow (no browser needed)

--- a/cli/cmd/auth/logout.go
+++ b/cli/cmd/auth/logout.go
@@ -15,7 +15,7 @@ var logoutCmd = &cobra.Command{
 	Short: "Clear cached authentication token",
 	Long: `Clear cached authentication credentials.
 
-This command removes the locally cached OAuth token, effectively logging
+This command removes the locally cached OIDC token, effectively logging
 you out of the Directory server for all token-based auth flows.
 
 Examples:

--- a/cli/cmd/auth/status.go
+++ b/cli/cmd/auth/status.go
@@ -37,7 +37,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	if token == nil {
 		cmd.Println("Status: Not authenticated")
 		cmd.Println()
-		cmd.Println("Run 'dirctl auth login' (human) or 'dirctl auth machine' (service user) to authenticate.")
+		cmd.Println("Run 'dirctl auth login' to authenticate.")
 
 		return nil
 	}
@@ -90,7 +90,7 @@ func displayValidToken(cmd *cobra.Command, token *client.CachedToken) {
 func displayExpiredToken(cmd *cobra.Command) {
 	cmd.Println("  Token: Expired ✗")
 	cmd.Println()
-	cmd.Println("Run 'dirctl auth login' (human) or 'dirctl auth machine' (service user) to re-authenticate.")
+	cmd.Println("Run 'dirctl auth login' to re-authenticate.")
 }
 
 func detectPrincipalType(token *client.CachedToken) string {

--- a/cli/cmd/auth/status_logout_test.go
+++ b/cli/cmd/auth/status_logout_test.go
@@ -23,7 +23,7 @@ func TestRunStatus_NotAuthenticated(t *testing.T) {
 	got := out.String()
 	require.Contains(t, got, "Status: Not authenticated")
 	require.Contains(t, got, "dirctl auth login")
-	require.Contains(t, got, "dirctl auth machine")
+	require.NotContains(t, got, "dirctl auth machine")
 }
 
 func TestRunStatus_WithMachineToken(t *testing.T) {


### PR DESCRIPTION
## Summary
- Remove stale `dirctl auth machine` guidance from `dirctl auth status` output and keep only supported `dirctl auth login` instructions.
- Update auth command/help wording for consistency by standardizing OAuth/OIDC terminology in `auth` and `logout` long descriptions.
- Adjust auth status test assertions to ensure removed stale text does not reappear.

Closes #1316.