### PR TITLE
chore(ci): separate api and server release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,40 +1,103 @@
 # Release
 
-This document outlines the process for creating a new release for Directory packages. 
-All code block examples provided below correspond to an update to version `v1.0.0`, please update accordingly.
+This document outlines the process for creating a new release for Directory packages.
+All code block examples below use version `v1.3.0`; update the version accordingly.
 
-## 1. Create Release branch
+The Directory release is split into two phases:
 
-Prepare a new release for the desired version by running the following command:
+- API module release: Go module tags only, no root tag and no artifacts.
+- Server release: root tag, server module tags, images, Helm charts, CLI binaries, and GitHub Release.
+
+## 1. Prepare API Module Release
+
+Prepare the API module set release branch:
 
 ```sh
-task release:create RELEASE_VERSION=v1.0.0
+task release:create:api RELEASE_VERSION=v1.3.0
 ```
 
-> [!NOTE]
-> For SDK release candidates, versions like `1.0.0-rc.1` becomes `1.0.0-rc.1` in JavaScript package.json
-> and `1.0.0rc1` in Python pyproject.toml.
+This prepares only the `api` module set:
 
-## 2. Create and Push Tags
+- `github.com/agntcy/dir/api`
+- `github.com/agntcy/dir/client`
+- `github.com/agntcy/dir/utils`
 
-* After the pull request is approved and merged, update your local main branch.
+Open a pull request from the generated release branch, wait for approval, and merge it into `main`.
+
+## 2. Tag API Modules
+
+After the API release pull request is merged, update your local `main` branch:
+
 ```sh
 git checkout main
 git pull origin main
 ```
 
-* To trigger the release workflow, create and push to the repository a release tag for the last commit.
+Create and push only the API module tags:
+
 ```sh
-git tag -a v1.0.0
-git push origin v1.0.0
+git tag api/v1.3.0
+git tag client/v1.3.0
+git tag utils/v1.3.0
+
+git push origin api/v1.3.0 client/v1.3.0 utils/v1.3.0
 ```
 
-Please note that the release tag is not necessarily associated with the "release: prepare version v1.0.0" commit. For example, if any bug fixes were required after this commit, they can be merged and included in the release.
+Do not create the root `v1.3.0` tag during this phase. Root tags trigger artifact releases.
 
-## 3. Publish release
+## 3. Prepare Server Release
 
-* Wait until the release workflow is completed successfully.
+After the dependent repositories are updated and released, prepare the server module set release branch:
 
-* Navigate to the [Releases page](https://github.com/agntcy/dir/releases) and verify the draft release description as well as the assets listed.
+```sh
+task release:create:server RELEASE_VERSION=v1.3.0
+```
 
-* Once the draft release has been verified, click on `Edit` release and then on `Publish Release`.
+This prepares only the `server` module set:
+
+- `github.com/agntcy/dir/cli`
+- `github.com/agntcy/dir/tests`
+- `github.com/agntcy/dir/server`
+- `github.com/agntcy/dir/reconciler`
+
+Open a pull request from the generated release branch, wait for approval, and merge it into `main`.
+
+## 4. Create Root Release Tag
+
+After the server release pull request is merged, update your local `main` branch:
+
+```sh
+git checkout main
+git pull origin main
+```
+
+Create and push the root release tag:
+
+```sh
+git tag -a v1.3.0
+git push origin v1.3.0
+```
+
+The root tag triggers the release workflow, which publishes:
+
+- container images
+- Helm charts
+- CLI binaries
+- draft GitHub Release
+
+Please note that the release tag is not necessarily associated with the release preparation commit. For example, if bug fixes were required after this commit, they can be merged and included in the release.
+
+## 5. Publish Release
+
+- Wait until the release workflow completes successfully.
+- Navigate to the [Releases page](https://github.com/agntcy/dir/releases) and verify the draft release description and assets.
+- Click `Edit` on the draft release, then click `Publish Release`.
+
+Publishing the root GitHub Release creates only the server-side module tags:
+
+- `cli/v1.3.0`
+- `tests/v1.3.0`
+- `server/v1.3.0`
+- `reconciler/v1.3.0`
+
+It does not re-tag `api`, `client`, or `utils`.

--- a/Taskfile.deps.yml
+++ b/Taskfile.deps.yml
@@ -26,6 +26,7 @@ tasks:
       - task: deps:golangci-lint
       - task: deps:licensei
       - task: deps:multimod-bin
+      - task: deps:yq
       - task: deps:pre-commit
       - task: deps:cleanup
 
@@ -59,6 +60,7 @@ tasks:
       {{.PROTOC_BIN}}
       {{.BUFBUILD_BIN}}
       {{.MULTIMOD_BIN}}
+      {{.YQ_BIN}}
       {{.GOLANGCI_LINT_BIN}}
       {{.LICENSEI_BIN}}
       {{.UV_BIN}}
@@ -211,6 +213,20 @@ tasks:
       - rm -rf {{.MULTIMOD_REPO_DIR}}
     status:
       - test -x {{.MULTIMOD_BIN}}
+
+  deps:yq:
+    desc: Install yq
+    internal: true
+    deps:
+      - deps:bin-dir
+    preconditions:
+      - which go
+    cmds:
+      - GOBIN={{.BIN_DIR}} go install github.com/mikefarah/yq/v4@v{{.YQ_VERSION}}
+      - mv {{.BIN_DIR}}/yq {{.YQ_BIN}}
+      - chmod +x {{.YQ_BIN}}
+    status:
+      - test -x {{.YQ_BIN}}
 
   deps:uv:
     desc: Install uv

--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -57,6 +57,9 @@ vars:
   GO_VERSION: "1.26.2"
   MULTIMOD_VERSION: "0.29.0"
   MULTIMOD_BIN: "{{ .BIN_DIR }}/multimod-{{.MULTIMOD_VERSION}}"
+  # renovate: datasource=go depName=github.com/mikefarah/yq/v4 versioning=semver
+  YQ_VERSION: "4.53.2"
+  YQ_BIN: "{{ .BIN_DIR }}/yq-{{.YQ_VERSION}}"
   GOLANGCI_LINT_VERSION: "2.11.3"
   GOLANGCI_LINT_BIN: "{{ .BIN_DIR }}/golangci-lint-{{.GOLANGCI_LINT_VERSION}}"
   LICENSEI_VERSION: "0.9.0"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -187,22 +187,10 @@ tasks:
       # Switch to new branch
       - 'if [ "$(git rev-parse --abbrev-ref HEAD)" != "{{.RELEASE_BRANCH}}" ]; then git checkout -b {{.RELEASE_BRANCH}}; fi'
       # Update only the api module set in versions.yaml with the new version
-      - |
-        awk -v module_set="api" -v version="{{.RELEASE_VERSION}}" '
-          /^  [A-Za-z0-9_-]+:/ { in_module_set = ($1 == module_set ":") }
-          in_module_set && /^[[:space:]]+version:/ {
-            sub(/version: .*/, "version: " version)
-            updated = 1
-          }
-          { print }
-          END {
-            if (!updated) {
-              printf("module set %s not found in versions.yaml\n", module_set) > "/dev/stderr"
-              exit 1
-            }
-          }
-        ' versions.yaml > versions.yaml.tmp
-      - "mv versions.yaml.tmp versions.yaml"
+      - task: release:update-module-set-version
+        vars:
+          RELEASE_MODULE_SET: api
+          RELEASE_VERSION: "{{.RELEASE_VERSION}}"
       # Add release changes
       - |
         git add .
@@ -229,22 +217,10 @@ tasks:
       # Switch to new branch
       - 'if [ "$(git rev-parse --abbrev-ref HEAD)" != "{{.RELEASE_BRANCH}}" ]; then git checkout -b {{.RELEASE_BRANCH}}; fi'
       # Update only the server module set in versions.yaml with the new version
-      - |
-        awk -v module_set="server" -v version="{{.RELEASE_VERSION}}" '
-          /^  [A-Za-z0-9_-]+:/ { in_module_set = ($1 == module_set ":") }
-          in_module_set && /^[[:space:]]+version:/ {
-            sub(/version: .*/, "version: " version)
-            updated = 1
-          }
-          { print }
-          END {
-            if (!updated) {
-              printf("module set %s not found in versions.yaml\n", module_set) > "/dev/stderr"
-              exit 1
-            }
-          }
-        ' versions.yaml > versions.yaml.tmp
-      - "mv versions.yaml.tmp versions.yaml"
+      - task: release:update-module-set-version
+        vars:
+          RELEASE_MODULE_SET: server
+          RELEASE_VERSION: "{{.RELEASE_VERSION}}"
       # Add release changes
       - |
         git add .
@@ -269,6 +245,22 @@ tasks:
     cmds:
       - |
         git push --set-upstream origin {{.RELEASE_BRANCH}} || true
+
+  release:update-module-set-version:
+    internal: true
+    deps:
+      - deps:yq
+    vars:
+      RELEASE_MODULE_SET: "{{ .RELEASE_MODULE_SET }}"
+      RELEASE_VERSION: "{{ .RELEASE_VERSION }}"
+    cmds:
+      - |
+        RELEASE_MODULE_SET="{{.RELEASE_MODULE_SET}}" \
+          {{.YQ_BIN}} -e '.["module-sets"] | has(strenv(RELEASE_MODULE_SET))' versions.yaml > /dev/null
+      - |
+        RELEASE_MODULE_SET="{{.RELEASE_MODULE_SET}}" \
+        RELEASE_VERSION="{{.RELEASE_VERSION}}" \
+          {{.YQ_BIN}} -i '.["module-sets"][strenv(RELEASE_MODULE_SET)].version = strenv(RELEASE_VERSION)' versions.yaml
 
   release:push:
     internal: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,6 +152,7 @@ tasks:
 
   release:create:
     desc: Prepare release
+    internal: true
     deps:
       - task: deps:multimod-bin
     vars:
@@ -174,6 +175,100 @@ tasks:
         git commit --amend -S --signoff -m "release(dir): prepare release {{.RELEASE_VERSION}}"
       # Push prepared release
       - task: release:push
+
+  release:create:api:
+    desc: Prepare api module set release without root artifacts
+    deps:
+      - task: deps:multimod-bin
+    vars:
+      RELEASE_VERSION: "{{ .RELEASE_VERSION }}"
+      RELEASE_BRANCH: "release/api/{{.RELEASE_VERSION}}"
+    cmds:
+      # Switch to new branch
+      - 'if [ "$(git rev-parse --abbrev-ref HEAD)" != "{{.RELEASE_BRANCH}}" ]; then git checkout -b {{.RELEASE_BRANCH}}; fi'
+      # Update only the api module set in versions.yaml with the new version
+      - |
+        awk -v module_set="api" -v version="{{.RELEASE_VERSION}}" '
+          /^  [A-Za-z0-9_-]+:/ { in_module_set = ($1 == module_set ":") }
+          in_module_set && /^[[:space:]]+version:/ {
+            sub(/version: .*/, "version: " version)
+            updated = 1
+          }
+          { print }
+          END {
+            if (!updated) {
+              printf("module set %s not found in versions.yaml\n", module_set) > "/dev/stderr"
+              exit 1
+            }
+          }
+        ' versions.yaml > versions.yaml.tmp
+      - "mv versions.yaml.tmp versions.yaml"
+      # Add release changes
+      - |
+        git add .
+        git commit -S --signoff -m "release(dir): prepare api release {{.RELEASE_VERSION}}"
+      # Verify Go release for the api module set only
+      - |
+        {{ .MULTIMOD_BIN }} verify
+        {{ .MULTIMOD_BIN }} prerelease --module-set-names api --skip-go-mod-tidy=true --commit-to-different-branch=false
+      - |
+        git commit --amend -S --signoff -m "release(dir): prepare api release {{.RELEASE_VERSION}}"
+      # Push prepared release
+      - task: release:push:branch
+        vars:
+          RELEASE_BRANCH: "{{.RELEASE_BRANCH}}"
+
+  release:create:server:
+    desc: Prepare server module set release for root artifacts
+    deps:
+      - task: deps:multimod-bin
+    vars:
+      RELEASE_VERSION: "{{ .RELEASE_VERSION }}"
+      RELEASE_BRANCH: "release/server/{{.RELEASE_VERSION}}"
+    cmds:
+      # Switch to new branch
+      - 'if [ "$(git rev-parse --abbrev-ref HEAD)" != "{{.RELEASE_BRANCH}}" ]; then git checkout -b {{.RELEASE_BRANCH}}; fi'
+      # Update only the server module set in versions.yaml with the new version
+      - |
+        awk -v module_set="server" -v version="{{.RELEASE_VERSION}}" '
+          /^  [A-Za-z0-9_-]+:/ { in_module_set = ($1 == module_set ":") }
+          in_module_set && /^[[:space:]]+version:/ {
+            sub(/version: .*/, "version: " version)
+            updated = 1
+          }
+          { print }
+          END {
+            if (!updated) {
+              printf("module set %s not found in versions.yaml\n", module_set) > "/dev/stderr"
+              exit 1
+            }
+          }
+        ' versions.yaml > versions.yaml.tmp
+      - "mv versions.yaml.tmp versions.yaml"
+      # Add release changes
+      - |
+        git add .
+        git commit -S --signoff -m "release(dir): prepare server release {{.RELEASE_VERSION}}"
+      # Verify Go release for the server module set only
+      - |
+        {{ .MULTIMOD_BIN }} verify
+        {{ .MULTIMOD_BIN }} prerelease --module-set-names server --skip-go-mod-tidy=true --commit-to-different-branch=false
+      - |
+        git commit --amend -S --signoff -m "release(dir): prepare server release {{.RELEASE_VERSION}}"
+      # Push prepared release
+      - task: release:push:branch
+        vars:
+          RELEASE_BRANCH: "{{.RELEASE_BRANCH}}"
+
+  release:push:branch:
+    internal: true
+    vars:
+      RELEASE_BRANCH: "{{ .RELEASE_BRANCH }}"
+    prompt:
+      - "Are you sure you want to push the release branch {{.RELEASE_BRANCH}} to remote repository?"
+    cmds:
+      - |
+        git push --set-upstream origin {{.RELEASE_BRANCH}} || true
 
   release:push:
     internal: true

--- a/versions.yaml
+++ b/versions.yaml
@@ -2,14 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 module-sets:
-  directory:
+  api:
     version: v1.2.0
     modules:
       - github.com/agntcy/dir/api
       - github.com/agntcy/dir/client
+      - github.com/agntcy/dir/utils
+
+  server:
+    version: v1.2.0
+    modules:
       - github.com/agntcy/dir/cli
       - github.com/agntcy/dir/tests
       - github.com/agntcy/dir/server
-      - github.com/agntcy/dir/utils
       - github.com/agntcy/dir/reconciler
 


### PR DESCRIPTION
- Split the Directory release flow into API-only and server/artifact release tasks.
- Restricted artifact publishing to root release tags only.
- Updated post-release tagging so publishing a root release creates only server-side module tags.
- Documented the new release process in `RELEASE.md`.