### PR TITLE
refactor(dir): cleanup and v1.3.0 release alignment

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -74,16 +74,6 @@
 - name: 'area/dir/client'
   color: '0052cc'
 
-# SDK:
-- name: 'area/sdk'
-  color: '0052cc'
-- name: 'area/sdk/go'
-  color: '0052cc'
-- name: 'area/sdk/js'
-  color: '0052cc'
-- name: 'area/sdk/py'
-  color: '0052cc'
-
 # CLI:
 - name: 'area/cli'
   color: '0052cc'

--- a/.github/workflows/demo-dir.yaml
+++ b/.github/workflows/demo-dir.yaml
@@ -9,7 +9,7 @@ on:
       image_version:
         required: true
         type: string
-        default: v1.2.0
+        default: v1.3.0
         description: "dirctl version to use"
       server_addr:
         required: true

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -6,7 +6,7 @@ on:
       image_version:
         required: true
         type: string
-        default: v1.2.0
+        default: v1.3.0
         description: "dirctl version to use"
       import_config:
         description: "JSON config file path or inline JSON content"

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -39,10 +39,6 @@ jobs:
             dir/api
             dir/server
             dir/client
-            sdk
-            sdk/go
-            sdk/js
-            sdk/py
             cli
             cli/dir
             helm

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ It is not advised to use artifacts with mismatched versions.
 All container images are distributed via [GitHub Packages](https://github.com/orgs/agntcy/packages?repo_name=dir).
 
 ```bash
-docker pull ghcr.io/agntcy/dir-ctl:v1.2.0
-docker pull ghcr.io/agntcy/dir-apiserver:v1.2.0
+docker pull ghcr.io/agntcy/dir-ctl:v1.3.0
+docker pull ghcr.io/agntcy/dir-apiserver:v1.3.0
 ```
 
 ### Helm charts
@@ -123,7 +123,7 @@ docker pull ghcr.io/agntcy/dir-apiserver:v1.2.0
 All helm charts are distributed as OCI artifacts via [GitHub Packages](https://github.com/agntcy/dir/pkgs/container/dir%2Fhelm-charts%2Fdir).
 
 ```bash
-helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.2.0
+helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.3.0
 ```
 
 ### Binaries
@@ -186,8 +186,8 @@ task server:start
 This will deploy Directory services into an existing Kubernetes cluster.
 
 ```bash
-helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.2.0
-helm upgrade --install dir oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.2.0
+helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.3.0
+helm upgrade --install dir oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.3.0
 ```
 
 ## Copyright Notice

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,11 +6,6 @@ version: "3"
 env:
   GOWORK: off
 
-  # TODO(paralta): drop once dir-runtime is republished against
-  # github.com/agntcy/dir/api/runtime so the dirctl/test binaries no longer
-  # link both old and new proto descriptors.
-  GOLANG_PROTOBUF_REGISTRATION_CONFLICT: warn
-
 includes:
   vars:
     taskfile: Taskfile.vars.yml

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -100,18 +100,3 @@ target "dir-reconciler-coverage" {
   ]
   tags = get_tag(target.docker-metadata-action.tags, "dir-reconciler")
 }
-
-target "sdks-test" {
-  context = "."
-  dockerfile = "./tests/e2e/sdk/Dockerfile"
-  depends_on = ["dir-ctl"] # Ensures dir-ctl is built first
-  inherits = [
-    "_common",
-    "docker-metadata-action",
-  ]
-  args = {
-    IMAGE_REPO = "${IMAGE_REPO}"
-    IMAGE_TAG = "${IMAGE_TAG}"
-  }
-  tags = get_tag(target.docker-metadata-action.tags, "${target.sdks-test.name}")
-}


### PR DESCRIPTION
Bumps `v1.2.0` → `v1.3.0` in README.md (Docker image and Helm chart install snippets) and in the default `image_version` input of the `demo-dir` and `import-records` workflows, removes the deprecated `GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn` workaround from Taskfile.yml, drops the now-unused `sdks-test` target from docker-bake.hcl, and clears out leftover SDK references from .github/labels.yml and the `lint-pr-title` workflow scope allow-list following the SDK split into separate repositories.