### PR TITLE
feat(dir/helm): add dedicated Envoy timeout handling for EventService/Listen

### DIFF
--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -598,6 +598,15 @@ envoy-authz:
     backend:
       address: "" # e.g., dir-dir-dev-argoapp-apiserver.dir-dev-dir.svc.cluster.local
       port: 8888
+      # Default Envoy route timeout for Directory gRPC methods.
+      # This is an overall Envoy -> apiserver request/stream timeout, unlike the
+      # ingress read/send timeouts below which are mostly idle-gap timeouts.
+      timeout: 30s
+      # Dedicated timeout for the long-lived EventService/Listen stream route.
+      # Set to 0s to disable the Envoy route timeout for that RPC only.
+      # The effective stream lifetime is still capped by any tighter ingress or
+      # downstream timeout because the first layer to time out breaks the stream.
+      listenRouteTimeout: 0s
 
     oidc:
       dex:
@@ -681,6 +690,13 @@ envoy-authz:
       external-dns.alpha.kubernetes.io/hostname: ""
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
       nginx.ingress.kubernetes.io/grpc-backend: "true"
+      # Recommended for long-lived gRPC streams such as EventService/Listen.
+      # These are ingress-layer read/send idle timeouts, not overall request caps.
+      # They complement envoy.backend.timeout / listenRouteTimeout on the
+      # Envoy -> apiserver hop; the most restrictive layer still wins.
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      # nginx.ingress.kubernetes.io/proxy-stream-timeout: "3600"
 
 # PostgreSQL subchart configuration
 # Deploys PostgreSQL alongside the apiserver for dev/production use.

--- a/install/charts/envoy-authz/templates/configmap-envoy.yaml
+++ b/install/charts/envoy-authz/templates/configmap-envoy.yaml
@@ -59,6 +59,20 @@ data:
                                 envoy.filters.http.ext_authz:
                                   "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                                   disabled: true
+                            # Event stream - long-lived server streaming RPC
+                            - match:
+                                path: "/agntcy.dir.events.v1.EventService/Listen"
+                              route:
+                                cluster: directory_backend
+                                timeout: {{ .Values.envoy.backend.listenRouteTimeout }}
+                              request_headers_to_remove:
+                                - "authorization"
+                              typed_per_filter_config:
+                                envoy.filters.http.header_mutation:
+                                  "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutationPerRoute
+                                  mutations:
+                                    request_mutations:
+                                      - remove: "x-jwt-payload"
                             # Dir gRPC - require JWT, strip Authorization before backend
                             - match:
                                 prefix: "/agntcy.dir"

--- a/install/charts/envoy-authz/values.yaml
+++ b/install/charts/envoy-authz/values.yaml
@@ -25,8 +25,15 @@ envoy:
     # Example: dir-dir-dev-argoapp-apiserver.dir-dev-dir.svc.cluster.local
     address: ""
     port: 8888
-    # Connection timeout
+    # Default Envoy route timeout for Directory gRPC methods.
+    # This acts as an overall request/stream cap on the Envoy -> apiserver hop.
+    # For long-lived server streams, the smallest timeout across ingress and Envoy
+    # still wins because the first layer to time out breaks the full request path.
     timeout: 30s
+    # Dedicated route timeout for the EventService/Listen server stream.
+    # Use 0s to disable the Envoy route timeout for this long-lived stream only,
+    # while preserving backend.timeout for ordinary unary RPCs.
+    listenRouteTimeout: 0s
 
   # OIDC/JWT configuration for jwt_authn filter
   oidc:


### PR DESCRIPTION
## Summary
- add a dedicated Envoy route for `/agntcy.dir.events.v1.EventService/Listen` with its own timeout setting
- keep the default Envoy backend timeout for other Directory gRPC methods unchanged
- document how Envoy route timeouts relate to ingress gRPC timeout settings in chart defaults and env overlays

## Details
This change fixes the event-listener stream being terminated by the generic Envoy route timeout.

`EventService/Listen` is a long-lived server stream, but it previously matched the generic `/agntcy.dir` route and inherited the default `backend.timeout` value. That made the stream vulnerable to premature termination even while normal unary RPCs should continue using the shorter default timeout.

This PR:
- adds an exact-match Envoy route for `/agntcy.dir.events.v1.EventService/Listen`
- introduces `envoy.backend.listenRouteTimeout` for that route
- keeps `envoy.backend.timeout` as the default for normal RPCs
- adds explanatory comments around Envoy and ingress timeout behavior
- adds ingress timeout annotations in dev/prod overlays to reduce the chance that ingress closes long-lived streams first

Closes #1333