### PR TITLE
feat(client/cli): cache OIDC tokens per issuer

### DIFF
--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -29,7 +29,7 @@ var loginCmd = &cobra.Command{
 Default: Authorization Code + PKCE flow (opens browser).
 Device flow: --device flag (no browser needed; authorize on any device).
 
-Configuration (flags, env, or config file):
+Configuration (flags or environment):
   --oidc-issuer, DIRECTORY_CLIENT_OIDC_ISSUER        OIDC issuer URL (e.g. https://dex.example.com)
   --oidc-client-id, DIRECTORY_CLIENT_OIDC_CLIENT_ID  OIDC client ID
 
@@ -59,11 +59,25 @@ func init() {
 func runLogin(cmd *cobra.Command, _ []string) error {
 	cfg := config.Client
 
-	cache := client.NewTokenCache()
+	// Validate OIDC config
+	if cfg.OIDCIssuer == "" || cfg.OIDCClientID == "" {
+		return errors.New("OIDC issuer and client ID are required for login.\n\n" +
+			"Set via flags: --oidc-issuer, --oidc-client-id\n" +
+			"Or environment: DIRECTORY_CLIENT_OIDC_ISSUER, DIRECTORY_CLIENT_OIDC_CLIENT_ID")
+	}
 
-	// Check for existing valid token unless force login
+	cache, err := client.NewTokenCacheForIssuer(cfg.OIDCIssuer)
+	if err != nil {
+		return fmt.Errorf("failed to resolve OIDC token cache: %w", err)
+	}
+
+	// Check for existing valid token unless force login.
 	if !forceLogin {
-		existingToken, _ := cache.GetValidToken()
+		existingToken, err := cache.GetValidToken()
+		if err != nil {
+			return fmt.Errorf("failed to read token cache: %w", err)
+		}
+
 		if existingToken != nil {
 			cmd.Println()
 			cmd.Printf("✓ Already authenticated as: %s\n", existingToken.User)
@@ -78,14 +92,6 @@ func runLogin(cmd *cobra.Command, _ []string) error {
 
 			return nil
 		}
-	}
-
-	// Validate OIDC config
-	if cfg.OIDCIssuer == "" || cfg.OIDCClientID == "" {
-		return errors.New("OIDC issuer and client ID are required for login.\n\n" +
-			"Set via flags: --oidc-issuer, --oidc-client-id\n" +
-			"Or environment: DIRECTORY_CLIENT_OIDC_ISSUER, DIRECTORY_CLIENT_OIDC_CLIENT_ID\n" +
-			"Or config file (~/.config/dirctl/config.yaml): oidc_issuer, oidc_client_id")
 	}
 
 	if useDeviceFlow {

--- a/cli/cmd/auth/logout.go
+++ b/cli/cmd/auth/logout.go
@@ -4,8 +4,10 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/agntcy/dir/cli/config"
 	"github.com/agntcy/dir/client"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +27,21 @@ Examples:
 }
 
 func runLogout(cmd *cobra.Command, _ []string) error {
-	cache := client.NewTokenCache()
+	cache, err := client.ResolveTokenCacheForIssuer(config.Client.OIDCIssuer)
+	if err != nil {
+		var ambiguousErr *client.AmbiguousTokenCacheError
+		if errors.As(err, &ambiguousErr) {
+			return fmt.Errorf("%w; use --oidc-issuer or DIRECTORY_CLIENT_OIDC_ISSUER", err)
+		}
+
+		if errors.Is(err, client.ErrNoCachedIssuer) {
+			cmd.Println("No cached credentials found.")
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to resolve token cache: %w", err)
+	}
 
 	// Load existing token to show who we're logging out
 	token, _ := cache.Load()

--- a/cli/cmd/auth/status.go
+++ b/cli/cmd/auth/status.go
@@ -4,10 +4,12 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/agntcy/dir/cli/config"
 	"github.com/agntcy/dir/client"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +29,23 @@ Examples:
 }
 
 func runStatus(cmd *cobra.Command, _ []string) error {
-	cache := client.NewTokenCache()
+	cache, err := client.ResolveTokenCacheForIssuer(config.Client.OIDCIssuer)
+	if err != nil {
+		var ambiguousErr *client.AmbiguousTokenCacheError
+		if errors.As(err, &ambiguousErr) {
+			return fmt.Errorf("%w; use --oidc-issuer or DIRECTORY_CLIENT_OIDC_ISSUER", err)
+		}
+
+		if errors.Is(err, client.ErrNoCachedIssuer) {
+			cmd.Println("Status: Not authenticated")
+			cmd.Println()
+			cmd.Println("Run 'dirctl auth login' to authenticate.")
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to resolve token cache: %w", err)
+	}
 
 	token, err := cache.Load()
 	if err != nil {

--- a/cli/cmd/auth/status_logout_test.go
+++ b/cli/cmd/auth/status_logout_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	clcfg "github.com/agntcy/dir/cli/config"
 	"github.com/agntcy/dir/client"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,8 @@ import (
 
 func TestRunStatus_NotAuthenticated(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	clcfg.Client = &client.DefaultConfig
 
 	cmd, out := newTestCommand()
 	err := runStatus(cmd, nil)
@@ -29,8 +32,12 @@ func TestRunStatus_NotAuthenticated(t *testing.T) {
 func TestRunStatus_WithMachineToken(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cache := client.NewTokenCache()
-	err := cache.Save(&client.CachedToken{
+	clcfg.Client = &client.DefaultConfig
+
+	cache, err := client.NewTokenCacheForIssuer("https://issuer.example")
+	require.NoError(t, err)
+
+	err = cache.Save(&client.CachedToken{
 		AccessToken: "test-token",
 		TokenType:   "Bearer",
 		Provider:    "oidc",
@@ -58,10 +65,15 @@ func TestRunStatus_WithMachineToken(t *testing.T) {
 func TestRunLogout_ClearsCache(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cache := client.NewTokenCache()
-	err := cache.Save(&client.CachedToken{
+	clcfg.Client = &client.DefaultConfig
+
+	cache, err := client.NewTokenCacheForIssuer("https://issuer.example")
+	require.NoError(t, err)
+
+	err = cache.Save(&client.CachedToken{
 		AccessToken: "test-token",
 		Provider:    "oidc",
+		Issuer:      "https://issuer.example",
 		User:        "machine-client",
 		CreatedAt:   time.Now(),
 	})
@@ -78,6 +90,39 @@ func TestRunLogout_ClearsCache(t *testing.T) {
 	tok, err := cache.Load()
 	require.NoError(t, err)
 	require.Nil(t, tok)
+}
+
+func TestRunStatus_RequiresIssuerWhenMultipleCachesExist(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	clcfg.Client = &client.DefaultConfig
+
+	cacheA, err := client.NewTokenCacheForIssuer("https://issuer-a.example")
+	require.NoError(t, err)
+	require.NoError(t, cacheA.Save(&client.CachedToken{
+		AccessToken: "token-a",
+		Provider:    "oidc",
+		Issuer:      "https://issuer-a.example",
+		User:        "user-a",
+		CreatedAt:   time.Now(),
+	}))
+
+	cacheB, err := client.NewTokenCacheForIssuer("https://issuer-b.example")
+	require.NoError(t, err)
+	require.NoError(t, cacheB.Save(&client.CachedToken{
+		AccessToken: "token-b",
+		Provider:    "oidc",
+		Issuer:      "https://issuer-b.example",
+		User:        "user-b",
+		CreatedAt:   time.Now(),
+	}))
+
+	cmd, _ := newTestCommand()
+	err = runStatus(cmd, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--oidc-issuer")
+	require.Contains(t, err.Error(), "https://issuer-a.example")
+	require.Contains(t, err.Error(), "https://issuer-b.example")
 }
 
 func newTestCommand() (*cobra.Command, *bytes.Buffer) {

--- a/client/oidc_grpc.go
+++ b/client/oidc_grpc.go
@@ -44,7 +44,14 @@ func (o *options) resolveOIDCAccessToken(ctx context.Context) (string, error) {
 		return accessToken, nil
 	}
 
-	cache := NewTokenCache()
+	cache, err := ResolveTokenCacheForIssuer(o.config.OIDCIssuer)
+	if err != nil {
+		if errors.Is(err, ErrNoCachedIssuer) {
+			return "", errors.New("no OIDC access token: run 'dirctl auth login', or set DIRECTORY_CLIENT_AUTH_TOKEN")
+		}
+
+		return "", err
+	}
 
 	// Fast path: use only a currently valid token.
 	// Note: GetValidToken() returns (nil, nil) for both "missing" and "expired" tokens.

--- a/client/oidc_grpc_test.go
+++ b/client/oidc_grpc_test.go
@@ -69,9 +69,13 @@ func TestSetupOIDCAuth_NoTokenReturnsError(t *testing.T) {
 func TestSetupOIDCAuth_ExpiredCachedTokenReturnsAuthError(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cache := NewTokenCache()
-	err := cache.Save(&CachedToken{
+	cache, err := NewTokenCacheForIssuer("https://issuer.example.com")
+	require.NoError(t, err)
+
+	err = cache.Save(&CachedToken{
 		AccessToken: "expired-token",
+		Issuer:      "https://issuer.example.com",
+		Provider:    "oidc",
 		ExpiresAt:   time.Now().Add(-time.Hour),
 		CreatedAt:   time.Now().Add(-time.Hour),
 	})
@@ -112,9 +116,10 @@ func TestSetupOIDCAuth_ExpiredCachedTokenRefreshSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cache := NewTokenCache()
+	cache, err := NewTokenCacheForIssuer(srv.URL)
+	require.NoError(t, err)
 	//nolint:gosec // G101: test fixture token values, not real credentials
-	err := cache.Save(&CachedToken{
+	err = cache.Save(&CachedToken{
 		AccessToken:  "expired-token",
 		RefreshToken: "cached-refresh-token",
 		Issuer:       srv.URL,
@@ -153,9 +158,10 @@ func TestSetupOIDCAuth_ExpiredCachedTokenRefreshRejected(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cache := NewTokenCache()
+	cache, err := NewTokenCacheForIssuer(srv.URL)
+	require.NoError(t, err)
 	//nolint:gosec // G101: test fixture token values, not real credentials
-	err := cache.Save(&CachedToken{
+	err = cache.Save(&CachedToken{
 		AccessToken:  "expired-token",
 		RefreshToken: "cached-refresh-token",
 		Issuer:       srv.URL,
@@ -183,8 +189,10 @@ func TestSetupOIDCAuth_ExpiredCachedTokenRefreshRejected(t *testing.T) {
 func TestSetupOIDCAuth_ExpiredCachedTokenMissingRefreshToken(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cache := NewTokenCache()
-	err := cache.Save(&CachedToken{
+	cache, err := NewTokenCacheForIssuer("https://issuer.example.com")
+	require.NoError(t, err)
+
+	err = cache.Save(&CachedToken{
 		AccessToken: "expired-token",
 		Issuer:      "https://issuer.example.com",
 		Provider:    "oidc",
@@ -215,9 +223,10 @@ func TestSetupOIDCAuth_RefreshPreservesCachedRefreshTokenWhenMissingInResponse(t
 	}))
 	defer srv.Close()
 
-	cache := NewTokenCache()
+	cache, err := NewTokenCacheForIssuer(srv.URL)
+	require.NoError(t, err)
 	//nolint:gosec // G101: test fixture token values, not real credentials
-	err := cache.Save(&CachedToken{
+	err = cache.Save(&CachedToken{
 		AccessToken:  "expired-token",
 		RefreshToken: "cached-refresh-token",
 		Issuer:       srv.URL,
@@ -243,4 +252,41 @@ func TestSetupOIDCAuth_RefreshPreservesCachedRefreshTokenWhenMissingInResponse(t
 	require.NotNil(t, updatedToken)
 	assert.Equal(t, "new-access-token", updatedToken.AccessToken)
 	assert.Equal(t, "cached-refresh-token", updatedToken.RefreshToken)
+}
+
+func TestSetupOIDCAuth_RequiresIssuerSelectionWhenMultipleCachesExist(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cacheA, err := NewTokenCacheForIssuer("https://issuer-a.example.com")
+	require.NoError(t, err)
+	require.NoError(t, cacheA.Save(&CachedToken{
+		AccessToken: "token-a",
+		Issuer:      "https://issuer-a.example.com",
+		Provider:    "oidc",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		CreatedAt:   time.Now(),
+	}))
+
+	cacheB, err := NewTokenCacheForIssuer("https://issuer-b.example.com")
+	require.NoError(t, err)
+	require.NoError(t, cacheB.Save(&CachedToken{
+		AccessToken: "token-b",
+		Issuer:      "https://issuer-b.example.com",
+		Provider:    "oidc",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		CreatedAt:   time.Now(),
+	}))
+
+	opts := &options{
+		config: &Config{
+			ServerAddress: "gateway.example.com:443",
+			AuthMode:      "oidc",
+		},
+	}
+
+	err = opts.setupOIDCAuth(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "select one explicitly")
+	assert.Contains(t, err.Error(), "https://issuer-a.example.com")
+	assert.Contains(t, err.Error(), "https://issuer-b.example.com")
 }

--- a/client/options.go
+++ b/client/options.go
@@ -134,7 +134,14 @@ func (o *options) shouldAutoDetectOIDC() (bool, error) {
 		return true, nil
 	}
 
-	cache := NewTokenCache()
+	cache, err := ResolveTokenCacheForIssuer(o.config.OIDCIssuer)
+	if err != nil {
+		if errors.Is(err, ErrNoCachedIssuer) {
+			return false, nil
+		}
+
+		return false, err
+	}
 
 	tok, err := cache.Load()
 	if err != nil {

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -519,9 +519,13 @@ func TestSetupAutoDetectAuth(t *testing.T) {
 	t.Run("should not fallback to insecure when cached OIDC token is expired", func(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-		cache := NewTokenCache()
-		err := cache.Save(&CachedToken{
+		cache, err := NewTokenCacheForIssuer("https://issuer.example.com")
+		require.NoError(t, err)
+
+		err = cache.Save(&CachedToken{
 			AccessToken: "expired-token",
+			Issuer:      "https://issuer.example.com",
+			Provider:    "oidc",
 			ExpiresAt:   time.Now().Add(-time.Hour),
 			CreatedAt:   time.Now().Add(-time.Hour),
 		})
@@ -539,6 +543,72 @@ func TestSetupAutoDetectAuth(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cached OIDC token has expired")
+	})
+
+	t.Run("should auto-detect OIDC from a single cached issuer", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cache, err := NewTokenCacheForIssuer("https://issuer.example.com")
+		require.NoError(t, err)
+
+		err = cache.Save(&CachedToken{
+			AccessToken: "valid-token",
+			Issuer:      "https://issuer.example.com",
+			Provider:    "oidc",
+			ExpiresAt:   time.Now().Add(time.Hour),
+			CreatedAt:   time.Now(),
+		})
+		require.NoError(t, err)
+
+		opts := &options{
+			config: &Config{
+				ServerAddress: "gateway.example.com:443",
+				AuthMode:      "",
+			},
+		}
+
+		ctx := context.Background()
+		err = opts.setupAutoDetectAuth(ctx)
+
+		require.NoError(t, err)
+		assert.Len(t, opts.authOpts, 2)
+	})
+
+	t.Run("should require explicit issuer when multiple cached issuers exist", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cacheA, err := NewTokenCacheForIssuer("https://issuer-a.example.com")
+		require.NoError(t, err)
+		require.NoError(t, cacheA.Save(&CachedToken{
+			AccessToken: "token-a",
+			Issuer:      "https://issuer-a.example.com",
+			Provider:    "oidc",
+			ExpiresAt:   time.Now().Add(time.Hour),
+			CreatedAt:   time.Now(),
+		}))
+
+		cacheB, err := NewTokenCacheForIssuer("https://issuer-b.example.com")
+		require.NoError(t, err)
+		require.NoError(t, cacheB.Save(&CachedToken{
+			AccessToken: "token-b",
+			Issuer:      "https://issuer-b.example.com",
+			Provider:    "oidc",
+			ExpiresAt:   time.Now().Add(time.Hour),
+			CreatedAt:   time.Now(),
+		}))
+
+		opts := &options{
+			config: &Config{
+				ServerAddress: "gateway.example.com:443",
+				AuthMode:      "",
+			},
+		}
+
+		ctx := context.Background()
+		err = opts.setupAutoDetectAuth(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "select one explicitly")
 	})
 
 	t.Run("should auto-detect OIDC when issuer/client config is present", func(t *testing.T) {

--- a/client/token_cache.go
+++ b/client/token_cache.go
@@ -4,10 +4,16 @@
 package client
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -21,6 +27,9 @@ const (
 	//nolint:gosec // G101: This is a filename, not a credential
 	TokenCacheFile = "auth-token.json"
 
+	// TokenCacheSubdir is where issuer-scoped token cache files are stored.
+	TokenCacheSubdir = "tokens"
+
 	// DefaultTokenValidityDuration is how long a token is considered valid if no expiry is set.
 	DefaultTokenValidityDuration = 8 * time.Hour
 
@@ -30,6 +39,14 @@ const (
 	// File and directory permissions for secure token storage.
 	cacheDirPerms  = 0o700 // Owner read/write/execute only
 	cacheFilePerms = 0o600 // Owner read/write only
+)
+
+var (
+	// ErrTokenCacheNotFound indicates that a specific token cache file does not exist.
+	ErrTokenCacheNotFound = errors.New("token cache not found")
+
+	// ErrNoCachedIssuer indicates that no issuer-scoped token cache could be selected.
+	ErrNoCachedIssuer = errors.New("no cached OIDC issuer found")
 )
 
 // CachedToken represents a cached authentication token from any provider.
@@ -72,30 +89,53 @@ type TokenCacheEntry = CachedToken
 type TokenCache struct {
 	// CacheDir is the directory where tokens are stored.
 	CacheDir string
+
+	// CacheFile is the cache filename inside CacheDir.
+	CacheFile string
+
+	// Issuer is the issuer this cache is scoped to, if any.
+	Issuer string
 }
 
 // NewTokenCache creates a new token cache with the default directory.
 // Respects XDG_CONFIG_HOME environment variable for config directory location.
 func NewTokenCache() *TokenCache {
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		home, _ := os.UserHomeDir()
-		configHome = filepath.Join(home, ".config")
-	}
-
 	return &TokenCache{
-		CacheDir: filepath.Join(configHome, "dirctl"),
+		CacheDir:  defaultTokenCacheRoot(),
+		CacheFile: TokenCacheFile,
 	}
 }
 
 // NewTokenCacheWithDir creates a new token cache with a custom directory.
 func NewTokenCacheWithDir(dir string) *TokenCache {
-	return &TokenCache{CacheDir: dir}
+	return &TokenCache{
+		CacheDir:  dir,
+		CacheFile: TokenCacheFile,
+	}
+}
+
+// NewTokenCacheWithDirAndIssuer creates a token cache for a specific issuer using a custom root directory.
+func NewTokenCacheWithDirAndIssuer(dir, issuer string) (*TokenCache, error) {
+	normalizedIssuer, err := normalizeIssuer(issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TokenCache{
+		CacheDir:  filepath.Join(dir, TokenCacheSubdir),
+		CacheFile: issuerCacheFileName(normalizedIssuer),
+		Issuer:    normalizedIssuer,
+	}, nil
+}
+
+// NewTokenCacheForIssuer creates a token cache scoped to a specific issuer.
+func NewTokenCacheForIssuer(issuer string) (*TokenCache, error) {
+	return NewTokenCacheWithDirAndIssuer(defaultTokenCacheRoot(), issuer)
 }
 
 // GetCachePath returns the full path to the token cache file.
 func (c *TokenCache) GetCachePath() string {
-	return filepath.Join(c.CacheDir, TokenCacheFile)
+	return filepath.Join(c.CacheDir, c.cacheFileName())
 }
 
 // Load loads the cached token from disk.
@@ -116,6 +156,17 @@ func (c *TokenCache) Load() (*CachedToken, error) {
 	var token CachedToken
 	if err := json.Unmarshal(data, &token); err != nil {
 		return nil, fmt.Errorf("failed to parse token cache: %w", err)
+	}
+
+	if c.Issuer != "" {
+		normalizedIssuer, err := normalizeIssuer(token.Issuer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate cached token issuer: %w", err)
+		}
+
+		if normalizedIssuer != c.Issuer {
+			return nil, fmt.Errorf("cached token issuer mismatch: expected %s, got %s", c.Issuer, token.Issuer)
+		}
 	}
 
 	return &token, nil
@@ -157,7 +208,7 @@ func (c *TokenCache) save(token *CachedToken, atomic bool) error {
 		return nil
 	}
 
-	tmpFile, err := os.CreateTemp(c.CacheDir, TokenCacheFile+".tmp.*")
+	tmpFile, err := os.CreateTemp(c.CacheDir, c.cacheFileName()+".tmp.*")
 	if err != nil {
 		return fmt.Errorf("failed to create temp token cache file: %w", err)
 	}
@@ -231,4 +282,174 @@ func (c *TokenCache) GetValidToken() (*CachedToken, error) {
 	}
 
 	return token, nil
+}
+
+// AmbiguousTokenCacheError indicates multiple issuer-scoped caches exist and the caller must select one.
+type AmbiguousTokenCacheError struct {
+	Issuers []string
+}
+
+func (e *AmbiguousTokenCacheError) Error() string {
+	return fmt.Sprintf(
+		"multiple cached OIDC issuers found; select one explicitly: %s",
+		strings.Join(e.Issuers, ", "),
+	)
+}
+
+// CachedIssuer describes one issuer-scoped cache file.
+type CachedIssuer struct {
+	Issuer string
+	Path   string
+}
+
+// ResolveTokenCacheForIssuer resolves the appropriate token cache.
+// If issuer is provided, the corresponding issuer-scoped cache is returned.
+// If issuer is empty, the only available issuer cache is returned when exactly one exists.
+// Returns ErrNoCachedIssuer when no issuer is provided and no caches exist.
+func ResolveTokenCacheForIssuer(issuer string) (*TokenCache, error) {
+	if strings.TrimSpace(issuer) != "" {
+		return NewTokenCacheForIssuer(issuer)
+	}
+
+	cachedIssuers, err := ListCachedIssuers()
+	if err != nil {
+		return nil, err
+	}
+
+	switch len(cachedIssuers) {
+	case 0:
+		return nil, ErrNoCachedIssuer
+	case 1:
+		return NewTokenCacheForIssuer(cachedIssuers[0].Issuer)
+	default:
+		issuers := make([]string, 0, len(cachedIssuers))
+		for _, cachedIssuer := range cachedIssuers {
+			issuers = append(issuers, cachedIssuer.Issuer)
+		}
+
+		return nil, &AmbiguousTokenCacheError{Issuers: issuers}
+	}
+}
+
+// ListCachedIssuers returns all issuer-scoped token caches on disk.
+func ListCachedIssuers() ([]CachedIssuer, error) {
+	tokensDir := filepath.Join(defaultTokenCacheRoot(), TokenCacheSubdir)
+
+	entries, err := os.ReadDir(tokensDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to list token caches: %w", err)
+	}
+
+	cachedIssuers := make([]CachedIssuer, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		path := filepath.Join(tokensDir, entry.Name())
+
+		token, err := loadCachedTokenFromPath(path)
+		if err != nil {
+			if errors.Is(err, ErrTokenCacheNotFound) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		if token == nil || strings.TrimSpace(token.Issuer) == "" {
+			continue
+		}
+
+		normalizedIssuer, err := normalizeIssuer(token.Issuer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to normalize cached token issuer from %s: %w", path, err)
+		}
+
+		cachedIssuers = append(cachedIssuers, CachedIssuer{
+			Issuer: normalizedIssuer,
+			Path:   path,
+		})
+	}
+
+	sort.Slice(cachedIssuers, func(i, j int) bool {
+		return cachedIssuers[i].Issuer < cachedIssuers[j].Issuer
+	})
+
+	return cachedIssuers, nil
+}
+
+func defaultTokenCacheRoot() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, _ := os.UserHomeDir()
+		configHome = filepath.Join(home, ".config")
+	}
+
+	return filepath.Join(configHome, "dirctl")
+}
+
+func (c *TokenCache) cacheFileName() string {
+	if c.CacheFile != "" {
+		return c.CacheFile
+	}
+
+	return TokenCacheFile
+}
+
+func issuerCacheFileName(normalizedIssuer string) string {
+	sum := sha256.Sum256([]byte(normalizedIssuer))
+
+	return hex.EncodeToString(sum[:]) + ".json"
+}
+
+func normalizeIssuer(issuer string) (string, error) {
+	trimmedIssuer := strings.TrimSpace(issuer)
+	if trimmedIssuer == "" {
+		return "", errors.New("issuer is required")
+	}
+
+	parsed, err := url.Parse(trimmedIssuer)
+	if err != nil {
+		return "", fmt.Errorf("invalid issuer URL: %w", err)
+	}
+
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid issuer URL: %s", issuer)
+	}
+
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	parsed.Host = strings.ToLower(parsed.Host)
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+
+	if parsed.Path == "/" {
+		parsed.Path = ""
+	} else {
+		parsed.Path = strings.TrimRight(parsed.Path, "/")
+	}
+
+	return parsed.String(), nil
+}
+
+func loadCachedTokenFromPath(path string) (*CachedToken, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrTokenCacheNotFound
+		}
+
+		return nil, fmt.Errorf("failed to read token cache %s: %w", path, err)
+	}
+
+	var token CachedToken
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, fmt.Errorf("failed to parse token cache %s: %w", path, err)
+	}
+
+	return &token, nil
 }

--- a/client/token_cache_test.go
+++ b/client/token_cache_test.go
@@ -51,6 +51,26 @@ func TestNewTokenCacheWithDir(t *testing.T) {
 	})
 }
 
+func TestNewTokenCacheForIssuer(t *testing.T) {
+	t.Run("should create issuer-scoped cache under tokens directory", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cache, err := NewTokenCacheForIssuer("https://Issuer.EXAMPLE.com/")
+		require.NoError(t, err)
+
+		require.NotNil(t, cache)
+		assert.Equal(t, "https://issuer.example.com", cache.Issuer)
+		assert.Contains(t, cache.CacheDir, filepath.Join("dirctl", TokenCacheSubdir))
+		assert.Equal(t, issuerCacheFileName("https://issuer.example.com"), filepath.Base(cache.GetCachePath()))
+	})
+
+	t.Run("should reject invalid issuer", func(t *testing.T) {
+		cache, err := NewTokenCacheForIssuer("not a url")
+		require.Error(t, err)
+		assert.Nil(t, cache)
+	})
+}
+
 func TestTokenCache_GetCachePath(t *testing.T) {
 	t.Run("should return full path to cache file", func(t *testing.T) {
 		customDir := "/tmp/test-cache"
@@ -68,6 +88,64 @@ func TestTokenCache_GetCachePath(t *testing.T) {
 		path := cache.GetCachePath()
 
 		assert.Contains(t, path, TokenCacheFile)
+	})
+}
+
+func TestResolveTokenCacheForIssuer(t *testing.T) {
+	t.Run("should return nil when no issuer and no caches exist", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cache, err := ResolveTokenCacheForIssuer("")
+		require.ErrorIs(t, err, ErrNoCachedIssuer)
+		assert.Nil(t, cache)
+	})
+
+	t.Run("should resolve the only cached issuer when issuer is omitted", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cache, err := NewTokenCacheForIssuer("https://issuer.example.com")
+		require.NoError(t, err)
+		require.NoError(t, cache.Save(&CachedToken{
+			AccessToken: "token",
+			Issuer:      "https://issuer.example.com",
+			Provider:    "oidc",
+			CreatedAt:   time.Now(),
+		}))
+
+		resolvedCache, err := ResolveTokenCacheForIssuer("")
+		require.NoError(t, err)
+		require.NotNil(t, resolvedCache)
+		assert.Equal(t, cache.GetCachePath(), resolvedCache.GetCachePath())
+	})
+
+	t.Run("should return ambiguity error when multiple issuer caches exist", func(t *testing.T) {
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		cacheA, err := NewTokenCacheForIssuer("https://issuer-a.example.com")
+		require.NoError(t, err)
+		require.NoError(t, cacheA.Save(&CachedToken{
+			AccessToken: "token-a",
+			Issuer:      "https://issuer-a.example.com",
+			Provider:    "oidc",
+			CreatedAt:   time.Now(),
+		}))
+
+		cacheB, err := NewTokenCacheForIssuer("https://issuer-b.example.com")
+		require.NoError(t, err)
+		require.NoError(t, cacheB.Save(&CachedToken{
+			AccessToken: "token-b",
+			Issuer:      "https://issuer-b.example.com",
+			Provider:    "oidc",
+			CreatedAt:   time.Now(),
+		}))
+
+		resolvedCache, err := ResolveTokenCacheForIssuer("")
+		require.Error(t, err)
+		assert.Nil(t, resolvedCache)
+
+		var ambiguityErr *AmbiguousTokenCacheError
+		require.ErrorAs(t, err, &ambiguityErr)
+		assert.Equal(t, []string{"https://issuer-a.example.com", "https://issuer-b.example.com"}, ambiguityErr.Issuers)
 	})
 }
 


### PR DESCRIPTION
## Summary
`dirctl` now caches OIDC tokens per issuer instead of using a single global cache file. This prevents cross-issuer token reuse and makes issuer selection explicit when multiple cached issuers exist.

## What changed
- added issuer-scoped token cache resolution and hashed cache filenames
- updated login, OIDC runtime auth, status, logout, and auto-detect to use issuer-aware caches
- introduced explicit not-found and ambiguous-cache error handling
- kept CLI messaging in `cli/cmd/auth` and avoided CLI-specific behavior in `client`
- added tests covering single-issuer, multi-issuer, and refresh flows

## Behavior
- if exactly one issuer cache exists and no issuer is configured, `status`, `logout`, and auto-detect can use it
- if multiple issuer caches exist and no issuer is configured, explicit issuer selection is required
- users re-authenticate once after release; no legacy cache migration is included

Closes https://github.com/agntcy/dir/issues/1379 