### PR TITLE
feat(cli/export): add mcp-ghcopilot format support

### DIFF
--- a/cli/cmd/export/format/a2a.go
+++ b/cli/cmd/export/format/a2a.go
@@ -39,5 +39,5 @@ func (f *a2aFormatter) Format(record *corev1.Record) ([]byte, error) {
 }
 
 func (f *a2aFormatter) FileExtension() string {
-	return ".json"
+	return ExtJSON
 }

--- a/cli/cmd/export/format/format.go
+++ b/cli/cmd/export/format/format.go
@@ -19,6 +19,8 @@ type Formatter interface {
 	FileExtension() string
 }
 
+const ExtJSON = ".json"
+
 var (
 	registryMu sync.RWMutex
 	formatters = map[string]Formatter{}

--- a/cli/cmd/export/format/mcp.go
+++ b/cli/cmd/export/format/mcp.go
@@ -1,0 +1,43 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package format
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
+)
+
+func init() {
+	RegisterFormatter("mcp-ghcopilot", &mcpGHCopilotFormatter{})
+}
+
+type mcpGHCopilotFormatter struct{}
+
+func (f *mcpGHCopilotFormatter) Format(record *corev1.Record) ([]byte, error) {
+	data := record.GetData()
+	if data == nil {
+		return nil, fmt.Errorf("record contains no data")
+	}
+
+	ghCopilotConfig, err := translator.RecordToGHCopilot(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to translate record to GitHub Copilot MCP config: %w", err)
+	}
+
+	raw, err := json.MarshalIndent(ghCopilotConfig, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal GitHub Copilot MCP config to JSON: %w", err)
+	}
+
+	raw = append(raw, '\n')
+
+	return raw, nil
+}
+
+func (f *mcpGHCopilotFormatter) FileExtension() string {
+	return ExtJSON
+}

--- a/cli/cmd/export/format/mcp_test.go
+++ b/cli/cmd/export/format/mcp_test.go
@@ -1,0 +1,114 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package format_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/cmd/export/format"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// Minimal OASF record with an MCP module in 1.0.0 format (name + connections)
+// so that RecordToGHCopilot can translate it into a GHCopilotMCPConfig.
+const testMCPGHCopilotRecordJSON = `{
+  "schema_version": "1.0.0",
+  "name": "io.example/code-review-server",
+  "version": "1.0.0",
+  "description": "MCP server for code review",
+  "modules": [
+    {
+      "name": "integration/mcp",
+      "data": {
+        "name": "io.example/code-review-server",
+        "connections": [
+          {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["@example/code-review-server@1.0.0"],
+            "env_vars": [
+              {
+                "name": "API_KEY",
+                "description": "API key for authentication"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}`
+
+func newMCPGHCopilotTestRecord(t *testing.T, recordJSON string) *corev1.Record {
+	t.Helper()
+
+	var data structpb.Struct
+
+	require.NoError(t, protojson.Unmarshal([]byte(recordJSON), &data))
+
+	return &corev1.Record{Data: &data}
+}
+
+func TestGetMCPGHCopilotFormatter(t *testing.T) {
+	f, err := format.GetFormatter("mcp-ghcopilot")
+	require.NoError(t, err)
+	assert.NotNil(t, f)
+}
+
+func TestMCPGHCopilotFormatter_Format(t *testing.T) {
+	f, err := format.GetFormatter("mcp-ghcopilot")
+	require.NoError(t, err)
+
+	t.Run("formats a record with MCP module data into GHCopilot config", func(t *testing.T) {
+		record := newMCPGHCopilotTestRecord(t, testMCPGHCopilotRecordJSON)
+
+		output, err := f.Format(record)
+		require.NoError(t, err)
+		assert.NotEmpty(t, output)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(output, &parsed))
+
+		servers, ok := parsed["servers"].(map[string]any)
+		require.True(t, ok, "output should contain a 'servers' map")
+		assert.NotEmpty(t, servers, "servers map should not be empty")
+
+		// normalizeServerName trims "-server" so the key should be
+		// "io.example/code-review"
+		server, ok := servers["io.example/code-review"].(map[string]any)
+		require.True(t, ok, "servers should contain the normalized server name")
+		assert.Equal(t, "npx", server["command"])
+
+		inputs, ok := parsed["inputs"].([]any)
+		require.True(t, ok, "output should contain an 'inputs' array")
+		assert.NotEmpty(t, inputs, "inputs should contain the API_KEY entry")
+	})
+
+	t.Run("returns error for record with nil data", func(t *testing.T) {
+		record := &corev1.Record{}
+
+		_, err := f.Format(record)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "record contains no data")
+	})
+
+	t.Run("returns error for record without MCP module data", func(t *testing.T) {
+		record := newTestRecord()
+
+		_, err := f.Format(record)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to translate record to GitHub Copilot MCP config")
+	})
+}
+
+func TestMCPGHCopilotFormatter_FileExtension(t *testing.T) {
+	f, err := format.GetFormatter("mcp-ghcopilot")
+	require.NoError(t, err)
+	assert.Equal(t, ".json", f.FileExtension())
+}

--- a/cli/cmd/export/format/oasf.go
+++ b/cli/cmd/export/format/oasf.go
@@ -36,5 +36,5 @@ func (f *oasfFormatter) Format(record *corev1.Record) ([]byte, error) {
 }
 
 func (f *oasfFormatter) FileExtension() string {
-	return ".json"
+	return ExtJSON
 }

--- a/tests/e2e/local/11_export_test.go
+++ b/tests/e2e/local/11_export_test.go
@@ -210,6 +210,95 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command"
 		})
 	})
 
+	ginkgo.Context("Export with mcp-ghcopilot format", ginkgo.Ordered, ginkgo.Serial, func() {
+		var cid string
+
+		tempDir, err := os.MkdirTemp("", "export-mcp-ghcopilot-e2e-*")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.BeforeAll(func() {
+			factory.Replace(importerconfig.ImportTypeMCP, importerWithStaticEnricher)
+		})
+
+		ginkgo.AfterAll(func() {
+			os.RemoveAll(tempDir)
+			factory.Replace(importerconfig.ImportTypeMCP, importer.New)
+		})
+
+		ginkgo.It("should import an MCP server descriptor to set up test data", func() {
+			serverPath := filepath.Join(tempDir, "mcp-server.json")
+			gomega.Expect(os.WriteFile(serverPath, testdata.MCPServer, 0o600)).To(gomega.Succeed())
+
+			enrichCfg := filepath.Join(tempDir, "mcphost.json")
+			gomega.Expect(os.WriteFile(enrichCfg, []byte(`{}`), 0o600)).To(gomega.Succeed())
+
+			cidFile := filepath.Join(tempDir, "imported.cids")
+
+			cli.Import("mcp", serverPath).WithArgs("--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldSucceed()
+
+			cidData, err := os.ReadFile(cidFile)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			cid = strings.TrimSpace(string(cidData))
+			gomega.Expect(cid).NotTo(gomega.BeEmpty(), "imported CID should not be empty")
+		})
+
+		ginkgo.It("should export the record as GitHub Copilot MCP config to stdout", func() {
+			output := cli.Export(cid).WithArgs("--format", "mcp-ghcopilot").ShouldSucceed()
+			gomega.Expect(output).NotTo(gomega.BeEmpty())
+
+			var exported map[string]any
+
+			err := json.Unmarshal([]byte(output), &exported)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "stdout output should be valid JSON")
+
+			gomega.Expect(exported).To(gomega.HaveKey("servers"), "output should have a 'servers' key")
+			gomega.Expect(exported).To(gomega.HaveKey("inputs"), "output should have an 'inputs' key")
+
+			servers, ok := exported["servers"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(servers).NotTo(gomega.BeEmpty(), "servers map should contain at least one entry")
+		})
+
+		ginkgo.It("should export the record as GitHub Copilot MCP config to a file", func() {
+			outPath := filepath.Join(tempDir, "ghcopilot.json")
+
+			cli.Export(cid).WithArgs("--format", "mcp-ghcopilot", "--output-file", outPath).ShouldSucceed()
+
+			data, err := os.ReadFile(outPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			var parsed map[string]any
+
+			err = json.Unmarshal(data, &parsed)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "file content should be valid JSON")
+			gomega.Expect(parsed).To(gomega.HaveKey("servers"))
+		})
+
+		ginkgo.It("should auto-append .json extension when omitted", func() {
+			outPath := filepath.Join(tempDir, "ghcopilot_no_ext")
+			expectedPath := outPath + ".json"
+
+			cli.Export(cid).WithArgs("--format", "mcp-ghcopilot", "--output-file", outPath).ShouldSucceed()
+
+			_, err := os.Stat(expectedPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+				"file with auto-appended .json extension should exist")
+
+			data, err := os.ReadFile(expectedPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			var parsed map[string]any
+
+			err = json.Unmarshal(data, &parsed)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "file content should be valid JSON")
+		})
+
+		ginkgo.It("should clean up the test record", func() {
+			cli.Delete(cid).ShouldSucceed()
+		})
+	})
+
 	ginkgo.Context("Export with skill format", ginkgo.Ordered, ginkgo.Serial, func() {
 		var cid string
 

--- a/tests/e2e/shared/testdata/embed.go
+++ b/tests/e2e/shared/testdata/embed.go
@@ -36,6 +36,13 @@ var ExpectedRecordV070NameResolutionJSON []byte
 //go:embed a2a-agent-card.json
 var A2AAgentCard []byte
 
+// MCPServer is a sample MCP server descriptor JSON following the MCP registry server.json format.
+// Structure inspired by https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx
+// (Apache-2.0); content is original.
+//
+//go:embed mcp-server.json
+var MCPServer []byte
+
 // SkillMarkdown is a sample SKILL.md following the Agent Skills format
 // (https://agentskills.io/specification). The on-disk directory at
 // code-review/SKILL.md can be used directly with `dirctl import --type=agent-skill`.

--- a/tests/e2e/shared/testdata/mcp-server.json
+++ b/tests/e2e/shared/testdata/mcp-server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.example/code-review-server",
+  "description": "MCP server that performs automated code reviews",
+  "version": "1.0.0",
+  "repository": {
+    "url": "https://github.com/example/code-review-server",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@example/code-review-server",
+      "version": "1.0.0",
+      "environmentVariables": [
+        {
+          "name": "REVIEW_API_KEY",
+          "description": "API key for the code review service"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add `mcp-ghcopilot` export format for the local Directory, enabling records with MCP module data to be exported as GitHub Copilot MCP configuration JSON via `dirctl export <CID> --format mcp-ghcopilot`. The formatter uses the SDK's `RecordToGHCopilot` translator to produce a config with `servers` and `inputs` keys compatible with VS Code / GitHub Copilot's `.vscode/mcp.json`.