### PR TITLE
feat(helm): add OpenShift install support

### DIFF
--- a/docs/openshift-install.md
+++ b/docs/openshift-install.md
@@ -1,0 +1,326 @@
+# Installing the Directory Service on OpenShift
+
+This guide walks through deploying the AGNTCY Directory Service on an
+OpenShift cluster with SPIFFE/SPIRE mTLS authentication.
+
+## Architecture
+
+The core Directory Service consists of:
+
+| Component | Description |
+|-----------|-------------|
+| **apiserver** | gRPC API server for the Directory Service |
+| **reconciler** | Async worker that syncs records from remote registries and indexes them |
+| **Zot registry** | OCI-compliant container registry used as the storage backend |
+| **PostgreSQL** | Database for record metadata and indexing |
+
+When SPIRE is enabled, internal communication uses SPIFFE X.509-SVIDs for
+mTLS authentication. The apiserver only accepts connections from workloads
+with valid SPIFFE identities.
+
+### External Access
+
+For external access to the Directory Service, its a prerequisite to deploy the
+[oidc-gateway](https://github.com/agntcy/oidc-gateway) separately. The
+oidc-gateway provides:
+
+- TLS termination via an OpenShift passthrough route
+- OIDC/JWT or GitHub PAT authentication for external clients
+- SPIFFE mTLS to the apiserver backend
+
+Without the oidc-gateway, the apiserver is accessible only via
+`oc port-forward` (for development/debugging) or from other SPIFFE-authenticated
+workloads within the cluster.
+
+## Prerequisites
+
+### Required Tools
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| `oc` | 4.x | OpenShift CLI |
+| `helm` | 3.x+ | Helm chart installation |
+| `dirctl` | latest | Directory Service CLI (for testing) |
+
+### Cluster Requirements
+
+- OpenShift 4.x cluster with cluster-admin access
+- **SPIRE** deployed on the cluster (server, agent, CSI driver, and
+  controller manager). The Directory chart creates `ClusterSPIFFEID`
+  resources but does not install SPIRE itself.
+- A storage class available for PostgreSQL and Zot persistent volumes
+
+### Verify SPIRE Is Running
+
+Confirm that the SPIRE agent, server, and CSI driver pods are healthy:
+
+```bash
+# Find SPIRE pods (they may be in any namespace)
+oc get pods --all-namespaces | grep spire
+
+# Verify the SPIFFE CSI driver is registered
+oc get csidrivers | grep csi.spiffe.io
+```
+
+You should see a `spire-server`, `spire-agent` (DaemonSet), and
+`spire-spiffe-csi-driver` (DaemonSet) all in a Running state.
+
+## Step 1: Create the Namespace
+
+```bash
+oc new-project agent-directory
+```
+
+Or if the namespace already exists:
+
+```bash
+oc project agent-directory
+```
+
+## Step 2: Gather SPIRE Configuration
+
+You need four values from the existing SPIRE installation.
+
+### 2.1 Trust Domain
+
+```bash
+# Replace <spire-namespace> with the namespace where SPIRE is deployed
+oc get configmap -n <spire-namespace> spire-server -o yaml | grep trust_domain
+```
+
+Note this value as `<YOUR-TRUST-DOMAIN>`.
+
+### 2.2 Controller Manager className
+
+Check existing ClusterSPIFFEIDs on the cluster to find the className:
+
+```bash
+oc get clusterspiffeids -o yaml | grep className
+```
+
+Note this value as `<YOUR-SPIRE-CLASS-NAME>`.
+
+If there is no className configured (classless mode), you can set
+`className: "none"` in the values file — the chart will omit the field
+entirely.
+
+### 2.3 SPIRE Agent Socket Filename
+
+Different SPIRE deployments use different socket filenames inside the CSI
+mount. Deploy a debug pod to check:
+
+```bash
+oc run spire-debug --image=busybox -n agent-directory --restart=Never \
+  --overrides='{
+    "spec": {
+      "containers": [{
+        "name": "debug",
+        "image": "busybox",
+        "command": ["ls", "-la", "/run/spire/agent-sockets/"],
+        "volumeMounts": [{
+          "name": "spire-socket",
+          "mountPath": "/run/spire/agent-sockets",
+          "readOnly": true
+        }]
+      }],
+      "volumes": [{
+        "name": "spire-socket",
+        "csi": {
+          "driver": "csi.spiffe.io",
+          "readOnly": true
+        }
+      }]
+    }
+  }'
+
+# Wait a moment, then check
+oc logs spire-debug -n agent-directory
+
+# Clean up
+oc delete pod spire-debug -n agent-directory
+```
+
+You should see a socket file like `api.sock` or
+`spire-agent.sock`. Note the filename as
+`<YOUR-SOCKET-FILENAME>`.
+
+### 2.4 Namespace Selector Pattern
+
+Some SPIRE controller managers require ClusterSPIFFEID resources to include
+a `namespaceSelector` that scopes them to specific namespaces. Check if the
+existing ClusterSPIFFEIDs use one:
+
+```bash
+oc get clusterspiffeids -o yaml | grep -A5 namespaceSelector
+```
+
+If you see `namespaceSelector` blocks, you will need one too. The
+`values-openshift.yaml` template includes a namespaceSelector by default
+that matches the deployment namespace.
+
+## Step 3: Configure the Values File
+
+The deployment uses a two-file layering approach:
+
+1. **`values-openshift.yaml`** — Generic OpenShift settings (committed to the
+   repo, not modified)
+2. **Your cluster-specific values file** — Fills in the placeholders for your
+   cluster
+
+Create your cluster-specific values file:
+
+```bash
+cat > install/charts/dir/my-values.yaml << 'EOF'
+apiserver:
+  config:
+    authn:
+      socket_path: "unix:///run/spire/agent-sockets/<YOUR-SOCKET-FILENAME>"
+    database:
+      postgres:
+        host: dir-release-postgresql
+
+  authz_policies_csv: |
+    p,<YOUR-TRUST-DOMAIN>,*
+    p,*,/agntcy.dir.store.v1.StoreService/Pull
+    p,*,/agntcy.dir.store.v1.StoreService/Push
+    p,*,/agntcy.dir.store.v1.StoreService/PullReferrer
+    p,*,/agntcy.dir.store.v1.StoreService/Lookup
+    p,*,/agntcy.dir.search.v1.SearchService/SearchCIDs
+    p,*,/agntcy.dir.search.v1.SearchService/SearchRecords
+    p,*,/agntcy.dir.sync.v1.SyncService/RequestRegistryCredentials
+
+  spire:
+    trustDomain: <YOUR-TRUST-DOMAIN>
+    className: <YOUR-SPIRE-CLASS-NAME>
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - agent-directory
+    dnsNameTemplates:
+      - dir-release-apiserver-agent-directory.<YOUR-CLUSTER-DOMAIN>
+
+  reconciler:
+    config:
+      database:
+        postgres:
+          host: dir-release-postgresql
+EOF
+```
+
+Replace the placeholders with the values gathered in Step 2:
+
+| Placeholder | Description | Example |
+|-------------|-------------|---------|
+| `<YOUR-TRUST-DOMAIN>` | SPIRE trust domain (Step 2.1) | `apps.mycluster.example.com` |
+| `<YOUR-SPIRE-CLASS-NAME>` | SPIRE controller manager className (Step 2.2) | `my-spire-class` |
+| `<YOUR-SOCKET-FILENAME>` | SPIRE agent socket filename (Step 2.3) | `spire-agent.sock` |
+| `<YOUR-CLUSTER-DOMAIN>` | OpenShift cluster wildcard domain | `apps.mycluster.example.com` |
+
+## Step 4: Build Dependencies and Install
+
+### Build Chart Dependencies
+
+The Helm chart has local subchart dependencies that must be built first:
+
+```bash
+# Build the apiserver subchart dependencies
+helm dependency build ./install/charts/dir/apiserver
+
+# Build the top-level chart dependencies
+helm dependency build ./install/charts/dir
+```
+
+### Install the Chart
+
+```bash
+helm install dir-release ./install/charts/dir \
+  --namespace agent-directory \
+  -f install/charts/dir/values-openshift.yaml \
+  -f install/charts/dir/my-values.yaml \
+  --timeout 20m
+```
+
+## Step 5: Verify the Deployment
+
+### Check Pod Status
+
+```bash
+oc get pods -n agent-directory
+```
+
+> **Note:** The first boot may take several minutes due to PostgreSQL schema
+> migration, especially on network-attached storage (e.g., Ceph RBD). The
+> `--timeout 20m` flag accounts for this. Subsequent restarts are faster.
+
+You should see pods for the apiserver, reconciler, Zot registry, and
+PostgreSQL — all in a `Running` state.
+
+### Verify ClusterSPIFFEID Resources
+
+```bash
+oc get clusterspiffeids | grep dir-release
+```
+
+You should see entries for the apiserver and reconciler.
+
+### Test Connectivity
+
+Verify the apiserver is running by checking the logs:
+
+```bash
+oc logs -l app.kubernetes.io/name=apiserver -n agent-directory --tail=10
+```
+
+You should see `Server starting` with no errors.
+
+> **Note:** When SPIRE mTLS is enabled, the apiserver only accepts connections
+> from workloads with valid SPIFFE identities. External clients (including
+> `dirctl` via port-forward) cannot connect directly. To access the Directory
+> Service externally, deploy the
+> [oidc-gateway](https://github.com/agntcy/oidc-gateway) with a TLS
+> passthrough route. See the oidc-gateway documentation for OpenShift
+> deployment instructions.
+>
+> To test connectivity without the oidc-gateway, temporarily disable SPIRE:
+> ```bash
+> helm upgrade dir-release ./install/charts/dir \
+>   -n agent-directory \
+>   -f install/charts/dir/values-openshift.yaml \
+>   -f install/charts/dir/my-values.yaml \
+>   --set apiserver.spire.enabled=false \
+>   --set apiserver.config.authn.enabled=false \
+>   --set apiserver.config.authz.enabled=false \
+>   --timeout 15m
+>
+> oc port-forward svc/dir-release-apiserver 8888:8888 -n agent-directory &
+> dirctl search --server-addr "localhost:8888"
+> ```
+
+
+## Upgrading
+
+```bash
+helm dependency build ./install/charts/dir/apiserver
+helm dependency build ./install/charts/dir
+
+helm upgrade dir-release ./install/charts/dir \
+  -n agent-directory \
+  -f install/charts/dir/values-openshift.yaml \
+  -f install/charts/dir/my-values.yaml \
+  --timeout 20m \
+  --wait
+```
+
+## Uninstalling
+
+```bash
+helm uninstall dir-release -n agent-directory
+
+# Clean up cluster-scoped resources (not removed by helm uninstall)
+oc delete clusterspiffeids -l app.kubernetes.io/instance=dir-release
+
+# Optionally delete the namespace
+oc delete project agent-directory
+```

--- a/install/charts/dir/apiserver/templates/clusterspiffeids.yaml
+++ b/install/charts/dir/apiserver/templates/clusterspiffeids.yaml
@@ -5,7 +5,13 @@ kind: ClusterSPIFFEID
 metadata:
   name: {{ include "chart.fullname" . }}
 spec:
+  {{- if ne .Values.spire.className "none" }}
   className: {{ .Values.spire.className | default (printf "%s-spire" .Release.Namespace) }}
+  {{- end }}
+  {{- if .Values.spire.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml .Values.spire.namespaceSelector | nindent 4 }}
+  {{- end }}
   podSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/install/charts/dir/apiserver/templates/deployment.yaml
+++ b/install/charts/dir/apiserver/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
             - name: DIRECTORY_SERVER_AUTHZ_ENABLED
               value: "true"
             - name: DIRECTORY_SERVER_AUTHZ_SOCKET_PATH
-              value: "unix:/run/spire/agent-sockets/api.sock"
+              value: {{ .Values.config.authn.socket_path | default "unix:///run/spire/agent-sockets/api.sock" | quote }}
             - name: DIRECTORY_SERVER_AUTHZ_TRUST_DOMAIN
               value: {{ .Values.spire.trustDomain }}
             {{- end }}

--- a/install/charts/dir/apiserver/templates/reconciler-clusterspiffeid.yaml
+++ b/install/charts/dir/apiserver/templates/reconciler-clusterspiffeid.yaml
@@ -5,7 +5,13 @@ kind: ClusterSPIFFEID
 metadata:
   name: {{ include "chart.reconcilerName" . }}
 spec:
+  {{- if ne .Values.spire.className "none" }}
   className: {{ .Values.spire.className | default (printf "%s-spire" .Release.Namespace) }}
+  {{- end }}
+  {{- if .Values.spire.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml .Values.spire.namespaceSelector | nindent 4 }}
+  {{- end }}
   podSelector:
     matchExpressions:
     - key: app.kubernetes.io/name

--- a/install/charts/dir/apiserver/templates/route.yaml
+++ b/install/charts/dir/apiserver/templates/route.yaml
@@ -1,0 +1,38 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.route }}
+{{- if .Values.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  annotations:
+    # Required for gRPC (HTTP/2) through OpenShift's HAProxy router
+    haproxy.router.openshift.io/backend-protocol: h2c
+    {{- with .Values.route.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
+  port:
+    targetPort: grpc
+  {{- if .Values.route.tls }}
+  tls:
+    {{- toYaml .Values.route.tls | nindent 4 }}
+  {{- else }}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "chart.fullname" . }}
+    weight: 100
+  wildcardPolicy: None
+{{- end }}
+{{- end }}

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -409,6 +409,17 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# OpenShift Route configuration (optional)
+# Creates an OpenShift Route to expose the gRPC API externally.
+# Only applicable on OpenShift clusters. Disabled by default.
+route:
+  enabled: false
+  # host: dir-api.apps.example.com
+  annotations: {}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+
 ingress:
   enabled: false
   className: ""

--- a/install/charts/dir/values-openshift.yaml
+++ b/install/charts/dir/values-openshift.yaml
@@ -1,0 +1,154 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+#
+# OpenShift-specific overrides for the Directory Service Helm chart.
+#
+# This file contains the values needed to deploy the core Directory Service
+# on an OpenShift cluster with SPIFFE/SPIRE mTLS authentication.
+#
+# IMPORTANT: External gRPC access requires the oidc-gateway deployed
+# separately with a TLS passthrough route. OpenShift's edge routes do not
+# reliably support gRPC (HTTP/2). See docs/openshift-install.md for details.
+#
+# Prerequisites:
+#   - SPIRE deployed on the cluster (server, agent, CSI driver, controller manager)
+#   - oidc-gateway deployed separately for external access
+#     (see https://github.com/agntcy/oidc-gateway)
+#
+# Usage:
+#   helm install dir-release ./install/charts/dir \
+#     -n agent-directory --create-namespace \
+#     -f install/charts/dir/values-openshift.yaml \
+#     -f install/charts/dir/my-values.yaml \
+#     --timeout 20m
+#
+# See docs/openshift-install.md for the full step-by-step guide.
+
+apiserver:
+  image:
+    pullPolicy: Always
+    # Remove default pull secret reference (not needed for public images)
+    pullSecrets: []
+
+  # OpenShift uses Routes, not NodePort
+  service:
+    type: ClusterIP
+
+  # OpenShift Route for direct gRPC access to the apiserver.
+  # NOTE: Edge routes do not reliably support gRPC (HTTP/2) on OpenShift.
+  # For external access, deploy the oidc-gateway with a TLS passthrough route.
+  # This route is useful for non-SPIRE deployments or internal testing only.
+  route:
+    enabled: false
+    # host: dir-api.<your-cluster-domain>
+    annotations: {}
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+
+  # -------------------------------------------------------------------------
+  # Authentication and Authorization
+  # -------------------------------------------------------------------------
+  # Enable SPIFFE-based mTLS authentication and Casbin authorization policies.
+  # Requires SPIRE to be deployed and spire.enabled=true below.
+  #
+  # NOTE: When authn is enabled, external clients cannot connect directly —
+  # only workloads with valid SPIFFE identities (e.g., the oidc-gateway) can
+  # reach the apiserver.
+  config:
+    authn:
+      enabled: true
+      # SPIRE agent socket path — must match the filename provided by the
+      # SPIFFE CSI driver. Check with a debug pod (see docs/openshift-install.md).
+      # Common values: api.sock (upstream SPIRE), spire-agent.sock (managed SPIRE operators)
+      socket_path: "unix:///run/spire/agent-sockets/<YOUR-SOCKET-FILENAME>"
+    authz:
+      enabled: true
+    # Point apiserver at the Helm-deployed PostgreSQL service.
+    # Format: <release-name>-postgresql
+    database:
+      postgres:
+        host: "<RELEASE-NAME>-postgresql"
+
+  # Authorization policies (Casbin CSV format).
+  # The first rule grants full access to workloads from your SPIRE trust domain.
+  # Additional rules grant public read access to specific API methods.
+  #
+  # Replace <YOUR-TRUST-DOMAIN> with the trust domain configured in your
+  # SPIRE server (see docs/openshift-install.md).
+  authz_policies_csv: |
+    p,<YOUR-TRUST-DOMAIN>,*
+    p,*,/agntcy.dir.store.v1.StoreService/Pull
+    p,*,/agntcy.dir.store.v1.StoreService/Push
+    p,*,/agntcy.dir.store.v1.StoreService/PullReferrer
+    p,*,/agntcy.dir.store.v1.StoreService/Lookup
+    p,*,/agntcy.dir.search.v1.SearchService/SearchCIDs
+    p,*,/agntcy.dir.search.v1.SearchService/SearchRecords
+    p,*,/agntcy.dir.sync.v1.SyncService/RequestRegistryCredentials
+
+  # -------------------------------------------------------------------------
+  # SPIRE / SPIFFE Configuration
+  # -------------------------------------------------------------------------
+  # Connects to an existing SPIRE instance on the cluster.
+  # The SPIFFE CSI driver mounts the workload API socket into each pod.
+  spire:
+    enabled: true
+
+    # Trust domain of your SPIRE server.
+    # Find it with:
+    #   oc get configmap -n <spire-namespace> spire-server -o yaml | grep trust_domain
+    trustDomain: "<YOUR-TRUST-DOMAIN>"
+
+    # Must match the SPIRE controller manager's className.
+    # Find it with:
+    #   oc get clusterspiffeids -o yaml | grep className
+    # Set to "none" to omit the field entirely (for classless SPIRE controllers).
+    className: "<YOUR-SPIRE-CLASS-NAME>"
+
+    # Restrict ClusterSPIFFEID to the deployment namespace.
+    # Required when the SPIRE controller manager uses namespace-scoped matching.
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+        - "<NAMESPACE>"
+
+    # DNS SANs added to the SPIFFE X.509-SVID certificate.
+    # This should match the externally reachable hostname of the apiserver.
+    # Format: <release-name>-apiserver-<namespace>.<cluster-domain>
+    dnsNameTemplates:
+      - "<RELEASE-NAME>-apiserver-<NAMESPACE>.<YOUR-CLUSTER-DOMAIN>"
+
+  # Disable nginx Ingress — OpenShift uses Routes instead.
+  oasf:
+    ingress:
+      enabled: false
+
+  # -------------------------------------------------------------------------
+  # Reconciler
+  # -------------------------------------------------------------------------
+  # Ensure HOME is writable — OpenShift's restricted SCC assigns a random
+  # non-root UID that cannot write to /. Some containers attempt to create
+  # directories under $HOME on startup, which fails without this override.
+  extraEnv:
+    - name: HOME
+      value: /tmp
+
+  reconciler:
+    image:
+      repository: ghcr.io/agntcy/dir-reconciler
+      tag: latest
+      pullPolicy: Always
+    # Point reconciler at the Helm-deployed PostgreSQL service.
+    config:
+      database:
+        postgres:
+          host: "<RELEASE-NAME>-postgresql"
+
+  # -------------------------------------------------------------------------
+  # PostgreSQL
+  # -------------------------------------------------------------------------
+  # The Bitnami PostgreSQL subchart auto-detects OpenShift and adapts its
+  # security contexts via global.compatibility.openshift.adaptSecurityContext.
+  # No manual UID overrides are needed.


### PR DESCRIPTION
Addresses #1310

NOTE: For full functionality with envoy and access outside the cluster, a follow up PR will be made to the [oidc-gateway](https://github.com/agntcy/oidc-gateway) repo. 

## Summary
Enable the core Directory Service Helm chart to deploy on OpenShift clusters with SPIFFE/SPIRE mTLS authentication.
All changes follow an overlay pattern — existing default behavior is preserved for vanilla Kubernetes users. OpenShift-specific settings are activated through an optional `values-openshift.yaml` overlay file.
## Changes
- **Optional `className` in ClusterSPIFFEID templates** — Setting className to `"none"` omits the field, supporting SPIRE controllers running in classless mode. Existing default fallback preserved.
- **Optional `namespaceSelector` in ClusterSPIFFEID templates** — Required for managed SPIRE operators that scope workload registration by namespace. Only rendered when set via values.
- **Configurable SPIRE agent socket path** — Different SPIRE deployments may have different socket filenames. Default remains `api.sock` for backward compatibility.
- **OpenShift Route template for apiserver** — Gated by `route.enabled: false`, no impact on existing installs.
- **`values-openshift.yaml` overlay** — All OpenShift-specific overrides with placeholder values for cluster-specific configuration.
- **`docs/openshift-install.md`** — Step-by-step guide covering SPIRE config discovery, two-file values layering, helm install, and verification.
## Why this was needed
The existing Helm chart could not deploy on OpenShift because:
- The SPIRE agent socket path was hardcoded to `api.sock`
- ClusterSPIFFEID templates had no `namespaceSelector` support, causing SPIRE controllers to silently ignore them
- ClusterSPIFFEID `className` was not configurable for omission, preventing compatibility with classless SPIRE controllers
- The reconciler crashes on OpenShift due to `HOME` pointing to a non-writable path under the restricted SCC
- No OpenShift Route templates existed for exposing the service
## External access
For external access to the Directory Service, the [oidc-gateway](https://github.com/agntcy/oidc-gateway) must be deployed separately with a TLS passthrough route. OpenShift-specific changes for the oidc-gateway will be contributed to that repository separately.
## Testing
Verified on an OpenShift 4.x cluster with a SPIRE operator:
- Core deployment (apiserver, reconciler, PostgreSQL, Zot) runs successfully
- SPIRE mTLS authentication works end-to-end
- ClusterSPIFFEID resources are processed by the SPIRE controller manager
- No impact on existing vanilla Kubernetes deployments (verified via `helm template`)