### PR TITLE
test(dir): fix naming test

### DIFF
--- a/tests/e2e/local/09_naming_test.go
+++ b/tests/e2e/local/09_naming_test.go
@@ -4,6 +4,8 @@
 package local
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,6 +32,17 @@ const (
 	verificationPollInterval = 2 * time.Second
 )
 
+// verifyOutput is the JSON shape printed by `dirctl naming verify --output json`.
+type verifyOutput struct {
+	Cid        string `json:"cid"`
+	Verified   bool   `json:"verified"`
+	Message    string `json:"message,omitempty"`
+	Domain     string `json:"domain,omitempty"`
+	Method     string `json:"method,omitempty"`
+	KeyID      string `json:"key_id,omitempty"`
+	VerifiedAt string `json:"verified_at,omitempty"`
+}
+
 // namingTestPaths holds paths for test files.
 type namingTestPaths struct {
 	tempDir    string
@@ -50,6 +63,108 @@ func setupNamingTestPaths() *namingTestPaths {
 	}
 }
 
+// rewriteRecordNameForEnv takes the shared embedded OASF record and rewrites
+// only its top-level `name` field so it points at the dns-validation
+// infrastructure of the current test environment.
+func rewriteRecordNameForEnv(recordJSON []byte, host string) ([]byte, string) {
+	ginkgo.GinkgoHelper()
+
+	var record map[string]json.RawMessage
+	gomega.Expect(json.Unmarshal(recordJSON, &record)).To(gomega.Succeed(),
+		"embedded naming record must be valid JSON")
+
+	newName := fmt.Sprintf("http://%s/example/research-assistant-v4", host)
+	encoded, err := json.Marshal(newName)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	record["name"] = encoded
+
+	out, err := json.Marshal(record)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return out, newName
+}
+
+// parseVerifyOutput parses the JSON returned by `dirctl naming verify --output json`.
+func parseVerifyOutput(raw string) (*verifyOutput, error) {
+	var out verifyOutput
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("parse naming verify JSON: %w (raw=%q)", err, raw)
+	}
+
+	return &out, nil
+}
+
+// isPendingVerificationMessage reports whether the server response indicates
+// that the name reconciler has not yet attempted (or has expired the cache for)
+// verification of this record.
+func isPendingVerificationMessage(msg string) bool {
+	switch msg {
+	case "",
+		// Strings produced by server/controller/naming.go.
+		"no verification found",
+		"verification invalid or expired":
+		return true
+	default:
+		return false
+	}
+}
+
+// expectVerified polls `dirctl naming verify` for the given reference until the
+// server reports a terminal state.
+func expectVerified(ref, expectedHost string) *verifyOutput {
+	ginkgo.GinkgoHelper()
+
+	deadline := time.Now().Add(verificationWaitTimeout)
+
+	var last *verifyOutput
+
+	for {
+		raw, err := testEnv.CLI.Naming().Verify(ref).
+			WithArgs("--output", "json").
+			Execute()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+			"naming verify command must succeed for ref %q", ref)
+
+		parsed, err := parseVerifyOutput(raw)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		last = parsed
+
+		if parsed.Verified {
+			break
+		}
+
+		gomega.Expect(isPendingVerificationMessage(parsed.Message)).To(
+			gomega.BeTrue(),
+			"verification for %q reached terminal non-verified state: %s",
+			ref, parsed.Message,
+		)
+
+		if !time.Now().Before(deadline) {
+			ginkgo.Fail(fmt.Sprintf(
+				"verification for %q did not reach terminal `verified: true` state within %s (last message=%q)",
+				ref, verificationWaitTimeout, parsed.Message,
+			))
+		}
+
+		time.Sleep(verificationPollInterval)
+	}
+
+	gomega.Expect(last).NotTo(gomega.BeNil())
+	gomega.Expect(last.Verified).To(gomega.BeTrue())
+	gomega.Expect(last.Domain).To(gomega.Equal(expectedHost),
+		"verified domain should match the dns-validation host for this env")
+	gomega.Expect(last.Method).NotTo(gomega.BeEmpty(),
+		"verified result must report a verification method")
+	gomega.Expect(last.KeyID).NotTo(gomega.BeEmpty(),
+		"verified result must report a matched key id")
+	gomega.Expect(last.VerifiedAt).NotTo(gomega.BeEmpty(),
+		"verified result must report a verified_at timestamp")
+
+	return last
+}
+
 var _ = ginkgo.Describe("Running dirctl e2e tests for DNS name verification", func() {
 	ginkgo.BeforeEach(func() {
 		utils.ResetCLIState()
@@ -57,41 +172,41 @@ var _ = ginkgo.Describe("Running dirctl e2e tests for DNS name verification", fu
 
 	ginkgo.Context("naming verification workflow", ginkgo.Ordered, func() {
 		var (
-			paths *namingTestPaths
-			cid   string
+			paths      *namingTestPaths
+			cid        string
+			recordName string
+			host       string
 		)
 
 		ginkgo.BeforeAll(func() {
 			paths = setupNamingTestPaths()
 
-			// Write test record with DNS name to temp location
-			// The record name (http://dns-validation-http/example/research-assistant-v4) must match
-			// the service name that serves the JWKS endpoint
-			err := os.WriteFile(paths.record, testdata.ExpectedRecordV080V5JSON, 0o600)
+			host = testEnv.Config.NameVerificationHost
+			gomega.Expect(host).NotTo(gomega.BeEmpty(),
+				"test-config must set local.name_verification_host to the dns-validation host for this environment")
+
+			recordBytes, name := rewriteRecordNameForEnv(testdata.ExpectedRecordV080V5JSON, host)
+			recordName = name
+
+			err := os.WriteFile(paths.record, recordBytes, 0o600)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			// Verify pre-generated cosign key files exist
-			// These keys match the JWKS served by the dns-validation chart
 			gomega.Expect(paths.privateKey).To(gomega.BeAnExistingFile(),
 				"Pre-generated cosign.key not found at %s", paths.privateKey)
 			gomega.Expect(paths.publicKey).To(gomega.BeAnExistingFile(),
 				"Pre-generated cosign.pub not found at %s", paths.publicKey)
 
-			// Set empty cosign password (keys were generated with empty password)
 			err = os.Setenv("COSIGN_PASSWORD", "")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		})
 
 		ginkgo.AfterAll(func() {
-			// Unset COSIGN_PASSWORD
 			os.Unsetenv("COSIGN_PASSWORD")
 
-			// Clean up pushed record
 			if cid != "" {
 				_, _ = testEnv.CLI.Delete(cid).Execute()
 			}
 
-			// Clean up temp directory
 			if paths != nil && paths.tempDir != "" {
 				_ = os.RemoveAll(paths.tempDir)
 			}
@@ -101,7 +216,6 @@ var _ = ginkgo.Describe("Running dirctl e2e tests for DNS name verification", fu
 			cid = testEnv.CLI.Push(paths.record).WithArgs("--output", "raw").ShouldSucceed()
 			gomega.Expect(cid).NotTo(gomega.BeEmpty())
 
-			// Verify the record was pushed successfully
 			utils.LoadAndValidateCID(cid, paths.record)
 		})
 
@@ -113,49 +227,21 @@ var _ = ginkgo.Describe("Running dirctl e2e tests for DNS name verification", fu
 		})
 
 		ginkgo.It("should verify signature is trusted", func() {
-			// First verify the basic signature verification works
 			testEnv.CLI.Command("verify").
 				WithArgs(cid).
 				ShouldContain("Record signature is: trusted")
 		})
 
 		ginkgo.It("should check naming verification status by CID", func() {
-			// Poll until verification is created or timeout
-			gomega.Eventually(func() string {
-				output, err := testEnv.CLI.Naming().Verify(cid).
-					WithArgs("--output", "json").
-					Execute()
-				if err != nil {
-					return ""
-				}
-
-				return output
-			}, verificationWaitTimeout, verificationPollInterval).Should(
-				gomega.ContainSubstring("verified"),
-				"Verification should be created after server processes the signed record",
-			)
+			expectVerified(cid, host)
 		})
 
 		ginkgo.It("should check naming verification status by name", func() {
-			output := testEnv.CLI.Naming().Verify("http://dns-validation-http/example/research-assistant-v4").
-				WithArgs("--output", "json").
-				ShouldSucceed()
-
-			gomega.Expect(output).To(gomega.Or(
-				gomega.ContainSubstring("verified"),
-				gomega.ContainSubstring("verification"),
-			))
+			expectVerified(recordName, host)
 		})
 
 		ginkgo.It("should check naming verification status by name with version", func() {
-			output := testEnv.CLI.Naming().Verify("http://dns-validation-http/example/research-assistant-v4:v5.0.0").
-				WithArgs("--output", "json").
-				ShouldSucceed()
-
-			gomega.Expect(output).To(gomega.Or(
-				gomega.ContainSubstring("verified"),
-				gomega.ContainSubstring("verification"),
-			))
+			expectVerified(recordName+":v5.0.0", host)
 		})
 	})
 })

--- a/tests/e2e/local/config/config.go
+++ b/tests/e2e/local/config/config.go
@@ -15,4 +15,8 @@ type Config struct {
 
 	// CliExtraArgs are extra arguments to pass to the CLI.
 	CliExtraArgs []string `json:"cli_extra_args,omitempty" mapstructure:"cli_extra_args"`
+
+	// NameVerificationHost is the host:port the dir-daemon uses to fetch the JWKS
+	// well-known file from the dns-validation infrastructure in this environment.
+	NameVerificationHost string `json:"name_verification_host,omitempty" mapstructure:"name_verification_host"`
 }

--- a/tests/e2e/local/testenv/kind/Taskfile.testenv.yml
+++ b/tests/e2e/local/testenv/kind/Taskfile.testenv.yml
@@ -16,7 +16,7 @@ includes:
       CHART_DEPLOYMENTS: |
         [
           {
-            "release_name": "dns-validator",
+            "release_name": "dns-validation",
             "namespace": "dir",
             "chart_path": "{{.ROOT_DIR}}/tests/e2e/local/testenv/kind/dns-validation/chart"
           },

--- a/tests/e2e/local/testenv/kind/test-config.yaml
+++ b/tests/e2e/local/testenv/kind/test-config.yaml
@@ -5,3 +5,4 @@ local:
   cli_extra_args:
   - "--server-addr=localhost:18888"
   - "--auth-mode=insecure"
+  name_verification_host: "dns-validation-http"

--- a/tests/e2e/local/testenv/local/docker-compose.yaml
+++ b/tests/e2e/local/testenv/local/docker-compose.yaml
@@ -6,4 +6,4 @@ services:
     volumes:
       - ./jwks.dns-validation.json:/usr/share/nginx/html/.well-known/jwks.json
     ports:
-      - 80
+      - "127.0.0.1:19891:80"

--- a/tests/e2e/local/testenv/local/test-config.yaml
+++ b/tests/e2e/local/testenv/local/test-config.yaml
@@ -5,3 +5,4 @@ local:
   cli_extra_args:
   - "--server-addr=localhost:19888"
   - "--auth-mode=insecure"
+  name_verification_host: "localhost:19891"


### PR DESCRIPTION
This PR fixes: https://github.com/agntcy/dir/issues/1433

Test run from CI:
```bash
...
Running dirctl e2e tests for DNS name verification naming verification workflow should push a record with DNS-prefixed name
/home/runner/work/dir/dir/tests/e2e/local/09_naming_test.go:215
• [0.037 seconds]
------------------------------
Running dirctl e2e tests for DNS name verification naming verification workflow should sign the record with cosign key
/home/runner/work/dir/dir/tests/e2e/local/09_naming_test.go:222
• [5.224 seconds]
------------------------------
Running dirctl e2e tests for DNS name verification naming verification workflow should verify signature is trusted
/home/runner/work/dir/dir/tests/e2e/local/09_naming_test.go:229
• [0.017 seconds]
------------------------------
Running dirctl e2e tests for DNS name verification naming verification workflow should check naming verification status by CID
/home/runner/work/dir/dir/tests/e2e/local/09_naming_test.go:235
• [0.009 seconds]
------------------------------
Running dirctl e2e tests for DNS name verification naming verification workflow should check naming verification status by name
/home/runner/work/dir/dir/tests/e2e/local/09_naming_test.go:239
• [0.080 seconds]
------------------------------
Running dirctl e2e tests for DNS name verification naming verification workflow should check naming verification status by name with version
/home/runner/work/dir/dir/tests/e2e/local/09_naming_test.go:243
• [0.038 seconds]
...
```