### PR TITLE
fix(cli): expired OIDC token related error message

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -290,6 +290,8 @@ func TestClientClose_AggregatesErrors(t *testing.T) {
 
 // TestNew_WithInsecureConfig tests creating a client with insecure configuration.
 func TestNew_WithInsecureConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
 	defer cancel()
 
@@ -381,6 +383,8 @@ func TestNew_WithMissingConfig(t *testing.T) {
 
 // TestNew_AcceptsContext tests that New() accepts a context parameter.
 func TestNew_AcceptsContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
 	defer cancel()
@@ -479,6 +483,8 @@ func TestNew_WithTimeoutContext(t *testing.T) {
 
 // TestNew_ContextUsedInAuth tests that the context is actually passed to auth setup.
 func TestNew_ContextUsedInAuth(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	// This test verifies that the context parameter is actually used
 	// by checking that withAuth() receives the correct context
 
@@ -543,6 +549,8 @@ func TestNew_ContextUsedInAuth(t *testing.T) {
 
 // TestNew_MultipleClientsWithDifferentContexts tests creating multiple clients with different contexts.
 func TestNew_MultipleClientsWithDifferentContexts(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	// Start a real TCP listener
 	lc := net.ListenConfig{}
 
@@ -617,6 +625,8 @@ func TestNew_MultipleClientsWithDifferentContexts(t *testing.T) {
 
 // TestNew_BackgroundContext tests that New() works with background context.
 func TestNew_BackgroundContext(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 	// Start a real TCP listener
 	lc := net.ListenConfig{}
 

--- a/client/oidc_grpc.go
+++ b/client/oidc_grpc.go
@@ -45,6 +45,8 @@ func (o *options) resolveOIDCAccessToken(_ context.Context) (string, error) {
 
 	cache := NewTokenCache()
 
+	// Fast path: use only a currently valid token.
+	// Note: GetValidToken() returns (nil, nil) for both "missing" and "expired" tokens.
 	tok, err := cache.GetValidToken()
 	if err != nil {
 		return "", fmt.Errorf("failed to read OIDC token cache: %w", err)
@@ -52,6 +54,16 @@ func (o *options) resolveOIDCAccessToken(_ context.Context) (string, error) {
 
 	if tok != nil && strings.TrimSpace(tok.AccessToken) != "" {
 		return tok.AccessToken, nil
+	}
+
+	// Disambiguate "missing" vs "expired" so we can return a clearer auth error.
+	cachedToken, err := cache.Load()
+	if err != nil {
+		return "", fmt.Errorf("failed to read OIDC token cache: %w", err)
+	}
+
+	if cachedToken != nil && strings.TrimSpace(cachedToken.AccessToken) != "" && !cache.IsValid(cachedToken) {
+		return "", errors.New("cached OIDC token has expired; run 'dirctl auth login' to refresh authentication")
 	}
 
 	return "", errors.New("no OIDC access token: run 'dirctl auth login', or set DIRECTORY_CLIENT_AUTH_TOKEN")

--- a/client/oidc_grpc_test.go
+++ b/client/oidc_grpc_test.go
@@ -6,6 +6,7 @@ package client
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,5 +61,29 @@ func TestSetupOIDCAuth_NoTokenReturnsError(t *testing.T) {
 
 	err := opts.setupOIDCAuth(context.Background())
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dirctl auth login")
+}
+
+func TestSetupOIDCAuth_ExpiredCachedTokenReturnsAuthError(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cache := NewTokenCache()
+	err := cache.Save(&CachedToken{
+		AccessToken: "expired-token",
+		ExpiresAt:   time.Now().Add(-time.Hour),
+		CreatedAt:   time.Now().Add(-time.Hour),
+	})
+	require.NoError(t, err)
+
+	opts := &options{
+		config: &Config{
+			ServerAddress: "gateway.example.com:443",
+			AuthMode:      "oidc",
+		},
+	}
+
+	err = opts.setupOIDCAuth(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cached OIDC token has expired")
 	assert.Contains(t, err.Error(), "dirctl auth login")
 }

--- a/client/options.go
+++ b/client/options.go
@@ -130,9 +130,13 @@ func (o *options) shouldAutoDetectOIDC() (bool, error) {
 		return true, nil
 	}
 
+	if strings.TrimSpace(o.config.OIDCIssuer) != "" || strings.TrimSpace(o.config.OIDCClientID) != "" {
+		return true, nil
+	}
+
 	cache := NewTokenCache()
 
-	tok, err := cache.GetValidToken()
+	tok, err := cache.Load()
 	if err != nil {
 		return false, fmt.Errorf("failed to read OIDC token cache: %w", err)
 	}

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,6 +128,8 @@ func TestWithAuth_ConfigValidation(t *testing.T) {
 	})
 
 	t.Run("should use insecure credentials when no SPIFFE socket", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 		opts := &options{
 			config: &Config{
 				ServerAddress:    testServerAddr,
@@ -145,6 +148,8 @@ func TestWithAuth_ConfigValidation(t *testing.T) {
 	})
 
 	t.Run("should use insecure credentials when no auth mode", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 		opts := &options{
 			config: &Config{
 				ServerAddress:    testServerAddr,
@@ -222,6 +227,8 @@ func TestOptions_DefaultValues(t *testing.T) {
 
 func TestOptions_ContextUsage(t *testing.T) {
 	t.Run("should accept cancelled context", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 		// Create already-cancelled context
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
@@ -406,6 +413,8 @@ func TestWithAuth_AllAuthModes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
 			socketPath := ""
 			if tc.authMode != "" {
 				socketPath = "/tmp/test-socket-" + tc.name + ".sock"
@@ -505,5 +514,49 @@ func TestSetupAutoDetectAuth(t *testing.T) {
 		require.NoError(t, err)
 		// OIDC adds both transport creds and per-RPC bearer creds
 		assert.Len(t, opts.authOpts, 2)
+	})
+
+	t.Run("should not fallback to insecure when cached OIDC token is expired", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cache := NewTokenCache()
+		err := cache.Save(&CachedToken{
+			AccessToken: "expired-token",
+			ExpiresAt:   time.Now().Add(-time.Hour),
+			CreatedAt:   time.Now().Add(-time.Hour),
+		})
+		require.NoError(t, err)
+
+		opts := &options{
+			config: &Config{
+				ServerAddress: "gateway.example.com:443",
+				AuthMode:      "",
+			},
+		}
+
+		ctx := context.Background()
+		err = opts.setupAutoDetectAuth(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cached OIDC token has expired")
+	})
+
+	t.Run("should auto-detect OIDC when issuer/client config is present", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		opts := &options{
+			config: &Config{
+				ServerAddress: "gateway.example.com:443",
+				AuthMode:      "",
+				OIDCIssuer:    "https://issuer.example.com",
+			},
+		}
+
+		ctx := context.Background()
+		err := opts.setupAutoDetectAuth(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no OIDC access token")
+		assert.Contains(t, err.Error(), "dirctl auth login")
 	})
 }


### PR DESCRIPTION
Fix expired cached OIDC token handling in auth auto-detect mode, avoid insecure fallback when OIDC signals are present, and return a clear prompt to run dirctl auth login.

Closes #1317