### PR TITLE
chore(dir): remove SDK-specific steps of Renovate Sync workflow

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -35,20 +35,6 @@ jobs:
           cache: true
           cache-dependency-path: "**/*.sum"
 
-      - name: Setup Node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "24.x"
-          cache: "npm"
-          cache-dependency-path: "**/package*.json"
-
-      - name: Setup Python (uv)
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
-        with:
-          version: "0.11.6"
-          working-directory: "sdk"
-          enable-cache: true
-
       - name: Run Renovate
         run: task deps:renovate:sync
         env:


### PR DESCRIPTION
since SDKs got migrated, no need for these steps now