### PR TITLE
chore(dir): tag only server modules and releae artefacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,7 +259,7 @@ jobs:
 
   release:
     name: Release
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '/') }}
     needs:
       - test
     uses: ./.github/workflows/reusable-release.yaml

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -20,11 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get modules
+      - name: Get server modules
         id: modules
         run: |
-          # shellcheck disable=SC2016
-          echo "modules=$(find . -name go.mod -type f -exec awk '/^module / {print $2}' {} \; | jq -c -R '[.,inputs] | map(sub("^github.com\/agntcy\/dir\/";""))')" >> "$GITHUB_OUTPUT"
+          echo 'modules=["cli","tests","server","reconciler"]' >> "$GITHUB_OUTPUT"
 
   create-module-tags:
     needs: prepare


### PR DESCRIPTION
- Replaced dynamic `go.mod` discovery with the hard-coded server module list: `["cli","tests","server","reconciler"]` This prevents re-tagging api, client, and utils when the root release is published. 
- Tightened the release job condition to root tags only: `startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '/')` This keeps artifact release tied to root tags like v1.3.0.