### PR TITLE
docs(helm): clarify auto-resolve behavior in chart values comments

### DIFF
--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -133,11 +133,14 @@ apiserver:
         # Cache directory to use for metadata.
         # cache_dir: ""
 
-        # Registry address to connect to
+        # Registry address to connect to.
+        # Leave empty when zot.enabled=true (the default) to auto-resolve to the
+        # bundled Zot subchart. Set explicitly to use an external OCI registry
+        # (ECR, GCR, GHCR, Harbor, etc.).
         registry_address: ""
-        
-        # All data will be stored under this repo.
-        # Objects are pushed as tags, manifests, and blobs.
+
+        # OCI repository where records are stored as tags, manifests, and blobs.
+        # Defaults to "dir" when zot.enabled=true and this field is empty.
         repository_name: ""
 
         # Auth credentials to use.
@@ -230,20 +233,22 @@ apiserver:
 
     # Database configuration (PostgreSQL)
     # These values configure the database connection for apiserver and reconciler.
-    # Users must specify ALL values explicitly - there is no auto-detection.
-    # 
-    # For local development (postgresql.enabled=true):
-    #   Set host to the service name that will be created, e.g., "my-release-postgresql"
     #
-    # For external PostgreSQL (postgresql.enabled=false):
-    #   Set host to your external PostgreSQL host
+    # When postgresql.enabled=true (the default), the chart helpers auto-resolve
+    # the host to the bundled subchart's in-cluster Service:
+    #   "<release-name>-postgresql.<namespace>.svc.cluster.local"
+    # An explicit host below always takes precedence over auto-resolution.
+    #
+    # For external PostgreSQL, set postgresql.enabled=false and specify host
+    # explicitly below.
     database:
       # Database type (only postgres is supported)
       type: "postgres"
       postgres:
-        # PostgreSQL host address (required)
-        # For local: use "<release-name>-postgresql" 
-        # For external: your PostgreSQL hostname
+        # PostgreSQL host address.
+        # Leave empty to auto-resolve to the bundled postgresql subchart when
+        # postgresql.enabled=true (the default). Set explicitly for external
+        # PostgreSQL.
         host: ""
 
         # PostgreSQL port


### PR DESCRIPTION
## Summary

Updates `install/charts/dir/values.yaml` comments to accurately describe
the chart's auto-resolve behavior for PostgreSQL host and OCI registry
address. Comment-only changes; no chart behavior change.

## Why

The current values.yaml states:

> Users must specify ALL values explicitly - there is no auto-detection.

But the helpers in `apiserver/templates/_helpers.tpl` do auto-detect:

- `chart.postgres.host` returns `<release>-postgresql.<ns>.svc.cluster.local` when `postgresql.enabled=true` and no explicit host is set
- `chart.oci.registryAddress` returns the bundled Zot service when `zot.enabled=true`
- `chart.oci.repositoryName` defaults to `"dir"` when `zot.enabled=true` and the field is empty

Hit this while installing dir for the first time — I set host explicitly
per the comment, then later noticed the chart would have auto-resolved it.
Updating the comments so the next person doesn't trip on the same thing.

## Changes

- Replace "no auto-detection" prose in the Database section header
- Update `database.postgres.host` field comment
- Add auto-resolve note to `store.oci.registry_address` / `repository_name` (these didn't lie, but were silent about the helper behavior)

## Verification

Default helm install:

```
helm upgrade -i dir oci://ghcr.io/agntcy/dir/helm-charts/dir \
  --version v1.2.0 --namespace agntcy --create-namespace
```

Works without any host or registry_address override, confirming the
helpers auto-resolve. No keys, defaults, or runtime behavior changed —
no tests affected.
