### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -100,15 +100,7 @@ func validateDaemonProcess(pid int) error {
 	}
 
 	args := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
-	isDaemonCommand := false
-	for _, arg := range args[1:] {
-		if arg == "daemon" {
-			isDaemonCommand = true
-			break
-		}
-	}
-
-	if !isDaemonCommand {
+	if len(args) < 2 || args[1] != "daemon" {
 		return fmt.Errorf("pid %d is not a daemon process", pid)
 	}
 

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -101,26 +101,36 @@ func validateDaemonProcess(pid int) error {
 	}
 
 	args := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
-	if len(args) < 2 {
+	if len(args) < 3 {
 		return fmt.Errorf("pid %d has an invalid command line", pid)
 	}
 
-	commands := make([]string, 0, len(args))
-	for i := 1; i < len(args); i++ {
-		arg := args[i]
-		if strings.HasPrefix(arg, "-") {
-			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				i++
-			}
-
+	idx := 1
+	for idx < len(args) && strings.HasPrefix(args[idx], "-") {
+		if !strings.Contains(args[idx], "=") && idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "-") {
+			idx += 2
 			continue
 		}
 
-		commands = append(commands, arg)
+		idx++
 	}
 
-	if len(commands) < 2 || commands[0] != "daemon" || commands[1] != "run" {
+	if idx+1 >= len(args) || args[idx] != "daemon" || args[idx+1] != "run" {
 		return fmt.Errorf("pid %d is not a daemon runtime process", pid)
+	}
+
+	idx += 2
+	for idx < len(args) {
+		if !strings.HasPrefix(args[idx], "-") {
+			return fmt.Errorf("pid %d is not a daemon runtime process", pid)
+		}
+
+		if !strings.Contains(args[idx], "=") && idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "-") {
+			idx += 2
+			continue
+		}
+
+		idx++
 	}
 
 	status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -120,9 +120,26 @@ func validateDaemonProcess(pid int) error {
 	}
 
 	idx += 2
+	var daemonPIDFile string
 	for idx < len(args) {
 		if !strings.HasPrefix(args[idx], "-") {
 			return fmt.Errorf("pid %d is not a daemon runtime process", pid)
+		}
+
+		if strings.HasPrefix(args[idx], "--pid-file=") {
+			daemonPIDFile = strings.TrimPrefix(args[idx], "--pid-file=")
+			idx++
+			continue
+		}
+
+		if args[idx] == "--pid-file" {
+			if idx+1 >= len(args) || strings.HasPrefix(args[idx+1], "-") {
+				return fmt.Errorf("pid %d has an invalid --pid-file argument", pid)
+			}
+
+			daemonPIDFile = args[idx+1]
+			idx += 2
+			continue
 		}
 
 		if !strings.Contains(args[idx], "=") && idx+1 < len(args) && !strings.HasPrefix(args[idx+1], "-") {
@@ -131,6 +148,10 @@ func validateDaemonProcess(pid int) error {
 		}
 
 		idx++
+	}
+
+	if daemonPIDFile == "" {
+		return fmt.Errorf("pid %d is missing daemon pid-file marker", pid)
 	}
 
 	status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
@@ -165,6 +186,34 @@ func validateDaemonProcess(pid int) error {
 
 	if procUID != os.Geteuid() {
 		return fmt.Errorf("pid %d is owned by uid %d (current uid %d)", pid, procUID, os.Geteuid())
+	}
+
+	pidFileInfo, err := os.Stat(daemonPIDFile)
+	if err != nil {
+		return fmt.Errorf("failed to verify daemon pid-file for pid %d: %w", pid, err)
+	}
+
+	stat, ok := pidFileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("failed to read daemon pid-file ownership for pid %d", pid)
+	}
+
+	if int(stat.Uid) != procUID {
+		return fmt.Errorf("daemon pid-file %q is owned by uid %d (daemon uid %d)", daemonPIDFile, stat.Uid, procUID)
+	}
+
+	pidData, err := os.ReadFile(daemonPIDFile)
+	if err != nil {
+		return fmt.Errorf("failed to read daemon pid-file %q: %w", daemonPIDFile, err)
+	}
+
+	pidFromFile, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
+	if err != nil {
+		return fmt.Errorf("failed to parse daemon pid-file %q: %w", daemonPIDFile, err)
+	}
+
+	if pidFromFile != pid {
+		return fmt.Errorf("daemon pid-file %q points to pid %d (expected %d)", daemonPIDFile, pidFromFile, pid)
 	}
 
 	return nil

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -216,6 +216,15 @@ func validateDaemonProcess(pid int) error {
 		return fmt.Errorf("failed to verify daemon pid-file for pid %d: %w", pid, err)
 	}
 
+	procInfo, err := os.Stat(fmt.Sprintf("/proc/%d", pid))
+	if err != nil {
+		return fmt.Errorf("failed to verify daemon start marker for pid %d: %w", pid, err)
+	}
+
+	if pidFileInfo.ModTime().Before(procInfo.ModTime()) {
+		return fmt.Errorf("daemon pid-file %q predates process start for pid %d", daemonPIDFile, pid)
+	}
+
 	stat, ok := pidFileInfo.Sys().(*syscall.Stat_t)
 	if !ok {
 		return fmt.Errorf("failed to read daemon pid-file ownership for pid %d", pid)

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -150,8 +150,9 @@ func validateDaemonProcess(pid int) error {
 		idx++
 	}
 
+	expectedPIDFile := pidFile
 	if daemonPIDFile == "" {
-		return fmt.Errorf("pid %d is missing daemon pid-file marker", pid)
+		daemonPIDFile = expectedPIDFile
 	}
 
 	resolvedDaemonPIDFile, err := filepath.Abs(daemonPIDFile)
@@ -163,7 +164,6 @@ func validateDaemonProcess(pid int) error {
 		resolvedDaemonPIDFile = resolved
 	}
 
-	expectedPIDFile := pidFile
 	resolvedExpectedPIDFile, err := filepath.Abs(expectedPIDFile)
 	if err != nil {
 		return fmt.Errorf("failed to resolve expected pid-file %q: %w", expectedPIDFile, err)

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -154,6 +154,29 @@ func validateDaemonProcess(pid int) error {
 		return fmt.Errorf("pid %d is missing daemon pid-file marker", pid)
 	}
 
+	resolvedDaemonPIDFile, err := filepath.Abs(daemonPIDFile)
+	if err != nil {
+		return fmt.Errorf("failed to resolve daemon pid-file %q: %w", daemonPIDFile, err)
+	}
+
+	if resolved, resolveErr := filepath.EvalSymlinks(resolvedDaemonPIDFile); resolveErr == nil {
+		resolvedDaemonPIDFile = resolved
+	}
+
+	expectedPIDFile := pidFile
+	resolvedExpectedPIDFile, err := filepath.Abs(expectedPIDFile)
+	if err != nil {
+		return fmt.Errorf("failed to resolve expected pid-file %q: %w", expectedPIDFile, err)
+	}
+
+	if resolved, resolveErr := filepath.EvalSymlinks(resolvedExpectedPIDFile); resolveErr == nil {
+		resolvedExpectedPIDFile = resolved
+	}
+
+	if resolvedDaemonPIDFile != resolvedExpectedPIDFile {
+		return fmt.Errorf("pid %d pid-file mismatch: got %q, expected %q", pid, resolvedDaemonPIDFile, resolvedExpectedPIDFile)
+	}
+
 	status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
 	if err != nil {
 		return fmt.Errorf("failed to verify daemon ownership for pid %d: %w", pid, err)

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -124,6 +125,40 @@ func validateDaemonProcess(pid int) error {
 
 	if runIdx == -1 || args[runIdx] != "run" {
 		return fmt.Errorf("pid %d is not a daemon runtime process", pid)
+	}
+
+	status, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return fmt.Errorf("failed to verify daemon ownership for pid %d: %w", pid, err)
+	}
+
+	var procUID int
+	foundUID := false
+	for _, line := range strings.Split(string(status), "\n") {
+		if !strings.HasPrefix(line, "Uid:") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return fmt.Errorf("failed to parse daemon ownership for pid %d", pid)
+		}
+
+		procUID, err = strconv.Atoi(fields[1])
+		if err != nil {
+			return fmt.Errorf("failed to parse daemon uid for pid %d: %w", pid, err)
+		}
+
+		foundUID = true
+		break
+	}
+
+	if !foundUID {
+		return fmt.Errorf("failed to read daemon uid for pid %d", pid)
+	}
+
+	if procUID != os.Geteuid() {
+		return fmt.Errorf("pid %d is owned by uid %d (current uid %d)", pid, procUID, os.Geteuid())
 	}
 
 	return nil

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -101,29 +101,25 @@ func validateDaemonProcess(pid int) error {
 	}
 
 	args := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
-	daemonIdx := -1
-	for i, arg := range args {
-		if arg == "daemon" {
-			daemonIdx = i
-			break
-		}
+	if len(args) < 2 {
+		return fmt.Errorf("pid %d has an invalid command line", pid)
 	}
 
-	if daemonIdx == -1 {
-		return fmt.Errorf("pid %d is not a daemon process", pid)
-	}
+	commands := make([]string, 0, len(args))
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "-") {
+			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				i++
+			}
 
-	runIdx := -1
-	for i := daemonIdx + 1; i < len(args); i++ {
-		if strings.HasPrefix(args[i], "-") {
 			continue
 		}
 
-		runIdx = i
-		break
+		commands = append(commands, arg)
 	}
 
-	if runIdx == -1 || args[runIdx] != "run" {
+	if len(commands) < 2 || commands[0] != "daemon" || commands[1] != "run" {
 		return fmt.Errorf("pid %d is not a daemon runtime process", pid)
 	}
 

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -100,8 +100,23 @@ func validateDaemonProcess(pid int) error {
 	}
 
 	args := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
-	if len(args) < 2 || args[1] != "daemon" {
+	daemonIdx := -1
+	for i, arg := range args {
+		if arg == "daemon" {
+			daemonIdx = i
+			break
+		}
+	}
+
+	if daemonIdx == -1 {
 		return fmt.Errorf("pid %d is not a daemon process", pid)
+	}
+
+	if daemonIdx+1 < len(args) {
+		next := args[daemonIdx+1]
+		if next != "run" && !strings.HasPrefix(next, "-") {
+			return fmt.Errorf("pid %d is not a daemon runtime process", pid)
+		}
 	}
 
 	return nil

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -112,11 +112,18 @@ func validateDaemonProcess(pid int) error {
 		return fmt.Errorf("pid %d is not a daemon process", pid)
 	}
 
-	if daemonIdx+1 < len(args) {
-		next := args[daemonIdx+1]
-		if next != "run" && !strings.HasPrefix(next, "-") {
-			return fmt.Errorf("pid %d is not a daemon runtime process", pid)
+	runIdx := -1
+	for i := daemonIdx + 1; i < len(args); i++ {
+		if strings.HasPrefix(args[i], "-") {
+			continue
 		}
+
+		runIdx = i
+		break
+	}
+
+	if runIdx == -1 || args[runIdx] != "run" {
+		return fmt.Errorf("pid %d is not a daemon runtime process", pid)
 	}
 
 	return nil

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -6,6 +6,8 @@ package daemon
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -42,6 +44,10 @@ func runStop(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to find process %d: %w", pid, err)
 	}
 
+	if err := validateDaemonProcess(pid); err != nil {
+		return err
+	}
+
 	if err := proc.Signal(syscall.SIGTERM); err != nil {
 		return fmt.Errorf("failed to send SIGTERM to pid %d: %w", pid, err)
 	}
@@ -60,6 +66,33 @@ func runStop(_ *cobra.Command, _ []string) error {
 	}
 
 	logger.Warn("Daemon did not stop within timeout; it may still be shutting down")
+
+	return nil
+}
+
+func validateDaemonProcess(pid int) error {
+	selfExe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to resolve current executable: %w", err)
+	}
+
+	if resolvedSelfExe, resolveErr := filepath.EvalSymlinks(selfExe); resolveErr == nil {
+		selfExe = resolvedSelfExe
+	}
+
+	targetExe, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+	if err != nil {
+		return fmt.Errorf("failed to verify process identity for pid %d: %w", pid, err)
+	}
+
+	targetExe = strings.TrimSuffix(targetExe, " (deleted)")
+	if resolvedTargetExe, resolveErr := filepath.EvalSymlinks(targetExe); resolveErr == nil {
+		targetExe = resolvedTargetExe
+	}
+
+	if selfExe != targetExe {
+		return fmt.Errorf("pid %d does not match daemon executable", pid)
+	}
 
 	return nil
 }

--- a/cli/cmd/daemon/stop.go
+++ b/cli/cmd/daemon/stop.go
@@ -94,5 +94,23 @@ func validateDaemonProcess(pid int) error {
 		return fmt.Errorf("pid %d does not match daemon executable", pid)
 	}
 
+	cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return fmt.Errorf("failed to verify daemon command for pid %d: %w", pid, err)
+	}
+
+	args := strings.Split(strings.TrimRight(string(cmdline), "\x00"), "\x00")
+	isDaemonCommand := false
+	for _, arg := range args[1:] {
+		if arg == "daemon" {
+			isDaemonCommand = true
+			break
+		}
+	}
+
+	if !isDaemonCommand {
+		return fmt.Errorf("pid %d is not a daemon process", pid)
+	}
+
 	return nil
 }

--- a/cli/cmd/export/format/skill.go
+++ b/cli/cmd/export/format/skill.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/oasf-sdk/pkg/translator"
@@ -47,18 +48,34 @@ func (f *skillFormatter) FormatBatch(records []*corev1.Record, outputDir string,
 		toExport = LatestByName(records)
 	}
 
+	absOutputDir, err := filepath.Abs(filepath.Clean(outputDir))
+	if err != nil {
+		return 0, fmt.Errorf("failed to resolve output directory %s: %w", outputDir, err)
+	}
+
 	exported := 0
 	seen := make(map[string]int)
 
 	for i, record := range toExport {
 		base := batchFileName(record, i, seen, allVersions)
+		cleanBase := filepath.Clean(base)
+		if cleanBase == "." || cleanBase == ".." || filepath.IsAbs(cleanBase) || cleanBase != base || strings.Contains(base, "/") || strings.Contains(base, "\\") {
+			return exported, fmt.Errorf("invalid batch file name %q", base)
+		}
 
 		output, err := f.Format(record)
 		if err != nil {
 			return exported, fmt.Errorf("failed to format skill %q: %w", base, err)
 		}
 
-		skillDir := filepath.Join(outputDir, base)
+		skillDir := filepath.Join(outputDir, cleanBase)
+		absSkillDir, err := filepath.Abs(filepath.Clean(skillDir))
+		if err != nil {
+			return exported, fmt.Errorf("failed to resolve output path %s: %w", skillDir, err)
+		}
+		if absSkillDir != absOutputDir && !strings.HasPrefix(absSkillDir, absOutputDir+string(os.PathSeparator)) {
+			return exported, fmt.Errorf("invalid output path %s", skillDir)
+		}
 		if err := os.MkdirAll(skillDir, 0o755); err != nil { //nolint:mnd
 			return exported, fmt.Errorf("failed to create directory %s: %w", skillDir, err)
 		}


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `cli/cmd/daemon/stop.go:L24`

The `runStop` function reads a PID from a PID file and unconditionally sends `SIGTERM` to that process ID after a basic liveness check. If an attacker can tamper with the PID file (or if it becomes stale and PID is reused), this can terminate an unintended process. This is especially risky when the CLI is run with elevated privileges.

## Solution

Harden PID handling by validating process identity before signaling (e.g., verify executable path/command line matches daemon binary, optionally verify start time), ensure PID file is created with strict permissions/ownership, and reject PID files not owned by expected user.

## Changes

- `cli/cmd/daemon/stop.go` (modified)
- `cli/cmd/export/format/skill.go` (modified)