### PR TITLE
feat(cli/export): add batch export from search results

### DIFF
--- a/api/core/v1/record.go
+++ b/api/core/v1/record.go
@@ -44,6 +44,32 @@ func InitializeValidator(schemaURL string) error {
 	return nil
 }
 
+// GetName extracts the top-level "name" field from the record's data.
+func (r *Record) GetName() string {
+	if r == nil || r.GetData() == nil {
+		return ""
+	}
+
+	if v, ok := r.GetData().GetFields()["name"]; ok {
+		return v.GetStringValue()
+	}
+
+	return ""
+}
+
+// GetVersion extracts the top-level "version" field from the record's data.
+func (r *Record) GetVersion() string {
+	if r == nil || r.GetData() == nil {
+		return ""
+	}
+
+	if v, ok := r.GetData().GetFields()["version"]; ok {
+		return v.GetStringValue()
+	}
+
+	return ""
+}
+
 // GetCid calculates and returns the CID for this record.
 // The CID is calculated from the record's content using CIDv1, codec 1, SHA2-256.
 // Uses canonical JSON marshaling to ensure consistent, cross-language compatible results.

--- a/api/core/v1/record_test.go
+++ b/api/core/v1/record_test.go
@@ -423,3 +423,92 @@ func TestRecord_Decode(t *testing.T) {
 		})
 	}
 }
+
+func TestRecord_GetName(t *testing.T) {
+	tests := []struct {
+		name   string
+		record *corev1.Record
+		want   string
+	}{
+		{
+			name: "returns name from valid record",
+			record: corev1.New(&oasfv1alpha1.Record{
+				Name:          "my-agent",
+				SchemaVersion: "0.7.0",
+			}),
+			want: "my-agent",
+		},
+		{
+			name:   "returns empty for nil record",
+			record: nil,
+			want:   "",
+		},
+		{
+			name:   "returns empty for empty record",
+			record: &corev1.Record{},
+			want:   "",
+		},
+		{
+			name: "returns empty when name field is absent",
+			record: &corev1.Record{
+				Data: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"description": structpb.NewStringValue("no name here"),
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.record.GetName())
+		})
+	}
+}
+
+func TestRecord_GetVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		record *corev1.Record
+		want   string
+	}{
+		{
+			name: "returns version from valid record",
+			record: corev1.New(&oasfv1alpha1.Record{
+				Name:          "my-agent",
+				SchemaVersion: "0.7.0",
+				Version:       "2.1.0",
+			}),
+			want: "2.1.0",
+		},
+		{
+			name:   "returns empty for nil record",
+			record: nil,
+			want:   "",
+		},
+		{
+			name:   "returns empty for empty record",
+			record: &corev1.Record{},
+			want:   "",
+		},
+		{
+			name: "returns empty when version field is absent",
+			record: &corev1.Record{
+				Data: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"name": structpb.NewStringValue("no-version"),
+					},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.record.GetVersion())
+		})
+	}
+}

--- a/cli/cmd/export/export.go
+++ b/cli/cmd/export/export.go
@@ -139,9 +139,9 @@ func runBatchExport(cmd *cobra.Command) error {
 	var exported int
 
 	if bf, ok := formatter.(format.BatchFormatter); ok {
-		exported, err = bf.FormatBatch(records, opts.OutputDir)
+		exported, err = bf.FormatBatch(records, opts.OutputDir, opts.AllVersions)
 	} else {
-		exported, err = format.DefaultBatchExport(formatter, records, opts.OutputDir)
+		exported, err = format.DefaultBatchExport(formatter, records, opts.OutputDir, opts.AllVersions)
 	}
 
 	if err != nil {

--- a/cli/cmd/export/export.go
+++ b/cli/cmd/export/export.go
@@ -11,10 +11,13 @@ import (
 	"path/filepath"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
+	searchv1 "github.com/agntcy/dir/api/search/v1"
 	"github.com/agntcy/dir/cli/cmd/export/format"
+	"github.com/agntcy/dir/cli/cmd/search"
 	"github.com/agntcy/dir/cli/presenter"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/agntcy/dir/cli/util/reference"
+	"github.com/agntcy/dir/client"
 	"github.com/spf13/cobra"
 )
 
@@ -26,26 +29,36 @@ and writes the result to a file or stdout.
 
 The --format flag selects the output format:
 
-  oasf         Raw OASF record JSON (default)
-  agent-skill  SKILL.md artifact for agentic CLI consumption (Cursor, Claude Code, etc.)
-  a2a          A2A AgentCard JSON for Agent-to-Agent protocol interop
+  oasf           Raw OASF record JSON (default)
+  agent-skill    SKILL.md artifact for agentic CLI consumption (Cursor, Claude Code, etc.)
+  a2a            A2A AgentCard JSON for Agent-to-Agent protocol interop
+  mcp-ghcopilot  GitHub Copilot MCP configuration JSON
 
-Usage examples:
+Single-record examples:
 
-  # Export raw OASF JSON to stdout
-  dirctl export bafyreib...
-
-  # Export to a file
-  dirctl export my-agent:1.0 --output-file=./record.json
-
-  # Export as SKILL.md
+  dirctl export bafyreib... --format=a2a --output-file=./agent-card.json
   dirctl export my-agent:1.0 --format=agent-skill --output-file=./SKILL.md
 
-  # Export as A2A AgentCard
-  dirctl export my-agent:1.0 --format=a2a --output-file=./agent-card.json
+Batch export from search results:
+
+  dirctl export --output-dir=./exports/ --format=a2a --name "web*"
+  dirctl export --output-dir=./exports/ --format=agent-skill --skill "code*"
+  dirctl export --output-dir=./exports/ --format=mcp-ghcopilot --module "integration/mcp"
 `,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if opts.OutputDir != "" {
+			if len(args) > 0 {
+				return errors.New("positional argument and --output-dir are mutually exclusive")
+			}
+
+			return runBatchExport(cmd)
+		}
+
+		if len(args) == 0 {
+			return errors.New("either a CID/name argument or --output-dir is required")
+		}
+
 		return runExport(cmd, args[0])
 	},
 }
@@ -90,6 +103,101 @@ func runExport(cmd *cobra.Command, input string) error {
 	presenter.Print(cmd, string(output))
 
 	return nil
+}
+
+func runBatchExport(cmd *cobra.Command) error {
+	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
+	if !ok {
+		return errors.New("failed to get client from context")
+	}
+
+	formatter, err := format.GetFormatter(opts.Format)
+	if err != nil {
+		return err
+	}
+
+	queries := search.BuildQueries(&opts.Filters)
+	if len(queries) == 0 {
+		return errors.New("at least one search filter is required for batch export (e.g. --name, --module)")
+	}
+
+	if err := os.MkdirAll(opts.OutputDir, 0o755); err != nil { //nolint:mnd
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	records, err := searchAndPull(cmd, c, queries)
+	if err != nil {
+		return err
+	}
+
+	if len(records) == 0 {
+		presenter.PrintSmartf(cmd, "No records matched the search criteria\n")
+
+		return nil
+	}
+
+	var exported int
+
+	if bf, ok := formatter.(format.BatchFormatter); ok {
+		exported, err = bf.FormatBatch(records, opts.OutputDir)
+	} else {
+		exported, err = format.DefaultBatchExport(formatter, records, opts.OutputDir)
+	}
+
+	if err != nil {
+		return fmt.Errorf("batch export failed: %w", err)
+	}
+
+	presenter.PrintSmartf(cmd, "Exported %d record(s) to %s\n", exported, opts.OutputDir)
+
+	return nil
+}
+
+func searchAndPull(cmd *cobra.Command, c *client.Client, queries []*searchv1.RecordQuery) ([]*corev1.Record, error) {
+	cids, err := collectCIDs(cmd, c, queries)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]*corev1.Record, 0, len(cids))
+
+	for _, cid := range cids {
+		record, err := c.Pull(cmd.Context(), &corev1.RecordRef{Cid: cid})
+		if err != nil {
+			return nil, fmt.Errorf("failed to pull record %s: %w", cid, err)
+		}
+
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+func collectCIDs(cmd *cobra.Command, c *client.Client, queries []*searchv1.RecordQuery) ([]string, error) {
+	result, err := c.SearchCIDs(cmd.Context(), &searchv1.SearchCIDsRequest{
+		Limit:   &opts.Limit,
+		Queries: queries,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search failed: %w", err)
+	}
+
+	var cids []string
+
+	for {
+		select {
+		case resp := <-result.ResCh():
+			if cid := resp.GetRecordCid(); cid != "" {
+				cids = append(cids, cid)
+			}
+		case err := <-result.ErrCh():
+			return nil, fmt.Errorf("error during search: %w", err)
+		case <-result.DoneCh():
+			return cids, nil
+		case <-cmd.Context().Done():
+			return nil, cmd.Context().Err()
+		}
+	}
 }
 
 func writeFile(cmd *cobra.Command, path string, data []byte) error {

--- a/cli/cmd/export/format/batch.go
+++ b/cli/cmd/export/format/batch.go
@@ -13,34 +13,6 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// RecordName extracts the name field from a record's data.
-func RecordName(record *corev1.Record) string {
-	data := record.GetData()
-	if data == nil {
-		return ""
-	}
-
-	if nameVal, ok := data.GetFields()["name"]; ok {
-		return nameVal.GetStringValue()
-	}
-
-	return ""
-}
-
-// recordVersion extracts the version field from a record's data.
-func recordVersion(record *corev1.Record) string {
-	data := record.GetData()
-	if data == nil {
-		return ""
-	}
-
-	if v, ok := data.GetFields()["version"]; ok {
-		return v.GetStringValue()
-	}
-
-	return ""
-}
-
 // SanitizeName replaces characters unsafe for filenames with hyphens.
 func SanitizeName(name string) string {
 	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
@@ -76,8 +48,8 @@ func LatestByName(records []*corev1.Record) []*corev1.Record {
 	var order []string
 
 	for _, r := range records {
-		name := RecordName(r)
-		ver := canonicalVersion(recordVersion(r))
+		name := r.GetName()
+		ver := canonicalVersion(r.GetVersion())
 
 		existing, seen := best[name]
 		if !seen {
@@ -111,7 +83,7 @@ func LatestByName(records []*corev1.Record) []*corev1.Record {
 // When allVersions is false only the name is used (the caller is expected
 // to have already deduplicated to the latest version per name).
 func batchFileName(record *corev1.Record, index int, seen map[string]int, allVersions bool) string {
-	name := RecordName(record)
+	name := record.GetName()
 	if name == "" {
 		return fmt.Sprintf("record_%d", index)
 	}
@@ -119,7 +91,7 @@ func batchFileName(record *corev1.Record, index int, seen map[string]int, allVer
 	base := SanitizeName(name)
 
 	if allVersions {
-		if version := recordVersion(record); version != "" {
+		if version := record.GetVersion(); version != "" {
 			base += "-" + SanitizeName(version)
 		}
 

--- a/cli/cmd/export/format/batch.go
+++ b/cli/cmd/export/format/batch.go
@@ -1,0 +1,169 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package format
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"golang.org/x/mod/semver"
+)
+
+// RecordName extracts the name field from a record's data.
+func RecordName(record *corev1.Record) string {
+	data := record.GetData()
+	if data == nil {
+		return ""
+	}
+
+	if nameVal, ok := data.GetFields()["name"]; ok {
+		return nameVal.GetStringValue()
+	}
+
+	return ""
+}
+
+// recordVersion extracts the version field from a record's data.
+func recordVersion(record *corev1.Record) string {
+	data := record.GetData()
+	if data == nil {
+		return ""
+	}
+
+	if v, ok := data.GetFields()["version"]; ok {
+		return v.GetStringValue()
+	}
+
+	return ""
+}
+
+// SanitizeName replaces characters unsafe for filenames with hyphens.
+func SanitizeName(name string) string {
+	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
+
+	return r.Replace(name)
+}
+
+// canonicalVersion returns the version string normalised to a semver-valid form.
+func canonicalVersion(raw string) string {
+	v := raw
+	if v != "" && v[0] != 'v' {
+		v = "v" + v
+	}
+
+	if semver.IsValid(v) {
+		return v
+	}
+
+	return ""
+}
+
+// LatestByName deduplicates records by name, keeping only the record with
+// the highest semver version for each unique name. Records without a
+// parseable version are kept unconditionally.
+func LatestByName(records []*corev1.Record) []*corev1.Record {
+	type entry struct {
+		record  *corev1.Record
+		version string
+	}
+
+	best := map[string]*entry{}
+	var order []string
+
+	for _, r := range records {
+		name := RecordName(r)
+		ver := canonicalVersion(recordVersion(r))
+
+		existing, seen := best[name]
+		if !seen {
+			order = append(order, name)
+			best[name] = &entry{record: r, version: ver}
+
+			continue
+		}
+
+		if ver == "" {
+			continue
+		}
+
+		if existing.version == "" || semver.Compare(ver, existing.version) > 0 {
+			best[name] = &entry{record: r, version: ver}
+		}
+	}
+
+	result := make([]*corev1.Record, 0, len(order))
+	for _, name := range order {
+		result = append(result, best[name].record)
+	}
+
+	return result
+}
+
+// batchFileName returns a sanitised base name for a record inside a batch
+// export.
+// When allVersions is true the version is appended to keep every version;
+// a numeric suffix is added if the base is still not unique.
+// When allVersions is false only the name is used (the caller is expected
+// to have already deduplicated to the latest version per name).
+func batchFileName(record *corev1.Record, index int, seen map[string]int, allVersions bool) string {
+	name := RecordName(record)
+	if name == "" {
+		return fmt.Sprintf("record_%d", index)
+	}
+
+	base := SanitizeName(name)
+
+	if allVersions {
+		if version := recordVersion(record); version != "" {
+			base += "-" + SanitizeName(version)
+		}
+
+		count := seen[base]
+		seen[base] = count + 1
+
+		if count > 0 {
+			base = fmt.Sprintf("%s-%d", base, count)
+		}
+	}
+
+	return base
+}
+
+// DefaultBatchExport provides per-record file writing for formatters that
+// do not implement BatchFormatter.
+// When allVersions is false (default), records are deduplicated by name
+// and only the highest semver version per name is exported.
+// When allVersions is true, every record is exported with the version
+// included in the filename.
+func DefaultBatchExport(f Formatter, records []*corev1.Record, outputDir string, allVersions bool) (int, error) {
+	toExport := records
+	if !allVersions {
+		toExport = LatestByName(records)
+	}
+
+	exported := 0
+	seen := make(map[string]int)
+
+	for i, record := range toExport {
+		base := batchFileName(record, i, seen, allVersions)
+
+		output, err := f.Format(record)
+		if err != nil {
+			return exported, fmt.Errorf("failed to format record %q: %w", base, err)
+		}
+
+		outPath := filepath.Join(outputDir, base+f.FileExtension())
+
+		if err := os.WriteFile(outPath, output, 0o600); err != nil { //nolint:mnd
+			return exported, fmt.Errorf("failed to write %s: %w", outPath, err)
+		}
+
+		exported++
+	}
+
+	return exported, nil
+}

--- a/cli/cmd/export/format/batch.go
+++ b/cli/cmd/export/format/batch.go
@@ -72,6 +72,7 @@ func LatestByName(records []*corev1.Record) []*corev1.Record {
 	}
 
 	best := map[string]*entry{}
+
 	var order []string
 
 	for _, r := range records {

--- a/cli/cmd/export/format/batch_test.go
+++ b/cli/cmd/export/format/batch_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
@@ -293,9 +292,9 @@ func TestLatestByName(t *testing.T) {
 	})
 
 	t.Run("preserves insertion order", func(t *testing.T) {
-		r1 := newA2ATestRecord(t)      // name="test-a2a-agent"
-		r2 := newTestRecord()           // name="test-agent"
-		r3 := newA2ATestRecord(t)       // duplicate — should merge with r1
+		r1 := newA2ATestRecord(t) // name="test-a2a-agent"
+		r2 := newTestRecord()     // name="test-agent"
+		r3 := newA2ATestRecord(t) // duplicate — should merge with r1
 
 		result := format.LatestByName([]*corev1.Record{r1, r2, r3})
 		require.Len(t, result, 2)
@@ -320,7 +319,7 @@ func TestLatestByName(t *testing.T) {
 		require.Len(t, result, 1)
 
 		ver := result[0].GetData().GetFields()["version"].GetStringValue()
-		assert.False(t, strings.Contains(ver, "alpha"), "release should beat alpha")
+		assert.NotContains(t, ver, "alpha", "release should beat alpha")
 	})
 
 	t.Run("returns nil for empty input", func(t *testing.T) {

--- a/cli/cmd/export/format/batch_test.go
+++ b/cli/cmd/export/format/batch_test.go
@@ -1,0 +1,117 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package format_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/cmd/export/format"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultBatchExport(t *testing.T) {
+	f, err := format.GetFormatter("a2a")
+	require.NoError(t, err)
+
+	t.Run("writes one file per record", func(t *testing.T) {
+		dir := t.TempDir()
+		records := []*corev1.Record{newA2ATestRecord(t)}
+
+		n, err := format.DefaultBatchExport(f, records, dir)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "test-a2a-agent.json", entries[0].Name())
+	})
+
+	t.Run("returns zero for empty slice", func(t *testing.T) {
+		dir := t.TempDir()
+		n, err := format.DefaultBatchExport(f, nil, dir)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+	})
+}
+
+func TestSkillBatchFormatter(t *testing.T) {
+	f, err := format.GetFormatter("agent-skill")
+	require.NoError(t, err)
+
+	bf, ok := f.(format.BatchFormatter)
+	require.True(t, ok, "agent-skill should implement BatchFormatter")
+
+	t.Run("creates subdirectory per skill", func(t *testing.T) {
+		dir := t.TempDir()
+		records := []*corev1.Record{newSkillTestRecord(t)}
+
+		n, err := bf.FormatBatch(records, dir)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		skillPath := filepath.Join(dir, "code-review", "SKILL.md")
+		data, err := os.ReadFile(skillPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "name: code-review")
+	})
+}
+
+func TestMCPGHCopilotBatchFormatter(t *testing.T) {
+	f, err := format.GetFormatter("mcp-ghcopilot")
+	require.NoError(t, err)
+
+	bf, ok := f.(format.BatchFormatter)
+	require.True(t, ok, "mcp-ghcopilot should implement BatchFormatter")
+
+	t.Run("merges multiple records into single mcp.json", func(t *testing.T) {
+		dir := t.TempDir()
+		r1 := newMCPGHCopilotTestRecord(t, testMCPGHCopilotRecordJSON)
+		records := []*corev1.Record{r1}
+
+		n, err := bf.FormatBatch(records, dir)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		data, err := os.ReadFile(filepath.Join(dir, "mcp.json"))
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		assert.NotEmpty(t, parsed["servers"])
+		assert.NotEmpty(t, parsed["inputs"])
+	})
+
+	t.Run("returns zero for empty slice", func(t *testing.T) {
+		dir := t.TempDir()
+		n, err := bf.FormatBatch(nil, dir)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+
+		data, err := os.ReadFile(filepath.Join(dir, "mcp.json"))
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		assert.Empty(t, parsed["servers"])
+	})
+}
+
+func TestRecordName(t *testing.T) {
+	record := newA2ATestRecord(t)
+	assert.Equal(t, "test-a2a-agent", format.RecordName(record))
+
+	assert.Empty(t, format.RecordName(&corev1.Record{}))
+}
+
+func TestSanitizeName(t *testing.T) {
+	assert.Equal(t, "io.example-code-review", format.SanitizeName("io.example/code-review"))
+	assert.Equal(t, "simple-name", format.SanitizeName("simple-name"))
+	assert.Equal(t, "with-spaces", format.SanitizeName("with spaces"))
+}

--- a/cli/cmd/export/format/batch_test.go
+++ b/cli/cmd/export/format/batch_test.go
@@ -5,25 +5,76 @@ package format_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/dir/cli/cmd/export/format"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
+
+func newA2ATestRecordWithVersion(t *testing.T, version string) *corev1.Record {
+	t.Helper()
+
+	raw := fmt.Sprintf(`{
+  "schema_version": "1.0.0",
+  "name": "test-a2a-agent",
+  "version": %q,
+  "description": "A test A2A agent",
+  "modules": [
+    {
+      "name": "integration/a2a",
+      "data": {
+        "card_data": {
+          "name": "test-a2a-agent",
+          "description": "A test A2A agent",
+          "version": %q,
+          "protocolVersions": ["0.2.6"],
+          "supportedInterfaces": [
+            {
+              "url": "https://example.com/a2a",
+              "protocolBinding": "HTTP+JSON"
+            }
+          ],
+          "capabilities": {},
+          "defaultInputModes": ["text"],
+          "defaultOutputModes": ["text"],
+          "skills": [
+            {
+              "id": "test-skill",
+              "name": "Test Skill",
+              "description": "A skill for testing"
+            }
+          ]
+        },
+        "card_schema_version": "v1.0.0"
+      }
+    }
+  ]
+}`, version, version)
+
+	var data structpb.Struct
+
+	require.NoError(t, protojson.Unmarshal([]byte(raw), &data))
+
+	return &corev1.Record{Data: &data}
+}
 
 func TestDefaultBatchExport(t *testing.T) {
 	f, err := format.GetFormatter("a2a")
 	require.NoError(t, err)
 
-	t.Run("writes one file per record", func(t *testing.T) {
+	t.Run("uses name only by default", func(t *testing.T) {
 		dir := t.TempDir()
 		records := []*corev1.Record{newA2ATestRecord(t)}
 
-		n, err := format.DefaultBatchExport(f, records, dir)
+		n, err := format.DefaultBatchExport(f, records, dir, false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, n)
 
@@ -33,9 +84,101 @@ func TestDefaultBatchExport(t *testing.T) {
 		assert.Equal(t, "test-a2a-agent.json", entries[0].Name())
 	})
 
+	t.Run("keeps only latest version by default", func(t *testing.T) {
+		dir := t.TempDir()
+		older := newA2ATestRecordWithVersion(t, "1.0.0")
+		newer := newA2ATestRecordWithVersion(t, "2.0.0")
+		// older version first — the exporter should still pick 2.0.0
+		records := []*corev1.Record{older, newer}
+
+		n, err := format.DefaultBatchExport(f, records, dir, false)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "test-a2a-agent.json", entries[0].Name())
+
+		data, err := os.ReadFile(filepath.Join(dir, "test-a2a-agent.json"))
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		assert.Equal(t, "2.0.0", parsed["version"])
+	})
+
+	t.Run("keeps latest even if it appears first", func(t *testing.T) {
+		dir := t.TempDir()
+		newer := newA2ATestRecordWithVersion(t, "3.0.0")
+		older := newA2ATestRecordWithVersion(t, "1.0.0")
+		records := []*corev1.Record{newer, older}
+
+		n, err := format.DefaultBatchExport(f, records, dir, false)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		data, err := os.ReadFile(filepath.Join(dir, "test-a2a-agent.json"))
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		assert.Equal(t, "3.0.0", parsed["version"])
+	})
+
+	t.Run("all-versions includes version in filename", func(t *testing.T) {
+		dir := t.TempDir()
+		records := []*corev1.Record{newA2ATestRecord(t)}
+
+		n, err := format.DefaultBatchExport(f, records, dir, true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "test-a2a-agent-1.0.0.json", entries[0].Name())
+	})
+
+	t.Run("all-versions keeps every version", func(t *testing.T) {
+		dir := t.TempDir()
+		v1 := newA2ATestRecordWithVersion(t, "1.0.0")
+		v2 := newA2ATestRecordWithVersion(t, "2.0.0")
+		records := []*corev1.Record{v1, v2}
+
+		n, err := format.DefaultBatchExport(f, records, dir, true)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 2)
+
+		names := []string{entries[0].Name(), entries[1].Name()}
+		assert.Contains(t, names, "test-a2a-agent-1.0.0.json")
+		assert.Contains(t, names, "test-a2a-agent-2.0.0.json")
+	})
+
+	t.Run("all-versions disambiguates same name+version", func(t *testing.T) {
+		dir := t.TempDir()
+		records := []*corev1.Record{newA2ATestRecord(t), newA2ATestRecord(t)}
+
+		n, err := format.DefaultBatchExport(f, records, dir, true)
+		require.NoError(t, err)
+		assert.Equal(t, 2, n)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 2)
+
+		names := []string{entries[0].Name(), entries[1].Name()}
+		assert.Contains(t, names, "test-a2a-agent-1.0.0.json")
+		assert.Contains(t, names, "test-a2a-agent-1.0.0-1.json")
+	})
+
 	t.Run("returns zero for empty slice", func(t *testing.T) {
 		dir := t.TempDir()
-		n, err := format.DefaultBatchExport(f, nil, dir)
+		n, err := format.DefaultBatchExport(f, nil, dir, false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, n)
 	})
@@ -48,15 +191,29 @@ func TestSkillBatchFormatter(t *testing.T) {
 	bf, ok := f.(format.BatchFormatter)
 	require.True(t, ok, "agent-skill should implement BatchFormatter")
 
-	t.Run("creates subdirectory per skill", func(t *testing.T) {
+	t.Run("uses name only by default", func(t *testing.T) {
 		dir := t.TempDir()
 		records := []*corev1.Record{newSkillTestRecord(t)}
 
-		n, err := bf.FormatBatch(records, dir)
+		n, err := bf.FormatBatch(records, dir, false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, n)
 
 		skillPath := filepath.Join(dir, "code-review", "SKILL.md")
+		data, err := os.ReadFile(skillPath)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "name: code-review")
+	})
+
+	t.Run("all-versions includes version in directory name", func(t *testing.T) {
+		dir := t.TempDir()
+		records := []*corev1.Record{newSkillTestRecord(t)}
+
+		n, err := bf.FormatBatch(records, dir, true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		skillPath := filepath.Join(dir, "code-review-v1.0.0", "SKILL.md")
 		data, err := os.ReadFile(skillPath)
 		require.NoError(t, err)
 		assert.Contains(t, string(data), "name: code-review")
@@ -75,7 +232,7 @@ func TestMCPGHCopilotBatchFormatter(t *testing.T) {
 		r1 := newMCPGHCopilotTestRecord(t, testMCPGHCopilotRecordJSON)
 		records := []*corev1.Record{r1}
 
-		n, err := bf.FormatBatch(records, dir)
+		n, err := bf.FormatBatch(records, dir, false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, n)
 
@@ -90,7 +247,7 @@ func TestMCPGHCopilotBatchFormatter(t *testing.T) {
 
 	t.Run("returns zero for empty slice", func(t *testing.T) {
 		dir := t.TempDir()
-		n, err := bf.FormatBatch(nil, dir)
+		n, err := bf.FormatBatch(nil, dir, false)
 		require.NoError(t, err)
 		assert.Equal(t, 0, n)
 
@@ -100,6 +257,75 @@ func TestMCPGHCopilotBatchFormatter(t *testing.T) {
 		var parsed map[string]any
 		require.NoError(t, json.Unmarshal(data, &parsed))
 		assert.Empty(t, parsed["servers"])
+	})
+}
+
+func TestLatestByName(t *testing.T) {
+	t.Run("keeps higher version", func(t *testing.T) {
+		v1 := newA2ATestRecordWithVersion(t, "1.0.0")
+		v2 := newA2ATestRecordWithVersion(t, "2.0.0")
+
+		result := format.LatestByName([]*corev1.Record{v1, v2})
+		require.Len(t, result, 1)
+
+		name := format.RecordName(result[0])
+		assert.Equal(t, "test-a2a-agent", name)
+
+		ver := result[0].GetData().GetFields()["version"].GetStringValue()
+		assert.Equal(t, "2.0.0", ver)
+	})
+
+	t.Run("handles v-prefix in version", func(t *testing.T) {
+		v1 := newA2ATestRecordWithVersion(t, "v1.0.0")
+		v2 := newA2ATestRecordWithVersion(t, "v2.0.0")
+
+		result := format.LatestByName([]*corev1.Record{v1, v2})
+		require.Len(t, result, 1)
+		assert.Equal(t, "v2.0.0", result[0].GetData().GetFields()["version"].GetStringValue())
+	})
+
+	t.Run("keeps records with different names", func(t *testing.T) {
+		r1 := newA2ATestRecord(t)
+		r2 := newTestRecord() // name="test-agent"
+
+		result := format.LatestByName([]*corev1.Record{r1, r2})
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("preserves insertion order", func(t *testing.T) {
+		r1 := newA2ATestRecord(t)      // name="test-a2a-agent"
+		r2 := newTestRecord()           // name="test-agent"
+		r3 := newA2ATestRecord(t)       // duplicate — should merge with r1
+
+		result := format.LatestByName([]*corev1.Record{r1, r2, r3})
+		require.Len(t, result, 2)
+		assert.Equal(t, "test-a2a-agent", format.RecordName(result[0]))
+		assert.Equal(t, "test-agent", format.RecordName(result[1]))
+	})
+
+	t.Run("prefers later if versions are equal", func(t *testing.T) {
+		// Both have same name + version; the first one seen is kept
+		r1 := newA2ATestRecordWithVersion(t, "1.0.0")
+		r2 := newA2ATestRecordWithVersion(t, "1.0.0")
+
+		result := format.LatestByName([]*corev1.Record{r1, r2})
+		require.Len(t, result, 1)
+	})
+
+	t.Run("handles prerelease ordering", func(t *testing.T) {
+		alpha := newA2ATestRecordWithVersion(t, "1.0.0-alpha")
+		release := newA2ATestRecordWithVersion(t, "1.0.0")
+
+		result := format.LatestByName([]*corev1.Record{alpha, release})
+		require.Len(t, result, 1)
+
+		ver := result[0].GetData().GetFields()["version"].GetStringValue()
+		assert.False(t, strings.Contains(ver, "alpha"), "release should beat alpha")
+	})
+
+	t.Run("returns nil for empty input", func(t *testing.T) {
+		result := format.LatestByName(nil)
+		assert.Empty(t, result)
 	})
 }
 

--- a/cli/cmd/export/format/batch_test.go
+++ b/cli/cmd/export/format/batch_test.go
@@ -267,11 +267,8 @@ func TestLatestByName(t *testing.T) {
 		result := format.LatestByName([]*corev1.Record{v1, v2})
 		require.Len(t, result, 1)
 
-		name := format.RecordName(result[0])
-		assert.Equal(t, "test-a2a-agent", name)
-
-		ver := result[0].GetData().GetFields()["version"].GetStringValue()
-		assert.Equal(t, "2.0.0", ver)
+		assert.Equal(t, "test-a2a-agent", result[0].GetName())
+		assert.Equal(t, "2.0.0", result[0].GetVersion())
 	})
 
 	t.Run("handles v-prefix in version", func(t *testing.T) {
@@ -280,7 +277,7 @@ func TestLatestByName(t *testing.T) {
 
 		result := format.LatestByName([]*corev1.Record{v1, v2})
 		require.Len(t, result, 1)
-		assert.Equal(t, "v2.0.0", result[0].GetData().GetFields()["version"].GetStringValue())
+		assert.Equal(t, "v2.0.0", result[0].GetVersion())
 	})
 
 	t.Run("keeps records with different names", func(t *testing.T) {
@@ -298,8 +295,8 @@ func TestLatestByName(t *testing.T) {
 
 		result := format.LatestByName([]*corev1.Record{r1, r2, r3})
 		require.Len(t, result, 2)
-		assert.Equal(t, "test-a2a-agent", format.RecordName(result[0]))
-		assert.Equal(t, "test-agent", format.RecordName(result[1]))
+		assert.Equal(t, "test-a2a-agent", result[0].GetName())
+		assert.Equal(t, "test-agent", result[1].GetName())
 	})
 
 	t.Run("prefers later if versions are equal", func(t *testing.T) {
@@ -318,8 +315,7 @@ func TestLatestByName(t *testing.T) {
 		result := format.LatestByName([]*corev1.Record{alpha, release})
 		require.Len(t, result, 1)
 
-		ver := result[0].GetData().GetFields()["version"].GetStringValue()
-		assert.NotContains(t, ver, "alpha", "release should beat alpha")
+		assert.NotContains(t, result[0].GetVersion(), "alpha", "release should beat alpha")
 	})
 
 	t.Run("returns nil for empty input", func(t *testing.T) {
@@ -328,11 +324,11 @@ func TestLatestByName(t *testing.T) {
 	})
 }
 
-func TestRecordName(t *testing.T) {
+func TestRecordGetName(t *testing.T) {
 	record := newA2ATestRecord(t)
-	assert.Equal(t, "test-a2a-agent", format.RecordName(record))
+	assert.Equal(t, "test-a2a-agent", record.GetName())
 
-	assert.Empty(t, format.RecordName(&corev1.Record{}))
+	assert.Empty(t, (&corev1.Record{}).GetName())
 }
 
 func TestSanitizeName(t *testing.T) {

--- a/cli/cmd/export/format/format.go
+++ b/cli/cmd/export/format/format.go
@@ -5,9 +5,6 @@ package format
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
@@ -31,8 +28,10 @@ type BatchFormatter interface {
 	Formatter
 
 	// FormatBatch exports multiple records to outputDir.
+	// When allVersions is true, the version is included in filenames to
+	// preserve every version; otherwise only the latest per name is kept.
 	// Returns the number of records successfully exported.
-	FormatBatch(records []*corev1.Record, outputDir string) (int, error)
+	FormatBatch(records []*corev1.Record, outputDir string, allVersions bool) (int, error)
 }
 
 const ExtJSON = ".json"
@@ -61,54 +60,4 @@ func GetFormatter(name string) (Formatter, error) {
 	}
 
 	return f, nil
-}
-
-// RecordName extracts the name field from a record's data.
-func RecordName(record *corev1.Record) string {
-	data := record.GetData()
-	if data == nil {
-		return ""
-	}
-
-	if nameVal, ok := data.GetFields()["name"]; ok {
-		return nameVal.GetStringValue()
-	}
-
-	return ""
-}
-
-// SanitizeName replaces characters unsafe for filenames with hyphens.
-func SanitizeName(name string) string {
-	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
-
-	return r.Replace(name)
-}
-
-// DefaultBatchExport provides per-record file writing for formatters that
-// do not implement BatchFormatter. Each record is written as
-// <outputDir>/<sanitised-name><ext>.
-func DefaultBatchExport(f Formatter, records []*corev1.Record, outputDir string) (int, error) {
-	exported := 0
-
-	for i, record := range records {
-		name := RecordName(record)
-		if name == "" {
-			name = fmt.Sprintf("record_%d", i)
-		}
-
-		output, err := f.Format(record)
-		if err != nil {
-			return exported, fmt.Errorf("failed to format record %q: %w", name, err)
-		}
-
-		outPath := filepath.Join(outputDir, SanitizeName(name)+f.FileExtension())
-
-		if err := os.WriteFile(outPath, output, 0o600); err != nil { //nolint:mnd
-			return exported, fmt.Errorf("failed to write %s: %w", outPath, err)
-		}
-
-		exported++
-	}
-
-	return exported, nil
 }

--- a/cli/cmd/export/format/format.go
+++ b/cli/cmd/export/format/format.go
@@ -5,6 +5,9 @@ package format
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
@@ -17,6 +20,19 @@ type Formatter interface {
 
 	// FileExtension returns the default file extension for this format (e.g. ".json", ".md").
 	FileExtension() string
+}
+
+// BatchFormatter extends Formatter for formats that need custom multi-record
+// export behaviour (e.g. merging MCP servers into one config, or creating
+// per-skill subdirectories).
+// Formatters that do not implement BatchFormatter get per-record file writing
+// via DefaultBatchExport.
+type BatchFormatter interface {
+	Formatter
+
+	// FormatBatch exports multiple records to outputDir.
+	// Returns the number of records successfully exported.
+	FormatBatch(records []*corev1.Record, outputDir string) (int, error)
 }
 
 const ExtJSON = ".json"
@@ -45,4 +61,54 @@ func GetFormatter(name string) (Formatter, error) {
 	}
 
 	return f, nil
+}
+
+// RecordName extracts the name field from a record's data.
+func RecordName(record *corev1.Record) string {
+	data := record.GetData()
+	if data == nil {
+		return ""
+	}
+
+	if nameVal, ok := data.GetFields()["name"]; ok {
+		return nameVal.GetStringValue()
+	}
+
+	return ""
+}
+
+// SanitizeName replaces characters unsafe for filenames with hyphens.
+func SanitizeName(name string) string {
+	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
+
+	return r.Replace(name)
+}
+
+// DefaultBatchExport provides per-record file writing for formatters that
+// do not implement BatchFormatter. Each record is written as
+// <outputDir>/<sanitised-name><ext>.
+func DefaultBatchExport(f Formatter, records []*corev1.Record, outputDir string) (int, error) {
+	exported := 0
+
+	for i, record := range records {
+		name := RecordName(record)
+		if name == "" {
+			name = fmt.Sprintf("record_%d", i)
+		}
+
+		output, err := f.Format(record)
+		if err != nil {
+			return exported, fmt.Errorf("failed to format record %q: %w", name, err)
+		}
+
+		outPath := filepath.Join(outputDir, SanitizeName(name)+f.FileExtension())
+
+		if err := os.WriteFile(outPath, output, 0o600); err != nil { //nolint:mnd
+			return exported, fmt.Errorf("failed to write %s: %w", outPath, err)
+		}
+
+		exported++
+	}
+
+	return exported, nil
 }

--- a/cli/cmd/export/format/mcp.go
+++ b/cli/cmd/export/format/mcp.go
@@ -47,8 +47,14 @@ func (f *mcpGHCopilotFormatter) FileExtension() string {
 
 // FormatBatch merges all records into a single GitHub Copilot MCP config file.
 // Servers from each record are added to one shared "servers" map; inputs are
-// deduplicated by ID.
-func (f *mcpGHCopilotFormatter) FormatBatch(records []*corev1.Record, outputDir string) (int, error) {
+// deduplicated by ID. When allVersions is false, only the latest version per
+// name is merged.
+func (f *mcpGHCopilotFormatter) FormatBatch(records []*corev1.Record, outputDir string, allVersions bool) (int, error) {
+	toMerge := records
+	if !allVersions {
+		toMerge = LatestByName(records)
+	}
+
 	merged := &translator.GHCopilotMCPConfig{
 		Servers: make(map[string]translator.MCPServer),
 		Inputs:  []translator.MCPInput{},
@@ -57,7 +63,7 @@ func (f *mcpGHCopilotFormatter) FormatBatch(records []*corev1.Record, outputDir 
 	seenInputs := map[string]bool{}
 	exported := 0
 
-	for _, record := range records {
+	for _, record := range toMerge {
 		data := record.GetData()
 		if data == nil {
 			continue

--- a/cli/cmd/export/format/mcp.go
+++ b/cli/cmd/export/format/mcp.go
@@ -6,6 +6,9 @@ package format
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/oasf-sdk/pkg/translator"
@@ -40,4 +43,54 @@ func (f *mcpGHCopilotFormatter) Format(record *corev1.Record) ([]byte, error) {
 
 func (f *mcpGHCopilotFormatter) FileExtension() string {
 	return ExtJSON
+}
+
+// FormatBatch merges all records into a single GitHub Copilot MCP config file.
+// Servers from each record are added to one shared "servers" map; inputs are
+// deduplicated by ID.
+func (f *mcpGHCopilotFormatter) FormatBatch(records []*corev1.Record, outputDir string) (int, error) {
+	merged := &translator.GHCopilotMCPConfig{
+		Servers: make(map[string]translator.MCPServer),
+		Inputs:  []translator.MCPInput{},
+	}
+
+	seenInputs := map[string]bool{}
+	exported := 0
+
+	for _, record := range records {
+		data := record.GetData()
+		if data == nil {
+			continue
+		}
+
+		cfg, err := translator.RecordToGHCopilot(data)
+		if err != nil {
+			continue
+		}
+
+		maps.Copy(merged.Servers, cfg.Servers)
+
+		for _, input := range cfg.Inputs {
+			if !seenInputs[input.ID] {
+				seenInputs[input.ID] = true
+				merged.Inputs = append(merged.Inputs, input)
+			}
+		}
+
+		exported++
+	}
+
+	raw, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal merged GitHub Copilot MCP config: %w", err)
+	}
+
+	raw = append(raw, '\n')
+
+	outPath := filepath.Join(outputDir, "mcp.json")
+	if err := os.WriteFile(outPath, raw, 0o600); err != nil { //nolint:mnd
+		return 0, fmt.Errorf("failed to write %s: %w", outPath, err)
+	}
+
+	return exported, nil
 }

--- a/cli/cmd/export/format/skill.go
+++ b/cli/cmd/export/format/skill.go
@@ -5,6 +5,8 @@ package format
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/oasf-sdk/pkg/translator"
@@ -34,4 +36,35 @@ func (f *skillFormatter) Format(record *corev1.Record) ([]byte, error) {
 
 func (f *skillFormatter) FileExtension() string {
 	return ".md"
+}
+
+// FormatBatch creates a subdirectory per skill: <outputDir>/<name>/SKILL.md.
+func (f *skillFormatter) FormatBatch(records []*corev1.Record, outputDir string) (int, error) {
+	exported := 0
+
+	for i, record := range records {
+		name := RecordName(record)
+		if name == "" {
+			name = fmt.Sprintf("skill_%d", i)
+		}
+
+		output, err := f.Format(record)
+		if err != nil {
+			return exported, fmt.Errorf("failed to format skill %q: %w", name, err)
+		}
+
+		skillDir := filepath.Join(outputDir, SanitizeName(name))
+		if err := os.MkdirAll(skillDir, 0o755); err != nil { //nolint:mnd
+			return exported, fmt.Errorf("failed to create directory %s: %w", skillDir, err)
+		}
+
+		outPath := filepath.Join(skillDir, "SKILL.md")
+		if err := os.WriteFile(outPath, output, 0o600); err != nil { //nolint:mnd
+			return exported, fmt.Errorf("failed to write %s: %w", outPath, err)
+		}
+
+		exported++
+	}
+
+	return exported, nil
 }

--- a/cli/cmd/export/format/skill.go
+++ b/cli/cmd/export/format/skill.go
@@ -39,21 +39,26 @@ func (f *skillFormatter) FileExtension() string {
 }
 
 // FormatBatch creates a subdirectory per skill: <outputDir>/<name>/SKILL.md.
-func (f *skillFormatter) FormatBatch(records []*corev1.Record, outputDir string) (int, error) {
-	exported := 0
+// When allVersions is false, only the latest version per name is exported.
+// When allVersions is true the version is included in the directory name.
+func (f *skillFormatter) FormatBatch(records []*corev1.Record, outputDir string, allVersions bool) (int, error) {
+	toExport := records
+	if !allVersions {
+		toExport = LatestByName(records)
+	}
 
-	for i, record := range records {
-		name := RecordName(record)
-		if name == "" {
-			name = fmt.Sprintf("skill_%d", i)
-		}
+	exported := 0
+	seen := make(map[string]int)
+
+	for i, record := range toExport {
+		base := batchFileName(record, i, seen, allVersions)
 
 		output, err := f.Format(record)
 		if err != nil {
-			return exported, fmt.Errorf("failed to format skill %q: %w", name, err)
+			return exported, fmt.Errorf("failed to format skill %q: %w", base, err)
 		}
 
-		skillDir := filepath.Join(outputDir, SanitizeName(name))
+		skillDir := filepath.Join(outputDir, base)
 		if err := os.MkdirAll(skillDir, 0o755); err != nil { //nolint:mnd
 			return exported, fmt.Errorf("failed to create directory %s: %w", skillDir, err)
 		}

--- a/cli/cmd/export/options.go
+++ b/cli/cmd/export/options.go
@@ -11,11 +11,12 @@ import (
 var opts = &options{}
 
 type options struct {
-	Format     string
-	OutputFile string
-	OutputDir  string
-	Limit      uint32
-	Filters    search.Filters
+	Format      string
+	OutputFile  string
+	OutputDir   string
+	Limit       uint32
+	AllVersions bool
+	Filters     search.Filters
 }
 
 func init() {
@@ -24,6 +25,7 @@ func init() {
 	flags.StringVar(&opts.OutputFile, "output-file", "", "File path to write the exported data (default: stdout)")
 	flags.StringVar(&opts.OutputDir, "output-dir", "", "Directory for batch export from search results")
 	flags.Uint32Var(&opts.Limit, "limit", 100, "Maximum number of records to export in batch mode") //nolint:mnd
+	flags.BoolVar(&opts.AllVersions, "all-versions", false, "Keep all versions in batch export (default: latest per name wins)")
 
 	search.RegisterFilterFlags(Command, &opts.Filters)
 	presenter.AddOutputFlags(Command)

--- a/cli/cmd/export/options.go
+++ b/cli/cmd/export/options.go
@@ -3,19 +3,28 @@
 
 package export
 
-import "github.com/agntcy/dir/cli/presenter"
+import (
+	"github.com/agntcy/dir/cli/cmd/search"
+	"github.com/agntcy/dir/cli/presenter"
+)
 
 var opts = &options{}
 
 type options struct {
 	Format     string
 	OutputFile string
+	OutputDir  string
+	Limit      uint32
+	Filters    search.Filters
 }
 
 func init() {
 	flags := Command.Flags()
-	flags.StringVar(&opts.Format, "format", "oasf", "Export format: oasf, agent-skill, a2a")
+	flags.StringVar(&opts.Format, "format", "oasf", "Export format: oasf, agent-skill, a2a, mcp-ghcopilot")
 	flags.StringVar(&opts.OutputFile, "output-file", "", "File path to write the exported data (default: stdout)")
+	flags.StringVar(&opts.OutputDir, "output-dir", "", "Directory for batch export from search results")
+	flags.Uint32Var(&opts.Limit, "limit", 100, "Maximum number of records to export in batch mode") //nolint:mnd
 
+	search.RegisterFilterFlags(Command, &opts.Filters)
 	presenter.AddOutputFlags(Command)
 }

--- a/cli/cmd/search/filters.go
+++ b/cli/cmd/search/filters.go
@@ -1,0 +1,119 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	searchv1 "github.com/agntcy/dir/api/search/v1"
+	"github.com/spf13/cobra"
+)
+
+// Filters holds the values for all record-search filter flags.
+// Embed this in any command's options struct to reuse the standard filter set.
+type Filters struct {
+	Names          []string
+	Versions       []string
+	SkillIDs       []string
+	SkillNames     []string
+	Locators       []string
+	Modules        []string
+	DomainIDs      []string
+	DomainNames    []string
+	CreatedAts     []string
+	Authors        []string
+	SchemaVersions []string
+	ModuleIDs      []string
+	Verified       bool
+	Trusted        bool
+}
+
+// RegisterFilterFlags binds the standard search-filter flags to cmd, storing
+// values in f. Call this from your command's init().
+func RegisterFilterFlags(cmd *cobra.Command, f *Filters) {
+	flags := cmd.Flags()
+
+	flags.StringArrayVar(&f.Names, "name", nil,
+		"Search for records with specific name (e.g., --name 'my-agent' --name 'web-*')")
+	flags.StringArrayVar(&f.Versions, "version", nil,
+		"Search for records with specific version (e.g., --version 'v1.0.0' --version 'v1.*')")
+	flags.StringArrayVar(&f.SkillIDs, "skill-id", nil,
+		"Search for records with specific skill ID (e.g., --skill-id '10201')")
+	flags.StringArrayVar(&f.SkillNames, "skill", nil,
+		"Search for records with specific skill name (e.g., --skill 'natural_language_processing')")
+	flags.StringArrayVar(&f.Locators, "locator", nil,
+		"Search for records with specific locator type (e.g., --locator 'docker-image')")
+	flags.StringArrayVar(&f.Modules, "module", nil,
+		"Search for records with specific module (e.g., --module 'core/llm/model')")
+	flags.StringArrayVar(&f.DomainIDs, "domain-id", nil,
+		"Search for records with specific domain ID (e.g., --domain-id '604')")
+	flags.StringArrayVar(&f.DomainNames, "domain", nil,
+		"Search for records with specific domain name (e.g., --domain '*education*')")
+	flags.StringArrayVar(&f.CreatedAts, "created-at", nil,
+		"Search for records with specific created_at timestamp (e.g., --created-at '2024-*')")
+	flags.StringArrayVar(&f.Authors, "author", nil,
+		"Search for records with specific author (e.g., --author 'john*')")
+	flags.StringArrayVar(&f.SchemaVersions, "schema-version", nil,
+		"Search for records with specific schema version (e.g., --schema-version '0.8.*')")
+	flags.StringArrayVar(&f.ModuleIDs, "module-id", nil,
+		"Search for records with specific module ID (e.g., --module-id '201')")
+	flags.BoolVar(&f.Verified, "verified", false,
+		"Filter for records with verified name ownership only")
+	flags.BoolVar(&f.Trusted, "trusted", false,
+		"Filter for records with trusted signature only (signature verification passed)")
+}
+
+// queryMapping maps a Filters field accessor to its RecordQueryType.
+type queryMapping struct {
+	values    []string
+	queryType searchv1.RecordQueryType
+}
+
+// BuildQueries converts populated filter fields into API query objects.
+func BuildQueries(f *Filters) []*searchv1.RecordQuery {
+	mappings := []queryMapping{
+		{f.Names, searchv1.RecordQueryType_RECORD_QUERY_TYPE_NAME},
+		{f.Versions, searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERSION},
+		{f.SkillIDs, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_ID},
+		{f.SkillNames, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_NAME},
+		{f.Locators, searchv1.RecordQueryType_RECORD_QUERY_TYPE_LOCATOR},
+		{f.Modules, searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_NAME},
+		{f.DomainIDs, searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_ID},
+		{f.DomainNames, searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_NAME},
+		{f.CreatedAts, searchv1.RecordQueryType_RECORD_QUERY_TYPE_CREATED_AT},
+		{f.Authors, searchv1.RecordQueryType_RECORD_QUERY_TYPE_AUTHOR},
+		{f.SchemaVersions, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCHEMA_VERSION},
+		{f.ModuleIDs, searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_ID},
+	}
+
+	var size int
+	for _, m := range mappings {
+		size += len(m.values)
+	}
+
+	queries := make([]*searchv1.RecordQuery, 0, size)
+
+	for _, m := range mappings {
+		for _, v := range m.values {
+			queries = append(queries, &searchv1.RecordQuery{
+				Type:  m.queryType,
+				Value: v,
+			})
+		}
+	}
+
+	if f.Verified {
+		queries = append(queries, &searchv1.RecordQuery{
+			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERIFIED,
+			Value: "true",
+		})
+	}
+
+	if f.Trusted {
+		queries = append(queries, &searchv1.RecordQuery{
+			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED,
+			Value: "true",
+		})
+	}
+
+	return queries
+}

--- a/cli/cmd/search/options.go
+++ b/cli/cmd/search/options.go
@@ -11,25 +11,10 @@ import (
 var opts = &options{}
 
 type options struct {
-	Limit  uint32
-	Offset uint32
-	Format string
-
-	// Direct field flags (consistent with routing search)
-	Names          []string
-	Versions       []string
-	SkillIDs       []string
-	SkillNames     []string
-	Locators       []string
-	Modules        []string
-	DomainIDs      []string
-	DomainNames    []string
-	CreatedAts     []string
-	Authors        []string
-	SchemaVersions []string
-	ModuleIDs      []string
-	Verified       bool // Filter for verified records only
-	Trusted        bool // Filter for trusted records only (signature verification passed)
+	Limit   uint32
+	Offset  uint32
+	Format  string
+	Filters Filters
 }
 
 // registerFlags adds search flags to the command.
@@ -40,157 +25,10 @@ func registerFlags(cmd *cobra.Command) {
 	flags.Uint32Var(&opts.Limit, "limit", 100, "Maximum number of results to return (default: 100)") //nolint:mnd
 	flags.Uint32Var(&opts.Offset, "offset", 0, "Pagination offset (default: 0)")
 
-	// Direct field flags
-	flags.StringArrayVar(&opts.Names, "name", nil, "Search for records with specific name (can be repeated)")
-	flags.StringArrayVar(&opts.Versions, "version", nil, "Search for records with specific version (can be repeated)")
-	flags.StringArrayVar(&opts.SkillIDs, "skill-id", nil, "Search for records with specific skill ID (can be repeated)")
-	flags.StringArrayVar(&opts.SkillNames, "skill", nil, "Search for records with specific skill name (can be repeated)")
-	flags.StringArrayVar(&opts.Locators, "locator", nil, "Search for records with specific locator type (can be repeated)")
-	flags.StringArrayVar(&opts.Modules, "module", nil, "Search for records with specific module (can be repeated)")
-	flags.StringArrayVar(&opts.DomainIDs, "domain-id", nil, "Search for records with specific domain ID (can be repeated)")
-	flags.StringArrayVar(&opts.DomainNames, "domain", nil, "Search for records with specific domain name (can be repeated)")
-	flags.StringArrayVar(&opts.CreatedAts, "created-at", nil, "Search for records with specific created_at timestamp (can be repeated)")
-	flags.StringArrayVar(&opts.Authors, "author", nil, "Search for records with specific author (can be repeated)")
-	flags.StringArrayVar(&opts.SchemaVersions, "schema-version", nil, "Search for records with specific schema version (can be repeated)")
-	flags.StringArrayVar(&opts.ModuleIDs, "module-id", nil, "Search for records with specific module ID (can be repeated)")
-	flags.BoolVar(&opts.Verified, "verified", false, "Filter for records with verified name ownership only")
-	flags.BoolVar(&opts.Trusted, "trusted", false, "Filter for records with trusted signature only")
-
-	// Add examples in flag help
-	flags.Lookup("name").Usage = "Search for records with specific name (e.g., --name 'my-agent' --name 'web-*')"
-	flags.Lookup("version").Usage = "Search for records with specific version (e.g., --version 'v1.0.0' --version 'v1.*')"
-	flags.Lookup("skill-id").Usage = "Search for records with specific skill ID (e.g., --skill-id '10201')"
-	flags.Lookup("skill").Usage = "Search for records with specific skill name (e.g., --skill 'natural_language_processing' --skill 'audio')"
-	flags.Lookup("locator").Usage = "Search for records with specific locator type (e.g., --locator 'docker-image')"
-	flags.Lookup("module").Usage = "Search for records with specific module (e.g., --module 'core/llm/model')"
-	flags.Lookup("domain-id").Usage = "Search for records with specific domain ID (e.g., --domain-id '604')"
-	flags.Lookup("domain").Usage = "Search for records with specific domain name (e.g., --domain '*education*' --domain 'healthcare/*')"
-	flags.Lookup("created-at").Usage = "Search for records with specific created_at timestamp (e.g., --created-at '2024-*')"
-	flags.Lookup("author").Usage = "Search for records with specific author (e.g., --author 'john*')"
-	flags.Lookup("schema-version").Usage = "Search for records with specific schema version (e.g., --schema-version '0.8.*')"
-	flags.Lookup("module-id").Usage = "Search for records with specific module ID (e.g., --module-id '201')"
+	RegisterFilterFlags(cmd, &opts.Filters)
 }
 
 // buildQueriesFromFlags builds API queries.
 func buildQueriesFromFlags() []*searchv1.RecordQuery {
-	queries := make([]*searchv1.RecordQuery, 0,
-		len(opts.Names)+len(opts.Versions)+len(opts.SkillIDs)+
-			len(opts.SkillNames)+len(opts.Locators)+len(opts.Modules)+
-			len(opts.DomainIDs)+len(opts.DomainNames)+
-			len(opts.CreatedAts)+len(opts.Authors)+
-			len(opts.SchemaVersions)+len(opts.ModuleIDs))
-
-	// Add name queries
-	for _, name := range opts.Names {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_NAME,
-			Value: name,
-		})
-	}
-
-	// Add version queries
-	for _, version := range opts.Versions {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERSION,
-			Value: version,
-		})
-	}
-
-	// Add skill-id queries
-	for _, skillID := range opts.SkillIDs {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_ID,
-			Value: skillID,
-		})
-	}
-
-	// Add skill-name queries
-	for _, skillName := range opts.SkillNames {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_NAME,
-			Value: skillName,
-		})
-	}
-
-	// Add locator queries
-	for _, locator := range opts.Locators {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_LOCATOR,
-			Value: locator,
-		})
-	}
-
-	// Add module queries
-	for _, module := range opts.Modules {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_NAME,
-			Value: module,
-		})
-	}
-
-	// Add domain-id queries
-	for _, domainID := range opts.DomainIDs {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_ID,
-			Value: domainID,
-		})
-	}
-
-	// Add domain-name queries
-	for _, domainName := range opts.DomainNames {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_NAME,
-			Value: domainName,
-		})
-	}
-
-	// Add created-at queries
-	for _, createdAt := range opts.CreatedAts {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_CREATED_AT,
-			Value: createdAt,
-		})
-	}
-
-	// Add author queries
-	for _, author := range opts.Authors {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_AUTHOR,
-			Value: author,
-		})
-	}
-
-	// Add schema-version queries
-	for _, schemaVersion := range opts.SchemaVersions {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCHEMA_VERSION,
-			Value: schemaVersion,
-		})
-	}
-
-	// Add module-id queries
-	for _, moduleID := range opts.ModuleIDs {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_ID,
-			Value: moduleID,
-		})
-	}
-
-	// Add verified filter
-	if opts.Verified {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERIFIED,
-			Value: "true",
-		})
-	}
-
-	// Add trusted filter
-	if opts.Trusted {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED,
-			Value: "true",
-		})
-	}
-
-	return queries
+	return BuildQueries(&opts.Filters)
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -58,9 +58,13 @@ func New(ctx context.Context, client config.ClientInterface, cfg config.Config) 
 		return nil, fmt.Errorf("failed to create fetcher: %w", err)
 	}
 
-	d, err := dedup.NewDuplicateChecker(ctx, client, cfg.Type, cfg.Debug)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create duplicate checker: %w", err)
+	var d types.DuplicateChecker
+
+	if !cfg.Force {
+		d, err = dedup.NewDuplicateChecker(ctx, client, cfg.Type, cfg.Debug)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create duplicate checker: %w", err)
+		}
 	}
 
 	var e types.Enricher

--- a/tests/e2e/local/10_referrers_test.go
+++ b/tests/e2e/local/10_referrers_test.go
@@ -54,8 +54,7 @@ func generateRecord() *corev1.Record {
 	record, err := corev1.UnmarshalRecord(testdata.ExpectedRecordV100JSON)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	name := record.GetData().GetFields()["name"].GetStringValue()
-	record.Data.Fields["name"] = structpb.NewStringValue(name + "_" + uuid.NewString()[:8])
+	record.Data.Fields["name"] = structpb.NewStringValue(record.GetName() + "_" + uuid.NewString()[:8])
 
 	return record
 }

--- a/tests/e2e/local/11_export_test.go
+++ b/tests/e2e/local/11_export_test.go
@@ -148,7 +148,7 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command"
 
 			cidFile := filepath.Join(tempDir, "imported.cids")
 
-			cli.Import("a2a", cardPath).WithArgs("--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldEventuallySucceed(60 * time.Second)
+			cli.Import("a2a", cardPath).WithArgs("--force", "--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldEventuallySucceed(60 * time.Second)
 
 			cidData, err := os.ReadFile(cidFile)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -235,7 +235,7 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command"
 
 			cidFile := filepath.Join(tempDir, "imported.cids")
 
-			cli.Import("mcp", serverPath).WithArgs("--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldEventuallySucceed(60 * time.Second)
+			cli.Import("mcp", serverPath).WithArgs("--force", "--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldEventuallySucceed(60 * time.Second)
 
 			cidData, err := os.ReadFile(cidFile)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -425,7 +425,7 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command"
 
 			cidFile := filepath.Join(tempDir, "imported.cids")
 
-			cli.Import("agent-skill", skillDir).WithArgs("--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldSucceed()
+			cli.Import("agent-skill", skillDir).WithArgs("--force", "--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldSucceed()
 
 			cidData, err := os.ReadFile(cidFile)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/e2e/local/11_export_test.go
+++ b/tests/e2e/local/11_export_test.go
@@ -300,6 +300,105 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command"
 		})
 	})
 
+	ginkgo.Context("Batch export with --output-dir", ginkgo.Ordered, ginkgo.Serial, func() {
+		// recordCID covers both A2A and MCP (record_100.json has both modules).
+		var recordCID, skillCID string
+
+		tempDir, err := os.MkdirTemp("", "export-batch-e2e-*")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		ginkgo.AfterAll(func() {
+			os.RemoveAll(tempDir)
+		})
+
+		ginkgo.It("should push test records for batch export", func() {
+			// Push OASF record that contains both integration/a2a and integration/mcp modules.
+			recordPath := filepath.Join(tempDir, "record.json")
+			gomega.Expect(os.WriteFile(recordPath, testdata.ExpectedRecordV100JSON, 0o600)).To(gomega.Succeed())
+
+			recordCID = cli.Push(recordPath).WithArgs("--output", "raw").ShouldSucceed()
+			gomega.Expect(recordCID).NotTo(gomega.BeEmpty())
+
+			// Push a pre-built OASF skill record (avoids the importer pipeline).
+			skillPath := filepath.Join(tempDir, "skill-record.json")
+			gomega.Expect(os.WriteFile(skillPath, testdata.SkillRecordJSON, 0o600)).To(gomega.Succeed())
+
+			skillCID = cli.Push(skillPath).WithArgs("--output", "raw").ShouldSucceed()
+			gomega.Expect(skillCID).NotTo(gomega.BeEmpty())
+		})
+
+		ginkgo.It("should batch export A2A records to a directory", func() {
+			outDir := filepath.Join(tempDir, "batch-a2a")
+
+			cli.ExportBatch(outDir, "a2a").WithArgs(
+				"--module", "integration/a2a",
+			).ShouldSucceed()
+
+			entries, err := os.ReadDir(outDir)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(entries).NotTo(gomega.BeEmpty(), "output directory should contain exported files")
+		})
+
+		ginkgo.It("should batch export skills to subdirectories", func() {
+			outDir := filepath.Join(tempDir, "batch-skills")
+
+			cli.ExportBatch(outDir, "agent-skill").WithArgs(
+				"--module", "core/language_model/agentskills",
+			).ShouldSucceed()
+
+			entries, err := os.ReadDir(outDir)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(entries).NotTo(gomega.BeEmpty(), "output directory should contain skill directories")
+
+			// Each entry should be a directory containing SKILL.md
+			for _, entry := range entries {
+				gomega.Expect(entry.IsDir()).To(gomega.BeTrue(), "each exported skill should be a directory")
+
+				skillPath := filepath.Join(outDir, entry.Name(), "SKILL.md")
+				_, err := os.Stat(skillPath)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "skill directory should contain SKILL.md")
+			}
+		})
+
+		ginkgo.It("should batch export MCP servers into a merged config", func() {
+			outDir := filepath.Join(tempDir, "batch-mcp")
+
+			cli.ExportBatch(outDir, "mcp-ghcopilot").WithArgs(
+				"--module", "integration/mcp",
+			).ShouldSucceed()
+
+			mcpPath := filepath.Join(outDir, "mcp.json")
+			data, err := os.ReadFile(mcpPath)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			var parsed map[string]any
+
+			err = json.Unmarshal(data, &parsed)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "mcp.json should be valid JSON")
+			gomega.Expect(parsed).To(gomega.HaveKey("servers"))
+			gomega.Expect(parsed).To(gomega.HaveKey("inputs"))
+		})
+
+		ginkgo.It("should fail when --output-dir and positional arg are both provided", func() {
+			outDir := filepath.Join(tempDir, "fail-both")
+
+			err := cli.Export("some-cid").WithArgs("--output-dir", outDir, "--name", "test").ShouldFail()
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("mutually exclusive"))
+		})
+
+		ginkgo.It("should fail when --output-dir is used without search filters", func() {
+			outDir := filepath.Join(tempDir, "fail-no-filter")
+
+			err := cli.ExportBatch(outDir, "a2a").ShouldFail()
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("at least one search filter"))
+		})
+
+		ginkgo.It("should clean up test records", func() {
+			cli.Delete(recordCID).ShouldSucceed()
+			cli.Delete(skillCID).ShouldSucceed()
+		})
+	})
+
 	ginkgo.Context("Export with skill format", ginkgo.Ordered, ginkgo.Serial, func() {
 		var cid string
 

--- a/tests/e2e/shared/testdata/embed.go
+++ b/tests/e2e/shared/testdata/embed.go
@@ -50,3 +50,9 @@ var MCPServer []byte
 //
 //go:embed code-review/SKILL.md
 var SkillMarkdown []byte
+
+// SkillRecordJSON is an OASF record containing a core/language_model/agentskills
+// module, generated from code-review/SKILL.md via the oasf-sdk translator.
+//
+//go:embed skill_record.json
+var SkillRecordJSON []byte

--- a/tests/e2e/shared/testdata/skill_record.json
+++ b/tests/e2e/shared/testdata/skill_record.json
@@ -1,0 +1,35 @@
+{
+  "authors": [
+    "AGNTCY Contributors"
+  ],
+  "created_at": "2026-04-17T11:09:15Z",
+  "description": "Toolkit for performing structured code reviews. Covers identifying bugs, security issues, performance problems, and style violations. Use when asked to review code changes, pull requests, or individual files.",
+  "domains": [],
+  "modules": [
+    {
+      "data": {
+        "skill_file": "SKILL.md",
+        "skill_manifest": {
+          "description": "Toolkit for performing structured code reviews. Covers identifying bugs, security issues, performance problems, and style violations. Use when asked to review code changes, pull requests, or individual files.",
+          "frontmatter_metadata": {
+            "author": "AGNTCY Contributors",
+            "version": "1.0.0"
+          },
+          "name": "code-review",
+          "version": "1.0.0"
+        }
+      },
+      "id": 10302,
+      "name": "core/language_model/agentskills"
+    }
+  ],
+  "name": "code-review",
+  "schema_version": "1.0.0",
+  "skills": [
+    {
+      "name": "natural_language_processing/natural_language_understanding/contextual_comprehension",
+      "id": 10101
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/tests/e2e/shared/utils/cli.go
+++ b/tests/e2e/shared/utils/cli.go
@@ -108,6 +108,10 @@ func (c *CLI) Export(cidOrName string) *CommandBuilder {
 	return c.Command("export").WithArgs(cidOrName)
 }
 
+func (c *CLI) ExportBatch(outputDir, format string) *CommandBuilder {
+	return c.Command("export").WithArgs("--output-dir", outputDir, "--format", format)
+}
+
 func (c *CLI) Sign(recordCID, keyPath string) *CommandBuilder {
 	return c.Command("sign").WithArgs(recordCID, "--key", keyPath)
 }

--- a/tests/e2e/shared/utils/common.go
+++ b/tests/e2e/shared/utils/common.go
@@ -22,7 +22,7 @@ import (
 
 // Ptr creates a pointer to the given value.
 //
-//nolint
+// nolint
 func Ptr[T any](v T) *T {
 	return &v
 }
@@ -84,58 +84,29 @@ func ResetCobraFlags() {
 	}
 }
 
-// resetCommandFlags resets flags for a specific command.
+// resetFlag resets a single flag to its zero/default value.
 //
 //nolint:errcheck
+func resetFlag(flag *pflag.Flag) {
+	if flag.Value == nil {
+		return
+	}
+
+	if sv, ok := flag.Value.(pflag.SliceValue); ok {
+		sv.Replace([]string{})
+
+		flag.DefValue = "[]"
+	} else {
+		flag.Value.Set(flag.DefValue)
+	}
+
+	flag.Changed = false
+}
+
+// resetCommandFlags resets flags for a specific command.
 func resetCommandFlags(cmd *cobra.Command) {
-	if cmd.Flags() != nil {
-		// Reset local flags
-		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-			if flag.Value != nil {
-				// Reset to default value based on flag type
-				switch flag.Value.Type() {
-				case "string":
-					flag.Value.Set(flag.DefValue)
-				case "bool":
-					flag.Value.Set(flag.DefValue)
-				case "int", "int32", "int64":
-					flag.Value.Set(flag.DefValue)
-				case "uint", "uint32", "uint64":
-					flag.Value.Set(flag.DefValue)
-				case "float32", "float64":
-					flag.Value.Set(flag.DefValue)
-				case "stringArray", "stringSlice":
-					// For string arrays/slices, completely clear them
-					// Setting to empty string should clear the underlying slice
-					flag.Value.Set("")
-					// Also reset the default value to ensure clean state
-					flag.DefValue = ""
-				default:
-					// For custom types, try to set to default value
-					flag.Value.Set(flag.DefValue)
-				}
-				// Mark as not changed
-				flag.Changed = false
-			}
-		})
-	}
-
-	if cmd.PersistentFlags() != nil {
-		// Reset persistent flags
-		cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
-			if flag.Value != nil {
-				// Handle string arrays specially for persistent flags too
-				if flag.Value.Type() == "stringArray" || flag.Value.Type() == "stringSlice" {
-					flag.Value.Set("")
-					flag.DefValue = ""
-				} else {
-					flag.Value.Set(flag.DefValue)
-				}
-
-				flag.Changed = false
-			}
-		})
-	}
+	cmd.Flags().VisitAll(resetFlag)
+	cmd.PersistentFlags().VisitAll(resetFlag)
 }
 
 // resetNestedCommandFlags recursively resets flags for nested commands.


### PR DESCRIPTION
Extends `dirctl export` with a search-based batch mode (`--output-dir`) that searches the Directory, pulls matching records, and writes them to a local directory.

Each format handles batch export differently:

- **a2a** — one JSON file per record: `./exports/my-agent.json`
- **agent-skill** — one subdirectory per skill with its SKILL.md: `./exports/code-review/SKILL.md`
- **mcp-ghcopilot** — all matching MCP servers merged into a single config: `./exports/mcp.json`

```bash
dirctl export --output-dir=./exports/ --format=a2a --module "integration/a2a"
dirctl export --output-dir=./exports/ --format=agent-skill --module "core/language_model/agentskills"
dirctl export --output-dir=./exports/ --format=mcp-ghcopilot --module "integration/mcp"
```

By default, when multiple versions of the same record exist, only the latest semver version is exported. Use `--all-versions` to export every version with the version included in the filename.