### PR TITLE
feat(client/cli): reusable client configuration

### DIFF
--- a/cli/cmd/auth/auth.go
+++ b/cli/cmd/auth/auth.go
@@ -4,6 +4,10 @@
 package auth
 
 import (
+	"fmt"
+
+	"github.com/agntcy/dir/cli/config"
+	clientconfig "github.com/agntcy/dir/client/config"
 	"github.com/spf13/cobra"
 )
 
@@ -27,9 +31,30 @@ Examples:
 
   # Logout (clear cached token)
   dirctl auth logout`,
-	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-		return nil
-	},
+	PersistentPreRunE: resolveAuthConfig,
+}
+
+func resolveAuthConfig(cmd *cobra.Command, _ []string) error {
+	fields := config.ChangedClientConfigFields(cmd)
+
+	overrides := config.Client
+	if len(fields) == 0 {
+		overrides = nil
+	}
+
+	cfg, _, err := clientconfig.Resolve(clientconfig.ResolveOptions{
+		Context:        config.Context,
+		Overrides:      overrides,
+		OverrideFields: fields,
+		SkipValidation: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to resolve auth config: %w", err)
+	}
+
+	*config.Client = *cfg
+
+	return nil
 }
 
 func init() {

--- a/cli/cmd/auth/status_logout_test.go
+++ b/cli/cmd/auth/status_logout_test.go
@@ -5,6 +5,9 @@ package auth
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,6 +15,11 @@ import (
 	"github.com/agntcy/dir/client"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	testConfigDirPerm  = 0o700
+	testConfigFilePerm = 0o600
 )
 
 func TestRunStatus_NotAuthenticated(t *testing.T) {
@@ -125,6 +133,81 @@ func TestRunStatus_RequiresIssuerWhenMultipleCachesExist(t *testing.T) {
 	require.Contains(t, err.Error(), "https://issuer-b.example")
 }
 
+func TestResolveAuthConfigUsesOIDCContextWithoutServerAddress(t *testing.T) {
+	resetAuthTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeAuthTestConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    auth_mode: oidc
+    oidc_issuer: https://issuer.example
+    oidc_client_id: dirctl
+`)
+
+	clcfg.Client = &client.DefaultConfig
+
+	cmd, _ := newTestCommand()
+	err := resolveAuthConfig(cmd, nil)
+
+	require.NoError(t, err)
+	require.Empty(t, clcfg.Client.ServerAddress)
+	require.Equal(t, "oidc", clcfg.Client.AuthMode)
+	require.Equal(t, "https://issuer.example", clcfg.Client.OIDCIssuer)
+	require.Equal(t, "dirctl", clcfg.Client.OIDCClientID)
+}
+
+func TestRunStatusUsesContextIssuerWhenMultipleCachesExist(t *testing.T) {
+	resetAuthTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeAuthTestConfig(t, configHome, `
+current_context: issuer-b
+contexts:
+  issuer-b:
+    auth_mode: oidc
+    oidc_issuer: https://issuer-b.example
+    oidc_client_id: dirctl
+`)
+
+	clcfg.Client = &client.DefaultConfig
+
+	cacheA, err := client.NewTokenCacheForIssuer("https://issuer-a.example")
+	require.NoError(t, err)
+	require.NoError(t, cacheA.Save(&client.CachedToken{
+		AccessToken: "token-a",
+		Provider:    "oidc",
+		Issuer:      "https://issuer-a.example",
+		User:        "user-a",
+		CreatedAt:   time.Now(),
+	}))
+
+	cacheB, err := client.NewTokenCacheForIssuer("https://issuer-b.example")
+	require.NoError(t, err)
+	require.NoError(t, cacheB.Save(&client.CachedToken{
+		AccessToken: "token-b",
+		TokenType:   "Bearer",
+		Provider:    "oidc",
+		Issuer:      "https://issuer-b.example",
+		User:        "user-b",
+		CreatedAt:   time.Now(),
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}))
+
+	cmd, out := newTestCommand()
+	require.NoError(t, resolveAuthConfig(cmd, nil))
+
+	err = runStatus(cmd, nil)
+
+	require.NoError(t, err)
+
+	got := out.String()
+	require.Contains(t, got, "Status: Authenticated")
+	require.Contains(t, got, "Subject: user-b")
+	require.NotContains(t, got, "user-a")
+}
+
 func newTestCommand() (*cobra.Command, *bytes.Buffer) {
 	cmd := &cobra.Command{}
 	out := &bytes.Buffer{}
@@ -138,4 +221,58 @@ func newTestCommand() (*cobra.Command, *bytes.Buffer) {
 	cmd.SetErr(out)
 
 	return cmd, out
+}
+
+func resetAuthTestEnv(t *testing.T) {
+	t.Helper()
+
+	clcfg.Context = ""
+
+	keys := []string{
+		"DIRECTORY_CLIENT_CONTEXT",
+		"DIRECTORY_CLIENT_SERVER_ADDRESS",
+		"DIRECTORY_CLIENT_TLS_SKIP_VERIFY",
+		"DIRECTORY_CLIENT_TLS_CERT_FILE",
+		"DIRECTORY_CLIENT_TLS_KEY_FILE",
+		"DIRECTORY_CLIENT_TLS_CA_FILE",
+		"DIRECTORY_CLIENT_SPIFFE_SOCKET_PATH",
+		"DIRECTORY_CLIENT_SPIFFE_TOKEN",
+		"DIRECTORY_CLIENT_AUTH_MODE",
+		"DIRECTORY_CLIENT_JWT_AUDIENCE",
+		"DIRECTORY_CLIENT_OIDC_ISSUER",
+		"DIRECTORY_CLIENT_OIDC_CLIENT_ID",
+		"DIRECTORY_CLIENT_AUTH_TOKEN",
+	}
+
+	original := make(map[string]string, len(keys))
+	present := make(map[string]bool, len(keys))
+
+	for _, key := range keys {
+		value, ok := os.LookupEnv(key)
+		original[key] = value
+		present[key] = ok
+		require.NoError(t, os.Unsetenv(key)) //nolint:usetesting // Need truly unset variables.
+	}
+
+	t.Cleanup(func() {
+		clcfg.Context = ""
+
+		for _, key := range keys {
+			if !present[key] {
+				_ = os.Unsetenv(key) //nolint:usetesting // Restoring process env after manual unset.
+
+				continue
+			}
+
+			_ = os.Setenv(key, original[key]) //nolint:usetesting // Restoring process env after manual unset.
+		}
+	})
+}
+
+func writeAuthTestConfig(t *testing.T, configHome string, content string) {
+	t.Helper()
+
+	configPath := filepath.Join(configHome, "dirctl", "config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), testConfigDirPerm))
+	require.NoError(t, os.WriteFile(configPath, []byte(strings.TrimSpace(content)+"\n"), testConfigFilePerm))
 }

--- a/cli/cmd/context/context.go
+++ b/cli/cmd/context/context.go
@@ -1,0 +1,61 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Command is the parent command for reusable client contexts.
+var Command = &cobra.Command{
+	Use:   "context",
+	Short: "Manage client contexts",
+	Long: `Manage reusable dirctl client contexts.
+
+Contexts live in the dirctl client config file and describe Directory nodes,
+authentication settings, and TLS/SPIFFE settings.
+
+This command group helps users operate against multiple Directory nodes from
+one terminal by inspecting configured contexts, switching the persisted active
+context, showing the effective client configuration, and validating context
+definitions before use.
+
+Available operations:
+
+- list: Show all configured contexts and mark the persisted active context
+- current: Print the context selected by --context, DIRCTL_CONTEXT, or config
+- set: Persist a configured context as the active context
+- show: Display the effective context with sensitive values redacted
+- validate: Validate one context or all configured contexts
+
+Examples:
+
+1. List all contexts:
+   dirctl context list
+
+2. Show the active context name:
+   dirctl context current
+
+3. Switch the persisted active context:
+   dirctl context set prod
+
+4. Show an effective context:
+   dirctl context show dev
+
+5. Validate all contexts:
+   dirctl context validate`,
+	PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+		return nil
+	},
+}
+
+func init() {
+	Command.AddCommand(
+		listCmd,
+		currentCmd,
+		setCmd,
+		showCmd,
+		validateCmd,
+	)
+}

--- a/cli/cmd/context/context.go
+++ b/cli/cmd/context/context.go
@@ -24,7 +24,7 @@ definitions before use.
 Available operations:
 
 - list: Show all configured contexts and mark the persisted active context
-- current: Print the context selected by --context, DIRCTL_CONTEXT, or config
+- current: Print the persisted current_context from config
 - set: Persist a configured context as the active context
 - show: Display the effective context with sensitive values redacted
 - validate: Validate one context or all configured contexts

--- a/cli/cmd/context/context_test.go
+++ b/cli/cmd/context/context_test.go
@@ -175,7 +175,7 @@ contexts:
     spiffe_token: secret-spiffe-token
 `)
 
-	output, err := executeContextRun(t, runShow)
+	output, err := executeShowCommand(t)
 
 	require.NoError(t, err)
 	require.Contains(t, output, "name: dev\n")
@@ -232,6 +232,20 @@ func executeCurrentCommand(t *testing.T, args ...string) (string, error) {
 	require.NoError(t, cmd.ParseFlags(args))
 
 	err := runCurrent(cmd, nil)
+
+	return output.String(), err
+}
+
+func executeShowCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	err := runShow(cmd, args)
 
 	return output.String(), err
 }

--- a/cli/cmd/context/context_test.go
+++ b/cli/cmd/context/context_test.go
@@ -5,6 +5,7 @@ package context
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -41,6 +42,28 @@ func TestContextCurrent(t *testing.T) {
 	resetContextTestEnv(t)
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("DIRECTORY_CLIENT_CONTEXT", "prod")
+	writeContextTestConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: insecure
+`)
+
+	output, err := executeCurrentCommand(t)
+
+	require.NoError(t, err)
+	require.Equal(t, "dev\n", output)
+}
+
+func TestContextCurrentQuiet(t *testing.T) {
+	resetContextTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
 	writeContextTestConfig(t, configHome, `
 current_context: dev
 contexts:
@@ -49,10 +72,68 @@ contexts:
     auth_mode: insecure
 `)
 
-	output, err := executeContextRun(t, runCurrent)
+	output, err := executeCurrentCommand(t, "--quiet")
 
 	require.NoError(t, err)
-	require.Equal(t, "dev\n", output)
+	require.Equal(t, "dev", output)
+}
+
+func TestContextCurrentQuietWithNoContext(t *testing.T) {
+	resetContextTestEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	output, err := executeCurrentCommand(t, "--quiet")
+
+	require.NoError(t, err)
+	require.Empty(t, output)
+}
+
+func TestContextCurrentJSON(t *testing.T) {
+	resetContextTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeContextTestConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+`)
+
+	output, err := executeCurrentCommand(t, "--json")
+
+	require.NoError(t, err)
+
+	var decoded currentContextOutput
+	require.NoError(t, json.Unmarshal([]byte(output), &decoded))
+	require.Equal(t, "dev", decoded.Name)
+	require.Equal(t, "current_context", decoded.Source)
+	require.NotEmpty(t, decoded.Path)
+}
+
+func TestContextCurrentJSONWithNoContext(t *testing.T) {
+	resetContextTestEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	output, err := executeCurrentCommand(t, "--json")
+
+	require.NoError(t, err)
+
+	var decoded currentContextOutput
+	require.NoError(t, json.Unmarshal([]byte(output), &decoded))
+	require.Empty(t, decoded.Name)
+	require.Equal(t, "none", decoded.Source)
+	require.NotEmpty(t, decoded.Path)
+}
+
+func TestContextCurrentRejectsQuietAndJSON(t *testing.T) {
+	resetContextTestEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	output, err := executeCurrentCommand(t, "--quiet", "--json")
+
+	require.ErrorContains(t, err, "use only one of --quiet or --json")
+	require.Empty(t, output)
 }
 
 func TestContextSet(t *testing.T) {
@@ -139,12 +220,27 @@ func executeContextRun(t *testing.T, run func(*cobra.Command, []string) error, a
 	return output.String(), err
 }
 
+func executeCurrentCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	addCurrentFlags(cmd)
+	require.NoError(t, cmd.ParseFlags(args))
+
+	err := runCurrent(cmd, nil)
+
+	return output.String(), err
+}
+
 func resetContextTestEnv(t *testing.T) {
 	t.Helper()
 
 	config.Context = ""
 	keys := []string{
-		"DIRCTL_CONTEXT",
 		"DIRECTORY_CLIENT_CONTEXT",
 		"DIRECTORY_CLIENT_SERVER_ADDRESS",
 		"DIRECTORY_CLIENT_TLS_SKIP_VERIFY",

--- a/cli/cmd/context/context_test.go
+++ b/cli/cmd/context/context_test.go
@@ -1,0 +1,194 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agntcy/dir/cli/config"
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextList(t *testing.T) {
+	resetContextTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeContextTestConfig(t, configHome, `
+current_context: dev
+contexts:
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: insecure
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+`)
+
+	output, err := executeContextRun(t, runList)
+
+	require.NoError(t, err)
+	require.Equal(t, "* dev\n  prod\n", output)
+}
+
+func TestContextCurrent(t *testing.T) {
+	resetContextTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeContextTestConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+`)
+
+	output, err := executeContextRun(t, runCurrent)
+
+	require.NoError(t, err)
+	require.Equal(t, "dev\n", output)
+}
+
+func TestContextSet(t *testing.T) {
+	resetContextTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeContextTestConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: insecure
+`)
+
+	output, err := executeContextRun(t, runSet, "prod")
+
+	require.NoError(t, err)
+	require.Equal(t, "Switched to context \"prod\".\n", output)
+
+	file, err := clientconfig.LoadFile("")
+	require.NoError(t, err)
+	require.Equal(t, "prod", file.CurrentContext)
+}
+
+func TestContextShowRedactsSensitiveValues(t *testing.T) {
+	resetContextTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeContextTestConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+    auth_token: secret-token
+    spiffe_token: secret-spiffe-token
+`)
+
+	output, err := executeContextRun(t, runShow)
+
+	require.NoError(t, err)
+	require.Contains(t, output, "name: dev\n")
+	require.Contains(t, output, "auth_token: <redacted>")
+	require.Contains(t, output, "spiffe_token: <redacted>")
+	require.NotContains(t, output, "secret-token")
+	require.NotContains(t, output, "secret-spiffe-token")
+}
+
+func TestContextValidate(t *testing.T) {
+	resetContextTestEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeContextTestConfig(t, configHome, `
+contexts:
+  valid:
+    server_address: valid.gateway.example.com:443
+    auth_mode: insecure
+  invalid:
+    auth_mode: insecure
+`)
+
+	output, err := executeContextRun(t, runValidate)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid context(s): invalid")
+	require.Contains(t, output, "invalid: server_address is required")
+	require.Contains(t, output, "valid: ok")
+}
+
+func executeContextRun(t *testing.T, run func(*cobra.Command, []string) error, args ...string) (string, error) {
+	t.Helper()
+
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	err := run(cmd, args)
+
+	return output.String(), err
+}
+
+func resetContextTestEnv(t *testing.T) {
+	t.Helper()
+
+	config.Context = ""
+	keys := []string{
+		"DIRCTL_CONTEXT",
+		"DIRECTORY_CLIENT_CONTEXT",
+		"DIRECTORY_CLIENT_SERVER_ADDRESS",
+		"DIRECTORY_CLIENT_TLS_SKIP_VERIFY",
+		"DIRECTORY_CLIENT_TLS_CERT_FILE",
+		"DIRECTORY_CLIENT_TLS_KEY_FILE",
+		"DIRECTORY_CLIENT_TLS_CA_FILE",
+		"DIRECTORY_CLIENT_SPIFFE_SOCKET_PATH",
+		"DIRECTORY_CLIENT_SPIFFE_TOKEN",
+		"DIRECTORY_CLIENT_AUTH_MODE",
+		"DIRECTORY_CLIENT_JWT_AUDIENCE",
+		"DIRECTORY_CLIENT_OIDC_ISSUER",
+		"DIRECTORY_CLIENT_OIDC_CLIENT_ID",
+		"DIRECTORY_CLIENT_AUTH_TOKEN",
+	}
+
+	original := make(map[string]string, len(keys))
+
+	present := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		value, ok := os.LookupEnv(key)
+		original[key] = value
+		present[key] = ok
+		require.NoError(t, os.Unsetenv(key)) //nolint:usetesting // Need truly unset variables.
+	}
+
+	t.Cleanup(func() {
+		config.Context = ""
+
+		for _, key := range keys {
+			if !present[key] {
+				_ = os.Unsetenv(key) //nolint:usetesting // Restoring process env after manual unset.
+
+				continue
+			}
+
+			_ = os.Setenv(key, original[key]) //nolint:usetesting // Restoring process env after manual unset.
+		}
+	})
+}
+
+func writeContextTestConfig(t *testing.T, configHome string, content string) {
+	t.Helper()
+
+	configPath := filepath.Join(configHome, "dirctl", "config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	require.NoError(t, os.WriteFile(configPath, []byte(strings.TrimSpace(content)+"\n"), 0o600))
+}

--- a/cli/cmd/context/current.go
+++ b/cli/cmd/context/current.go
@@ -4,10 +4,10 @@
 package context
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
-	"github.com/agntcy/dir/cli/config"
 	clientconfig "github.com/agntcy/dir/client/config"
 	"github.com/spf13/cobra"
 )
@@ -17,39 +17,121 @@ var currentCmd = &cobra.Command{
 	Short: "Show the active context",
 	Long: `Show the active dirctl client context.
 
-This command prints the context selected for the current invocation. Selection
-uses the same context precedence as client config resolution:
+This command prints the persisted current_context from the dirctl client config
+file. It intentionally ignores one-off context overrides such as --context,
+and DIRECTORY_CLIENT_CONTEXT so it stays consistent with dirctl context list,
+which marks the persisted current_context.
 
-1. --context
-2. DIRCTL_CONTEXT
-3. DIRECTORY_CLIENT_CONTEXT
-4. current_context from the config file
-
-It prints only the selected context name, which keeps the output suitable for
-shell prompts and scripts.
+By default, it prints only the persisted context name followed by a newline.
+Use --quiet for shell prompts where missing context should produce no output
+and no error. Use --json for stable machine-readable output.
 
 Examples:
 
 1. Show the active context:
    dirctl context current
 
-2. Show what an explicit override selects:
-   dirctl --context staging context current`,
+2. Switch the persisted current context:
+   dirctl context set staging
+
+3. Use in a shell prompt helper:
+   dirctl_context_prompt() {
+     ctx="$(dirctl context current --quiet 2>/dev/null)" || return
+     [ -n "$ctx" ] && printf "[dir:%s] " "$ctx"
+   }
+
+4. Get machine-readable status:
+   dirctl context current --json`,
 	Args: cobra.NoArgs,
 	RunE: runCurrent,
 }
 
+type currentContextOutput struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Path   string `json:"path"`
+}
+
+func init() {
+	addCurrentFlags(currentCmd)
+}
+
+func addCurrentFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("quiet", false, "Print only the persisted current context name; print nothing when no context is set")
+	cmd.Flags().Bool("json", false, "Print persisted current context details as JSON")
+}
+
 func runCurrent(cmd *cobra.Command, _ []string) error {
-	current, err := clientconfig.CurrentContext("", config.Context)
+	quiet, err := boolFlag(cmd, "quiet")
+	if err != nil {
+		return err
+	}
+
+	jsonOutput, err := boolFlag(cmd, "json")
+	if err != nil {
+		return err
+	}
+
+	if quiet && jsonOutput {
+		return errors.New("use only one of --quiet or --json")
+	}
+
+	current, err := clientconfig.CurrentContext("")
 	if err != nil {
 		return fmt.Errorf("failed to get current context: %w", err)
 	}
 
 	if current.Name == "" {
+		if quiet {
+			return nil
+		}
+
+		if jsonOutput {
+			return printCurrentContextJSON(cmd, current)
+		}
+
 		return errors.New("no current context is set")
 	}
 
+	if jsonOutput {
+		return printCurrentContextJSON(cmd, current)
+	}
+
+	if quiet {
+		cmd.Print(current.Name)
+
+		return nil
+	}
+
 	cmd.Println(current.Name)
+
+	return nil
+}
+
+func boolFlag(cmd *cobra.Command, name string) (bool, error) {
+	if cmd.Flags().Lookup(name) == nil {
+		return false, nil
+	}
+
+	value, err := cmd.Flags().GetBool(name)
+	if err != nil {
+		return false, fmt.Errorf("failed to read %s flag: %w", name, err)
+	}
+
+	return value, nil
+}
+
+func printCurrentContextJSON(cmd *cobra.Command, current *clientconfig.ResolvedContext) error {
+	output := currentContextOutput{
+		Name:   current.Name,
+		Source: current.Source,
+		Path:   current.Path,
+	}
+
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	if err := encoder.Encode(output); err != nil {
+		return fmt.Errorf("failed to encode current context output: %w", err)
+	}
 
 	return nil
 }

--- a/cli/cmd/context/current.go
+++ b/cli/cmd/context/current.go
@@ -1,0 +1,55 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/agntcy/dir/cli/config"
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/spf13/cobra"
+)
+
+var currentCmd = &cobra.Command{
+	Use:   "current",
+	Short: "Show the active context",
+	Long: `Show the active dirctl client context.
+
+This command prints the context selected for the current invocation. Selection
+uses the same context precedence as client config resolution:
+
+1. --context
+2. DIRCTL_CONTEXT
+3. DIRECTORY_CLIENT_CONTEXT
+4. current_context from the config file
+
+It prints only the selected context name, which keeps the output suitable for
+shell prompts and scripts.
+
+Examples:
+
+1. Show the active context:
+   dirctl context current
+
+2. Show what an explicit override selects:
+   dirctl --context staging context current`,
+	Args: cobra.NoArgs,
+	RunE: runCurrent,
+}
+
+func runCurrent(cmd *cobra.Command, _ []string) error {
+	current, err := clientconfig.CurrentContext("", config.Context)
+	if err != nil {
+		return fmt.Errorf("failed to get current context: %w", err)
+	}
+
+	if current.Name == "" {
+		return errors.New("no current context is set")
+	}
+
+	cmd.Println(current.Name)
+
+	return nil
+}

--- a/cli/cmd/context/list.go
+++ b/cli/cmd/context/list.go
@@ -1,0 +1,58 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List configured contexts",
+	Long: `List configured dirctl client contexts.
+
+This command reads the reusable client config file and prints each configured
+context in sorted order. The persisted current_context is marked with '*'.
+
+This command does not contact a Directory server and does not require a
+resolved client configuration.
+
+Examples:
+
+1. List all configured contexts:
+   dirctl context list
+
+2. Use the marker to see which context is persisted as current_context:
+   * prod
+     staging`,
+	Args: cobra.NoArgs,
+	RunE: runList,
+}
+
+func runList(cmd *cobra.Command, _ []string) error {
+	contexts, err := clientconfig.ListContexts("")
+	if err != nil {
+		return fmt.Errorf("failed to list contexts: %w", err)
+	}
+
+	if len(contexts) == 0 {
+		cmd.Println("No contexts configured.")
+
+		return nil
+	}
+
+	for _, contextSummary := range contexts {
+		marker := " "
+		if contextSummary.Current {
+			marker = "*"
+		}
+
+		cmd.Printf("%s %s\n", marker, contextSummary.Name)
+	}
+
+	return nil
+}

--- a/cli/cmd/context/set.go
+++ b/cli/cmd/context/set.go
@@ -1,0 +1,49 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/spf13/cobra"
+)
+
+var setCmd = &cobra.Command{
+	Use:   "set <name>",
+	Short: "Set the persisted active context",
+	Long: `Set the persisted active dirctl client context.
+
+This command updates current_context in the reusable client config file. The
+target context must already exist in the config file.
+
+Use this when switching your terminal session from one Directory node to
+another as the default target. For one-off commands, prefer --context instead
+of changing the persisted active context.
+
+Arguments:
+
+<name> is required and must match a configured context name.
+
+Examples:
+
+1. Switch to the prod context:
+   dirctl context set prod
+
+2. Run one command against staging without changing the persisted context:
+   dirctl --context staging info <record-cid>`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSet,
+}
+
+func runSet(cmd *cobra.Command, args []string) error {
+	resolved, err := clientconfig.SetCurrentContext("", args[0])
+	if err != nil {
+		return fmt.Errorf("failed to set current context: %w", err)
+	}
+
+	cmd.Printf("Switched to context %q.\n", resolved.Name)
+
+	return nil
+}

--- a/cli/cmd/context/show.go
+++ b/cli/cmd/context/show.go
@@ -90,7 +90,20 @@ func printResolvedConfig(cmd *cobra.Command, resolved *clientconfig.ResolvedCont
 	cmd.Printf("path: %s\n", resolved.Path)
 	cmd.Println("config:")
 
-	values := map[string]string{
+	values := resolvedConfigValues(cfg)
+	keys := sortedValueKeys(values)
+
+	for _, key := range keys {
+		if values[key] == "" {
+			continue
+		}
+
+		cmd.Printf("  %s: %s\n", key, values[key])
+	}
+}
+
+func resolvedConfigValues(cfg *client.Config) map[string]string {
+	return map[string]string{
 		"auth_mode":          cfg.AuthMode,
 		"auth_token":         redact(cfg.AuthToken),
 		"jwt_audience":       cfg.JWTAudience,
@@ -104,7 +117,9 @@ func printResolvedConfig(cmd *cobra.Command, resolved *clientconfig.ResolvedCont
 		"tls_key_file":       cfg.TlsKeyFile,
 		"tls_skip_verify":    fmt.Sprintf("%t", cfg.TlsSkipVerify),
 	}
+}
 
+func sortedValueKeys(values map[string]string) []string {
 	keys := make([]string, 0, len(values))
 	for key := range values {
 		keys = append(keys, key)
@@ -112,13 +127,7 @@ func printResolvedConfig(cmd *cobra.Command, resolved *clientconfig.ResolvedCont
 
 	sort.Strings(keys)
 
-	for _, key := range keys {
-		if values[key] == "" {
-			continue
-		}
-
-		cmd.Printf("  %s: %s\n", key, values[key])
-	}
+	return keys
 }
 
 func redact(value string) string {

--- a/cli/cmd/context/show.go
+++ b/cli/cmd/context/show.go
@@ -1,0 +1,130 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agntcy/dir/cli/config"
+	"github.com/agntcy/dir/client"
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/spf13/cobra"
+)
+
+const redacted = "<redacted>"
+
+var showCmd = &cobra.Command{
+	Use:   "show [name]",
+	Short: "Show a context with sensitive values redacted",
+	Long: `Show an effective dirctl client context.
+
+This command resolves a context using the shared client config resolver and
+prints the effective client settings. Sensitive values such as bearer tokens
+and SPIFFE token paths are redacted from output.
+
+If [name] is provided, that context is shown. If omitted, the command uses the
+same context selection rules as other dirctl commands. Environment variables
+and explicitly changed root flags are included in the effective output.
+
+Arguments:
+
+[name] is optional. When omitted, the active context is selected from --context,
+DIRCTL_CONTEXT, DIRECTORY_CLIENT_CONTEXT, or current_context.
+
+Examples:
+
+1. Show the active context:
+   dirctl context show
+
+2. Show a specific context:
+   dirctl context show prod
+
+3. Preview a context with a one-off server override:
+   dirctl --server-addr localhost:8888 context show dev`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runShow,
+}
+
+func runShow(cmd *cobra.Command, args []string) error {
+	contextName := selectedShowContext(args)
+	fields := config.ChangedClientConfigFields(cmd)
+
+	var overrides *client.Config
+	if len(fields) > 0 {
+		overrides = config.Client
+	}
+
+	cfg, resolved, err := clientconfig.Resolve(clientconfig.ResolveOptions{
+		Context:        contextName,
+		Overrides:      overrides,
+		OverrideFields: fields,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to show context: %w", err)
+	}
+
+	if resolved.Name == "" {
+		return errors.New("no context selected")
+	}
+
+	printResolvedConfig(cmd, resolved, cfg)
+
+	return nil
+}
+
+func selectedShowContext(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+
+	return config.Context
+}
+
+func printResolvedConfig(cmd *cobra.Command, resolved *clientconfig.ResolvedContext, cfg *client.Config) {
+	cmd.Printf("name: %s\n", resolved.Name)
+	cmd.Printf("source: %s\n", resolved.Source)
+	cmd.Printf("path: %s\n", resolved.Path)
+	cmd.Println("config:")
+
+	values := map[string]string{
+		"auth_mode":          cfg.AuthMode,
+		"auth_token":         redact(cfg.AuthToken),
+		"jwt_audience":       cfg.JWTAudience,
+		"oidc_client_id":     cfg.OIDCClientID,
+		"oidc_issuer":        cfg.OIDCIssuer,
+		"server_address":     cfg.ServerAddress,
+		"spiffe_socket_path": cfg.SpiffeSocketPath,
+		"spiffe_token":       redact(cfg.SpiffeToken),
+		"tls_ca_file":        cfg.TlsCAFile,
+		"tls_cert_file":      cfg.TlsCertFile,
+		"tls_key_file":       cfg.TlsKeyFile,
+		"tls_skip_verify":    fmt.Sprintf("%t", cfg.TlsSkipVerify),
+	}
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if values[key] == "" {
+			continue
+		}
+
+		cmd.Printf("  %s: %s\n", key, values[key])
+	}
+}
+
+func redact(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+
+	return redacted
+}

--- a/cli/cmd/context/show.go
+++ b/cli/cmd/context/show.go
@@ -33,7 +33,7 @@ and explicitly changed root flags are included in the effective output.
 Arguments:
 
 [name] is optional. When omitted, the active context is selected from --context,
-DIRCTL_CONTEXT, DIRECTORY_CLIENT_CONTEXT, or current_context.
+DIRECTORY_CLIENT_CONTEXT, or current_context.
 
 Examples:
 

--- a/cli/cmd/context/validate.go
+++ b/cli/cmd/context/validate.go
@@ -1,0 +1,77 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package context
+
+import (
+	"fmt"
+	"strings"
+
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/spf13/cobra"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate [name]",
+	Short: "Validate one or all configured contexts",
+	Long: `Validate dirctl client context definitions.
+
+This command validates stored context definitions from the reusable client
+config file without applying environment variable overrides. It is intended to
+catch missing required fields, unsupported auth modes, and auth-mode-specific
+configuration mistakes before a context is used.
+
+If [name] is provided, only that context is validated. If omitted, all
+configured contexts are validated in sorted order.
+
+Arguments:
+
+[name] is optional. When omitted, all configured contexts are validated.
+
+Examples:
+
+1. Validate all contexts:
+   dirctl context validate
+
+2. Validate one context:
+   dirctl context validate prod`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runValidate,
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	contextName := ""
+	if len(args) > 0 {
+		contextName = args[0]
+	}
+
+	results, err := clientconfig.ValidateContexts("", contextName)
+	if err != nil {
+		return fmt.Errorf("failed to validate contexts: %w", err)
+	}
+
+	if len(results) == 0 {
+		cmd.Println("No contexts configured.")
+
+		return nil
+	}
+
+	var invalid []string
+
+	for _, result := range results {
+		if result.Error == nil {
+			cmd.Printf("%s: ok\n", result.Name)
+
+			continue
+		}
+
+		invalid = append(invalid, result.Name)
+		cmd.Printf("%s: invalid: %v\n", result.Name, result.Error)
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("invalid context(s): %s", strings.Join(invalid, ", "))
+	}
+
+	return nil
+}

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -16,6 +16,7 @@ func init() {
 
 	// set flags
 	flags := RootCmd.PersistentFlags()
+	flags.StringVar(&config.Context, "context", "", "Directory client context name")
 	flags.StringVar(&config.Client.ServerAddress, "server-addr", config.Client.ServerAddress, "Directory Server API address")
 	flags.StringVar(&config.Client.AuthMode, "auth-mode", config.Client.AuthMode, "Authentication mode: x509, jwt, token (SPIFFE), tls, oidc, insecure, none, or empty for auto-detect")
 	flags.StringVar(&config.Client.SpiffeSocketPath, "spiffe-socket-path", config.Client.SpiffeSocketPath, "Path to SPIFFE Workload API socket (for x509 or JWT authentication)")
@@ -28,7 +29,4 @@ func init() {
 	flags.StringVar(&config.Client.OIDCIssuer, "oidc-issuer", config.Client.OIDCIssuer, "OIDC issuer URL (e.g. https://dex.example.com) for interactive login")
 	flags.StringVar(&config.Client.OIDCClientID, "oidc-client-id", config.Client.OIDCClientID, "OIDC client ID for interactive login (PKCE)")
 	flags.StringVar(&config.Client.AuthToken, "auth-token", config.Client.AuthToken, "Pre-issued Bearer token (JWT). Useful for CI and non-interactive workflows; no login needed")
-
-	// mark required flags
-	RootCmd.MarkFlagRequired("server-addr") //nolint:errcheck
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/agntcy/dir/cli/cmd/auth"
+	contextcmd "github.com/agntcy/dir/cli/cmd/context"
 	"github.com/agntcy/dir/cli/cmd/daemon"
 	"github.com/agntcy/dir/cli/cmd/delete"
 	"github.com/agntcy/dir/cli/cmd/events"
@@ -75,7 +76,7 @@ func shouldSkipClientSetup(cmd *cobra.Command) bool {
 }
 
 func resolveClientConfig(cmd *cobra.Command) (*client.Config, error) {
-	fields := changedClientConfigFields(cmd)
+	fields := cliconfig.ChangedClientConfigFields(cmd)
 
 	var overrides *client.Config
 	if len(fields) > 0 {
@@ -98,36 +99,6 @@ func resolveClientConfig(cmd *cobra.Command) (*client.Config, error) {
 	return cliconfig.Client, nil
 }
 
-func changedClientConfigFields(cmd *cobra.Command) []string {
-	//nolint:gosec // G101: These are configuration field names, not credential values.
-	flagToField := map[string]string{
-		"server-addr":        "server_address",
-		"auth-mode":          "auth_mode",
-		"spiffe-socket-path": "spiffe_socket_path",
-		"spiffe-token":       "spiffe_token",
-		"jwt-audience":       "jwt_audience",
-		"tls-skip-verify":    "tls_skip_verify",
-		"tls-ca-file":        "tls_ca_file",
-		"tls-cert-file":      "tls_cert_file",
-		"tls-key-file":       "tls_key_file",
-		"oidc-issuer":        "oidc_issuer",
-		"oidc-client-id":     "oidc_client_id",
-		"auth-token":         "auth_token",
-	}
-
-	fields := make([]string, 0, len(flagToField))
-
-	flags := cmd.Root().PersistentFlags()
-	for flagName, fieldName := range flagToField {
-		flag := flags.Lookup(flagName)
-		if flag != nil && flag.Changed {
-			fields = append(fields, fieldName)
-		}
-	}
-
-	return fields
-}
-
 func init() {
 	network.Command.Hidden = true
 	network.Command.PersistentPreRunE = skipClientSetup
@@ -137,6 +108,7 @@ func init() {
 	RootCmd.AddCommand(
 		// auth commands
 		auth.Command, // Contains: login, logout, status
+		contextcmd.Command,
 		// local commands
 		version.Command,
 		// initialize.Command, // REMOVED: Initialize functionality

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -26,9 +26,10 @@ import (
 	"github.com/agntcy/dir/cli/cmd/validate"
 	"github.com/agntcy/dir/cli/cmd/verify"
 	"github.com/agntcy/dir/cli/cmd/version"
-	"github.com/agntcy/dir/cli/config"
+	cliconfig "github.com/agntcy/dir/cli/config"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/agntcy/dir/client"
+	clientconfig "github.com/agntcy/dir/client/config"
 	"github.com/spf13/cobra"
 )
 
@@ -42,9 +43,12 @@ var RootCmd = &cobra.Command{
 			return nil
 		}
 
-		// Set client via context for all requests
-		// TODO: make client config configurable via CLI args
-		c, err := client.New(cmd.Context(), client.WithConfig(config.Client))
+		cfg, err := resolveClientConfig(cmd)
+		if err != nil {
+			return err
+		}
+
+		c, err := client.New(cmd.Context(), client.WithConfig(cfg))
 		if err != nil {
 			return fmt.Errorf("failed to create client: %w", err)
 		}
@@ -68,6 +72,60 @@ func skipClientSetup(_ *cobra.Command, _ []string) error {
 
 func shouldSkipClientSetup(cmd *cobra.Command) bool {
 	return cmd.Name() == "help" || cmd.Name() == "completion"
+}
+
+func resolveClientConfig(cmd *cobra.Command) (*client.Config, error) {
+	fields := changedClientConfigFields(cmd)
+
+	var overrides *client.Config
+	if len(fields) > 0 {
+		overrides = cliconfig.Client
+	}
+
+	cfg, _, err := clientconfig.Resolve(clientconfig.ResolveOptions{
+		Context:        cliconfig.Context,
+		Overrides:      overrides,
+		OverrideFields: fields,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve client config: %w", err)
+	}
+
+	// Keep the existing pointer so Cobra flag bindings remain valid across
+	// repeated command executions in tests.
+	*cliconfig.Client = *cfg
+
+	return cliconfig.Client, nil
+}
+
+func changedClientConfigFields(cmd *cobra.Command) []string {
+	//nolint:gosec // G101: These are configuration field names, not credential values.
+	flagToField := map[string]string{
+		"server-addr":        "server_address",
+		"auth-mode":          "auth_mode",
+		"spiffe-socket-path": "spiffe_socket_path",
+		"spiffe-token":       "spiffe_token",
+		"jwt-audience":       "jwt_audience",
+		"tls-skip-verify":    "tls_skip_verify",
+		"tls-ca-file":        "tls_ca_file",
+		"tls-cert-file":      "tls_cert_file",
+		"tls-key-file":       "tls_key_file",
+		"oidc-issuer":        "oidc_issuer",
+		"oidc-client-id":     "oidc_client_id",
+		"auth-token":         "auth_token",
+	}
+
+	fields := make([]string, 0, len(flagToField))
+
+	flags := cmd.Root().PersistentFlags()
+	for flagName, fieldName := range flagToField {
+		flag := flags.Lookup(flagName)
+		if flag != nil && flag.Changed {
+			fields = append(fields, fieldName)
+		}
+	}
+
+	return fields
 }
 
 func init() {

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -154,7 +154,7 @@ func TestResolveClientConfigUsesContextEnvOverride(t *testing.T) {
 	resetClientEnv(t)
 	configHome := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", configHome)
-	t.Setenv("DIRCTL_CONTEXT", "dev")
+	t.Setenv("DIRECTORY_CLIENT_CONTEXT", "dev")
 	writeDirctlConfig(t, configHome, `
 current_context: prod
 contexts:
@@ -278,7 +278,6 @@ func resetClientEnv(t *testing.T) {
 	t.Helper()
 
 	keys := []string{
-		"DIRCTL_CONTEXT",
 		"DIRECTORY_CLIENT_CONTEXT",
 		"DIRECTORY_CLIENT_SERVER_ADDRESS",
 		"DIRECTORY_CLIENT_TLS_SKIP_VERIFY",

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -7,11 +7,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/agntcy/dir/cli/config"
+	"github.com/agntcy/dir/client"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,6 +85,125 @@ func TestAPICommandsStillRequireOIDCToken(t *testing.T) {
 	require.Contains(t, err.Error(), missingOIDCTokenError)
 }
 
+func TestResolveClientConfigUsesCurrentContext(t *testing.T) {
+	resetClientEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeDirctlConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+`)
+	resetClientConfig()
+
+	cfg, err := resolveClientConfig(newResolveTestCommand(t))
+
+	require.NoError(t, err)
+	require.Equal(t, "dev.gateway.example.com:443", cfg.ServerAddress)
+	require.Equal(t, "insecure", cfg.AuthMode)
+}
+
+func TestResolveClientConfigUsesContextOverride(t *testing.T) {
+	resetClientEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeDirctlConfig(t, configHome, `
+current_context: prod
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: insecure
+`)
+	resetClientConfig()
+
+	config.Context = "dev"
+
+	cfg, err := resolveClientConfig(newResolveTestCommand(t))
+
+	require.NoError(t, err)
+	require.Equal(t, "dev.gateway.example.com:443", cfg.ServerAddress)
+}
+
+func TestResolveClientConfigUsesContextEnvOverride(t *testing.T) {
+	resetClientEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv("DIRCTL_CONTEXT", "dev")
+	writeDirctlConfig(t, configHome, `
+current_context: prod
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: insecure
+`)
+	resetClientConfig()
+
+	cfg, err := resolveClientConfig(newResolveTestCommand(t))
+
+	require.NoError(t, err)
+	require.Equal(t, "dev.gateway.example.com:443", cfg.ServerAddress)
+}
+
+func TestResolveClientConfigFlagsOverrideContext(t *testing.T) {
+	resetClientEnv(t)
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	writeDirctlConfig(t, configHome, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://dev.idp.example.com
+`)
+	resetClientConfig()
+
+	cmd := newResolveTestCommand(t)
+	require.NoError(t, cmd.ParseFlags([]string{
+		"--server-addr", "flag.gateway.example.com:443",
+		"--auth-mode", "insecure",
+	}))
+
+	cfg, err := resolveClientConfig(cmd)
+
+	require.NoError(t, err)
+	require.Equal(t, "flag.gateway.example.com:443", cfg.ServerAddress)
+	require.Equal(t, "insecure", cfg.AuthMode)
+}
+
+func TestResolveClientConfigMissingServerAddress(t *testing.T) {
+	resetClientEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	resetClientConfig()
+
+	cfg, err := resolveClientConfig(newResolveTestCommand(t))
+
+	require.Error(t, err)
+	require.Nil(t, cfg)
+	require.Contains(t, err.Error(), "server_address is required")
+}
+
+func TestResolveClientConfigIgnoresDefaultClientConfigWithoutChangedFlags(t *testing.T) {
+	resetClientEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	*config.Client = client.DefaultConfig
+
+	cfg, err := resolveClientConfig(newResolveTestCommand(t))
+
+	require.Error(t, err)
+	require.Nil(t, cfg)
+	require.Contains(t, err.Error(), "server_address is required")
+}
+
 func executeRootWithOIDCWithoutToken(t *testing.T, args ...string) error {
 	t.Helper()
 
@@ -116,6 +238,7 @@ func executeRootWithOIDCWithoutToken(t *testing.T, args ...string) error {
 }
 
 func resetClientConfig() {
+	config.Context = ""
 	config.Client.ServerAddress = ""
 	config.Client.AuthMode = ""
 	config.Client.SpiffeSocketPath = ""
@@ -128,6 +251,77 @@ func resetClientConfig() {
 	config.Client.OIDCIssuer = ""
 	config.Client.OIDCClientID = ""
 	config.Client.AuthToken = ""
+}
+
+func resetClientEnv(t *testing.T) {
+	t.Helper()
+
+	keys := []string{
+		"DIRCTL_CONTEXT",
+		"DIRECTORY_CLIENT_CONTEXT",
+		"DIRECTORY_CLIENT_SERVER_ADDRESS",
+		"DIRECTORY_CLIENT_TLS_SKIP_VERIFY",
+		"DIRECTORY_CLIENT_TLS_CERT_FILE",
+		"DIRECTORY_CLIENT_TLS_KEY_FILE",
+		"DIRECTORY_CLIENT_TLS_CA_FILE",
+		"DIRECTORY_CLIENT_SPIFFE_SOCKET_PATH",
+		"DIRECTORY_CLIENT_SPIFFE_TOKEN",
+		"DIRECTORY_CLIENT_AUTH_MODE",
+		"DIRECTORY_CLIENT_JWT_AUDIENCE",
+		"DIRECTORY_CLIENT_OIDC_ISSUER",
+		"DIRECTORY_CLIENT_OIDC_CLIENT_ID",
+		"DIRECTORY_CLIENT_AUTH_TOKEN",
+	}
+
+	original := make(map[string]string, len(keys))
+	present := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		value, ok := os.LookupEnv(key)
+		original[key] = value
+		present[key] = ok
+		require.NoError(t, os.Unsetenv(key)) //nolint:usetesting // Need truly unset variables.
+	}
+
+	t.Cleanup(func() {
+		for _, key := range keys {
+			if !present[key] {
+				_ = os.Unsetenv(key) //nolint:usetesting // Restoring process env after manual unset.
+
+				continue
+			}
+
+			_ = os.Setenv(key, original[key]) //nolint:usetesting // Restoring process env after manual unset.
+		}
+	})
+}
+
+func newResolveTestCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "dirctl"}
+	flags := cmd.PersistentFlags()
+	flags.StringVar(&config.Client.ServerAddress, "server-addr", config.Client.ServerAddress, "Directory Server API address")
+	flags.StringVar(&config.Client.AuthMode, "auth-mode", config.Client.AuthMode, "Authentication mode")
+	flags.StringVar(&config.Client.SpiffeSocketPath, "spiffe-socket-path", config.Client.SpiffeSocketPath, "Path to SPIFFE Workload API socket")
+	flags.StringVar(&config.Client.SpiffeToken, "spiffe-token", config.Client.SpiffeToken, "Path to JSON file containing SPIFFE token")
+	flags.StringVar(&config.Client.JWTAudience, "jwt-audience", config.Client.JWTAudience, "JWT audience")
+	flags.BoolVar(&config.Client.TlsSkipVerify, "tls-skip-verify", config.Client.TlsSkipVerify, "Skip TLS verification")
+	flags.StringVar(&config.Client.TlsCAFile, "tls-ca-file", config.Client.TlsCAFile, "Path to TLS CA file")
+	flags.StringVar(&config.Client.TlsCertFile, "tls-cert-file", config.Client.TlsCertFile, "Path to TLS certificate file")
+	flags.StringVar(&config.Client.TlsKeyFile, "tls-key-file", config.Client.TlsKeyFile, "Path to TLS key file")
+	flags.StringVar(&config.Client.OIDCIssuer, "oidc-issuer", config.Client.OIDCIssuer, "OIDC issuer URL")
+	flags.StringVar(&config.Client.OIDCClientID, "oidc-client-id", config.Client.OIDCClientID, "OIDC client ID")
+	flags.StringVar(&config.Client.AuthToken, "auth-token", config.Client.AuthToken, "Pre-issued Bearer token")
+
+	return cmd
+}
+
+func writeDirctlConfig(t *testing.T, configHome string, content string) {
+	t.Helper()
+
+	configPath := filepath.Join(configHome, "dirctl", "config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(configPath), 0o700))
+	require.NoError(t, os.WriteFile(configPath, []byte(content), 0o600))
 }
 
 func errorString(err error) string {

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -85,6 +85,27 @@ func TestAPICommandsStillRequireOIDCToken(t *testing.T) {
 	require.Contains(t, err.Error(), missingOIDCTokenError)
 }
 
+func TestContextCommandsDoNotRequireClientConfig(t *testing.T) {
+	resetClientEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	resetClientConfig()
+
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+	)
+
+	RootCmd.SetArgs([]string{"context", "list"})
+	RootCmd.SetContext(context.Background())
+	RootCmd.SetOut(&stdout)
+	RootCmd.SetErr(&stderr)
+
+	err := RootCmd.Execute()
+
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "No contexts configured.")
+}
+
 func TestResolveClientConfigUsesCurrentContext(t *testing.T) {
 	resetClientEnv(t)
 	configHome := t.TempDir()
@@ -274,6 +295,7 @@ func resetClientEnv(t *testing.T) {
 	}
 
 	original := make(map[string]string, len(keys))
+
 	present := make(map[string]bool, len(keys))
 	for _, key := range keys {
 		value, ok := os.LookupEnv(key)

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -10,3 +10,6 @@ import (
 // Client holds the merged CLI config (from config file, env, and flags).
 // It is populated by cmd/options.go init and updated when flags are parsed.
 var Client *client.Config = &client.DefaultConfig
+
+// Context is the per-command context override.
+var Context string

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"github.com/agntcy/dir/client"
+	"github.com/spf13/cobra"
 )
 
 // Client holds the merged CLI config (from config file, env, and flags).
@@ -13,3 +14,34 @@ var Client *client.Config = &client.DefaultConfig
 
 // Context is the per-command context override.
 var Context string
+
+// ChangedClientConfigFields returns schema field names for explicitly set client flags.
+func ChangedClientConfigFields(cmd *cobra.Command) []string {
+	//nolint:gosec // G101: These are configuration field names, not credential values.
+	flagToField := map[string]string{
+		"server-addr":        "server_address",
+		"auth-mode":          "auth_mode",
+		"spiffe-socket-path": "spiffe_socket_path",
+		"spiffe-token":       "spiffe_token",
+		"jwt-audience":       "jwt_audience",
+		"tls-skip-verify":    "tls_skip_verify",
+		"tls-ca-file":        "tls_ca_file",
+		"tls-cert-file":      "tls_cert_file",
+		"tls-key-file":       "tls_key_file",
+		"oidc-issuer":        "oidc_issuer",
+		"oidc-client-id":     "oidc_client_id",
+		"auth-token":         "auth_token",
+	}
+
+	fields := make([]string, 0, len(flagToField))
+
+	flags := cmd.Root().PersistentFlags()
+	for flagName, fieldName := range flagToField {
+		flag := flags.Lookup(flagName)
+		if flag != nil && flag.Changed {
+			fields = append(fields, fieldName)
+		}
+	}
+
+	return fields
+}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -71,6 +71,10 @@ type ResolveOptions struct {
 	// applied, including zero values. If empty, non-zero override values are
 	// applied.
 	OverrideFields []string
+
+	// SkipValidation skips required-field validation for callers that only need
+	// a subset of client config, such as auth token cache commands.
+	SkipValidation bool
 }
 
 // ResolvedContext describes which context was selected during resolution.
@@ -175,8 +179,10 @@ func Resolve(opts ResolveOptions) (*dirclient.Config, *ResolvedContext, error) {
 		return nil, nil, err
 	}
 
-	if err := validateClientConfig(cfg); err != nil {
-		return nil, nil, err
+	if !opts.SkipValidation {
+		if err := validateClientConfig(cfg); err != nil {
+			return nil, nil, err
+		}
 	}
 
 	return cfg, &ResolvedContext{

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -29,6 +29,8 @@ const (
 
 	configDirName  = "dirctl"
 	configFileName = "config.yaml"
+	configDirPerm  = 0o700
+	configFilePerm = 0o600
 )
 
 // File is the top-level reusable client context configuration file.
@@ -85,6 +87,12 @@ type ResolvedContext struct {
 type ContextSummary struct {
 	Name    string
 	Current bool
+}
+
+// ContextValidation describes the validation result for a configured context.
+type ContextValidation struct {
+	Name  string
+	Error error
 }
 
 // LoadFile loads a reusable client context config file from path.
@@ -209,6 +217,139 @@ func ListContexts(path string) ([]ContextSummary, error) {
 	}
 
 	return summaries, nil
+}
+
+// CurrentContext returns the selected context name without resolving client settings.
+func CurrentContext(path string, contextOverride string) (*ResolvedContext, error) {
+	resolvedPath, explicitPath, err := resolvePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := loadOptionalFile(resolvedPath, explicitPath)
+	if err != nil {
+		return nil, err
+	}
+
+	contextName, source := selectedContextName(ResolveOptions{Context: contextOverride}, file)
+	if contextName == "" {
+		return &ResolvedContext{
+			Source: source,
+			Path:   resolvedPath,
+		}, nil
+	}
+
+	if _, ok := file.Contexts[contextName]; !ok {
+		return nil, fmt.Errorf("unknown client context %q in %s", contextName, resolvedPath)
+	}
+
+	return &ResolvedContext{
+		Name:   contextName,
+		Source: source,
+		Path:   resolvedPath,
+	}, nil
+}
+
+// SetCurrentContext persists name as the active context.
+func SetCurrentContext(path string, name string) (*ResolvedContext, error) {
+	resolvedPath, explicitPath, err := resolvePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := loadOptionalFile(resolvedPath, explicitPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := file.Contexts[name]; !ok {
+		return nil, fmt.Errorf("unknown client context %q in %s", name, resolvedPath)
+	}
+
+	file.CurrentContext = name
+	if err := SaveFile(resolvedPath, file); err != nil {
+		return nil, err
+	}
+
+	return &ResolvedContext{
+		Name:   name,
+		Source: "current_context",
+		Path:   resolvedPath,
+	}, nil
+}
+
+// SaveFile writes a reusable client context config file.
+func SaveFile(path string, file *File) error {
+	if path == "" {
+		defaultPath, err := DefaultPath()
+		if err != nil {
+			return err
+		}
+
+		path = defaultPath
+	}
+
+	if file.Contexts == nil {
+		file.Contexts = map[string]Context{}
+	}
+
+	if err := validateContextNames(file); err != nil {
+		return fmt.Errorf("invalid client config file %s: %w", path, err)
+	}
+
+	data, err := yaml.Marshal(file)
+	if err != nil {
+		return fmt.Errorf("failed to encode client config file %s: %w", path, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), configDirPerm); err != nil {
+		return fmt.Errorf("failed to create client config directory %s: %w", filepath.Dir(path), err)
+	}
+
+	if err := os.WriteFile(path, data, configFilePerm); err != nil {
+		return fmt.Errorf("failed to write client config file %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// ValidateContexts validates stored context definitions without applying environment overrides.
+func ValidateContexts(path string, name string) ([]ContextValidation, error) {
+	resolvedPath, explicitPath, err := resolvePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := loadOptionalFile(resolvedPath, explicitPath)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(file.Contexts))
+	if name != "" {
+		if _, ok := file.Contexts[name]; !ok {
+			return nil, fmt.Errorf("unknown client context %q in %s", name, resolvedPath)
+		}
+
+		names = append(names, name)
+	} else {
+		for contextName := range file.Contexts {
+			names = append(names, contextName)
+		}
+
+		sort.Strings(names)
+	}
+
+	results := make([]ContextValidation, 0, len(names))
+	for _, contextName := range names {
+		cfg := file.Contexts[contextName].toClientConfig()
+		results = append(results, ContextValidation{
+			Name:  contextName,
+			Error: validateClientConfig(&cfg),
+		})
+	}
+
+	return results, nil
 }
 
 func resolvePath(path string) (string, bool, error) {

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -1,0 +1,485 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config loads reusable Directory client context configuration.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	dirclient "github.com/agntcy/dir/client"
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	// DefaultEnvPrefix is the default environment variable prefix for client config.
+	DefaultEnvPrefix = dirclient.DefaultEnvPrefix
+
+	// DirctlContextEnv is the dirctl-specific context selection environment variable.
+	DirctlContextEnv = "DIRCTL_CONTEXT"
+
+	// ClientContextEnv is the DIRECTORY_CLIENT-prefixed context selection environment variable.
+	ClientContextEnv = "DIRECTORY_CLIENT_CONTEXT"
+
+	configDirName  = "dirctl"
+	configFileName = "config.yaml"
+)
+
+// File is the top-level reusable client context configuration file.
+type File struct {
+	CurrentContext string             `yaml:"current_context"`
+	Contexts       map[string]Context `yaml:"contexts"`
+}
+
+// Context is a named client configuration block.
+type Context struct {
+	ServerAddress    string `yaml:"server_address"`
+	TlsSkipVerify    bool   `yaml:"tls_skip_verify"`
+	TlsCertFile      string `yaml:"tls_cert_file"`
+	TlsKeyFile       string `yaml:"tls_key_file"`
+	TlsCAFile        string `yaml:"tls_ca_file"`
+	SpiffeSocketPath string `yaml:"spiffe_socket_path"`
+	SpiffeToken      string `yaml:"spiffe_token"`
+	AuthMode         string `yaml:"auth_mode"`
+	JWTAudience      string `yaml:"jwt_audience"`
+	OIDCIssuer       string `yaml:"oidc_issuer"`
+	OIDCClientID     string `yaml:"oidc_client_id"`
+	AuthToken        string `yaml:"auth_token"`
+}
+
+// ResolveOptions controls context and client configuration resolution.
+type ResolveOptions struct {
+	// Path is the config file path. If empty, DefaultPath is used.
+	Path string
+
+	// Context is an explicit context name override.
+	Context string
+
+	// EnvPrefix is the client environment variable prefix. If empty,
+	// DefaultEnvPrefix is used.
+	EnvPrefix string
+
+	// Overrides contains explicit values, typically from CLI flags.
+	Overrides *dirclient.Config
+
+	// OverrideFields lists schema field names from Overrides that should be
+	// applied, including zero values. If empty, non-zero override values are
+	// applied.
+	OverrideFields []string
+}
+
+// ResolvedContext describes which context was selected during resolution.
+type ResolvedContext struct {
+	Name   string
+	Source string
+	Path   string
+}
+
+// ContextSummary is a list entry for a configured context.
+type ContextSummary struct {
+	Name    string
+	Current bool
+}
+
+// LoadFile loads a reusable client context config file from path.
+func LoadFile(path string) (*File, error) {
+	if path == "" {
+		defaultPath, err := DefaultPath()
+		if err != nil {
+			return nil, err
+		}
+
+		path = defaultPath
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open client config file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	decoder.KnownFields(true)
+
+	file := &File{}
+	if err := decoder.Decode(file); err != nil {
+		return nil, fmt.Errorf("failed to parse client config file %s: %w", path, err)
+	}
+
+	if file.Contexts == nil {
+		file.Contexts = map[string]Context{}
+	}
+
+	if err := validateContextNames(file); err != nil {
+		return nil, fmt.Errorf("invalid client config file %s: %w", path, err)
+	}
+
+	return file, nil
+}
+
+// DefaultPath returns the default reusable client config file path.
+func DefaultPath() (string, error) {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("failed to determine user home directory: %w", err)
+		}
+
+		configHome = filepath.Join(home, ".config")
+	}
+
+	return filepath.Join(configHome, configDirName, configFileName), nil
+}
+
+// Resolve resolves the effective Directory client config.
+func Resolve(opts ResolveOptions) (*dirclient.Config, *ResolvedContext, error) {
+	path, explicitPath, err := resolvePath(opts.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	file, err := loadOptionalFile(path, explicitPath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	contextName, source := selectedContextName(opts, file)
+	cfg := &dirclient.Config{}
+
+	if contextName != "" {
+		contextConfig, ok := file.Contexts[contextName]
+		if !ok {
+			return nil, nil, fmt.Errorf("unknown client context %q in %s", contextName, path)
+		}
+
+		*cfg = contextConfig.toClientConfig()
+	}
+
+	if err := applyEnv(cfg, envPrefix(opts.EnvPrefix)); err != nil {
+		return nil, nil, err
+	}
+
+	if err := applyOverrides(cfg, opts.Overrides, opts.OverrideFields); err != nil {
+		return nil, nil, err
+	}
+
+	if err := validateClientConfig(cfg); err != nil {
+		return nil, nil, err
+	}
+
+	return cfg, &ResolvedContext{
+		Name:   contextName,
+		Source: source,
+		Path:   path,
+	}, nil
+}
+
+// ListContexts lists configured contexts in name order.
+func ListContexts(path string) ([]ContextSummary, error) {
+	resolvedPath, explicitPath, err := resolvePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := loadOptionalFile(resolvedPath, explicitPath)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(file.Contexts))
+	for name := range file.Contexts {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	summaries := make([]ContextSummary, 0, len(names))
+	for _, name := range names {
+		summaries = append(summaries, ContextSummary{
+			Name:    name,
+			Current: name == file.CurrentContext,
+		})
+	}
+
+	return summaries, nil
+}
+
+func resolvePath(path string) (string, bool, error) {
+	if path != "" {
+		return path, true, nil
+	}
+
+	defaultPath, err := DefaultPath()
+	if err != nil {
+		return "", false, err
+	}
+
+	return defaultPath, false, nil
+}
+
+func loadOptionalFile(path string, explicitPath bool) (*File, error) {
+	file, err := LoadFile(path)
+	if err == nil {
+		return file, nil
+	}
+
+	if explicitPath || !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+
+	return &File{Contexts: map[string]Context{}}, nil
+}
+
+func selectedContextName(opts ResolveOptions, file *File) (string, string) {
+	if opts.Context != "" {
+		return opts.Context, "option"
+	}
+
+	if value, ok := os.LookupEnv(DirctlContextEnv); ok {
+		return value, "env"
+	}
+
+	if value, ok := os.LookupEnv(ClientContextEnv); ok {
+		return value, "env"
+	}
+
+	if file.CurrentContext != "" {
+		return file.CurrentContext, "current_context"
+	}
+
+	return "", "none"
+}
+
+func envPrefix(prefix string) string {
+	if prefix == "" {
+		return DefaultEnvPrefix
+	}
+
+	return prefix
+}
+
+func applyEnv(cfg *dirclient.Config, prefix string) error {
+	stringEnv := map[string]*string{
+		"server_address":     &cfg.ServerAddress,
+		"tls_cert_file":      &cfg.TlsCertFile,
+		"tls_key_file":       &cfg.TlsKeyFile,
+		"tls_ca_file":        &cfg.TlsCAFile,
+		"spiffe_socket_path": &cfg.SpiffeSocketPath,
+		"spiffe_token":       &cfg.SpiffeToken,
+		"auth_mode":          &cfg.AuthMode,
+		"jwt_audience":       &cfg.JWTAudience,
+		"oidc_issuer":        &cfg.OIDCIssuer,
+		"oidc_client_id":     &cfg.OIDCClientID,
+		"auth_token":         &cfg.AuthToken,
+	}
+
+	for key, target := range stringEnv {
+		if value, ok := os.LookupEnv(envVarName(prefix, key)); ok {
+			*target = value
+		}
+	}
+
+	if value, ok := os.LookupEnv(envVarName(prefix, "tls_skip_verify")); ok {
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid %s value %q: %w", envVarName(prefix, "tls_skip_verify"), value, err)
+		}
+
+		cfg.TlsSkipVerify = parsed
+	}
+
+	return nil
+}
+
+func applyOverrides(cfg *dirclient.Config, overrides *dirclient.Config, fields []string) error {
+	if overrides == nil {
+		return nil
+	}
+
+	if len(fields) == 0 {
+		applyNonZeroOverrides(cfg, overrides)
+
+		return nil
+	}
+
+	for _, field := range fields {
+		if err := applyOverrideField(cfg, overrides, field); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func applyNonZeroOverrides(cfg *dirclient.Config, overrides *dirclient.Config) {
+	if overrides.ServerAddress != "" {
+		cfg.ServerAddress = overrides.ServerAddress
+	}
+
+	if overrides.TlsSkipVerify {
+		cfg.TlsSkipVerify = overrides.TlsSkipVerify
+	}
+
+	if overrides.TlsCertFile != "" {
+		cfg.TlsCertFile = overrides.TlsCertFile
+	}
+
+	if overrides.TlsKeyFile != "" {
+		cfg.TlsKeyFile = overrides.TlsKeyFile
+	}
+
+	if overrides.TlsCAFile != "" {
+		cfg.TlsCAFile = overrides.TlsCAFile
+	}
+
+	if overrides.SpiffeSocketPath != "" {
+		cfg.SpiffeSocketPath = overrides.SpiffeSocketPath
+	}
+
+	if overrides.SpiffeToken != "" {
+		cfg.SpiffeToken = overrides.SpiffeToken
+	}
+
+	if overrides.AuthMode != "" {
+		cfg.AuthMode = overrides.AuthMode
+	}
+
+	if overrides.JWTAudience != "" {
+		cfg.JWTAudience = overrides.JWTAudience
+	}
+
+	if overrides.OIDCIssuer != "" {
+		cfg.OIDCIssuer = overrides.OIDCIssuer
+	}
+
+	if overrides.OIDCClientID != "" {
+		cfg.OIDCClientID = overrides.OIDCClientID
+	}
+
+	if overrides.AuthToken != "" {
+		cfg.AuthToken = overrides.AuthToken
+	}
+}
+
+func applyOverrideField(cfg *dirclient.Config, overrides *dirclient.Config, field string) error {
+	switch field {
+	case "server_address":
+		cfg.ServerAddress = overrides.ServerAddress
+	case "tls_skip_verify":
+		cfg.TlsSkipVerify = overrides.TlsSkipVerify
+	case "tls_cert_file":
+		cfg.TlsCertFile = overrides.TlsCertFile
+	case "tls_key_file":
+		cfg.TlsKeyFile = overrides.TlsKeyFile
+	case "tls_ca_file":
+		cfg.TlsCAFile = overrides.TlsCAFile
+	case "spiffe_socket_path":
+		cfg.SpiffeSocketPath = overrides.SpiffeSocketPath
+	case "spiffe_token":
+		cfg.SpiffeToken = overrides.SpiffeToken
+	case "auth_mode":
+		cfg.AuthMode = overrides.AuthMode
+	case "jwt_audience":
+		cfg.JWTAudience = overrides.JWTAudience
+	case "oidc_issuer":
+		cfg.OIDCIssuer = overrides.OIDCIssuer
+	case "oidc_client_id":
+		cfg.OIDCClientID = overrides.OIDCClientID
+	case "auth_token":
+		cfg.AuthToken = overrides.AuthToken
+	default:
+		return fmt.Errorf("unknown override field %q", field)
+	}
+
+	return nil
+}
+
+//nolint:cyclop // Keep auth-mode validation in one place for clearer, mode-specific errors.
+func validateClientConfig(cfg *dirclient.Config) error {
+	if strings.TrimSpace(cfg.ServerAddress) == "" {
+		return errors.New("server_address is required; set a context, --server-addr, or DIRECTORY_CLIENT_SERVER_ADDRESS")
+	}
+
+	switch cfg.AuthMode {
+	case "", "insecure", "none":
+		return nil
+	case "x509":
+		if cfg.SpiffeSocketPath == "" {
+			return errors.New("spiffe_socket_path is required for x509 authentication")
+		}
+	case "jwt":
+		if cfg.SpiffeSocketPath == "" {
+			return errors.New("spiffe_socket_path is required for jwt authentication")
+		}
+
+		if cfg.JWTAudience == "" {
+			return errors.New("jwt_audience is required for jwt authentication")
+		}
+	case "token":
+		if cfg.SpiffeToken == "" {
+			return errors.New("spiffe_token is required for token authentication")
+		}
+	case "tls":
+		if cfg.TlsCAFile == "" || cfg.TlsCertFile == "" || cfg.TlsKeyFile == "" {
+			return errors.New("tls_ca_file, tls_cert_file, and tls_key_file are required for tls authentication")
+		}
+	case "oidc":
+		if cfg.AuthToken == "" && cfg.OIDCIssuer == "" {
+			return errors.New("oidc_issuer is required for oidc authentication unless auth_token is set")
+		}
+	default:
+		return fmt.Errorf("unsupported auth_mode %q", cfg.AuthMode)
+	}
+
+	return nil
+}
+
+func validateContextNames(file *File) error {
+	for name := range file.Contexts {
+		if strings.TrimSpace(name) == "" {
+			return errors.New("context name must not be empty")
+		}
+
+		if strings.ContainsAny(name, `/\`) {
+			return fmt.Errorf("context name %q must not contain path separators", name)
+		}
+	}
+
+	if file.CurrentContext != "" {
+		if _, ok := file.Contexts[file.CurrentContext]; !ok {
+			return fmt.Errorf("current_context %q does not match a configured context", file.CurrentContext)
+		}
+	}
+
+	return nil
+}
+
+func envVarName(prefix string, key string) string {
+	replaced := strings.NewReplacer(".", "_", "-", "_").Replace(key)
+
+	return prefix + "_" + strings.ToUpper(replaced)
+}
+
+func (c Context) toClientConfig() dirclient.Config {
+	return dirclient.Config{
+		ServerAddress:    c.ServerAddress,
+		TlsSkipVerify:    c.TlsSkipVerify,
+		TlsCertFile:      c.TlsCertFile,
+		TlsKeyFile:       c.TlsKeyFile,
+		TlsCAFile:        c.TlsCAFile,
+		SpiffeSocketPath: c.SpiffeSocketPath,
+		SpiffeToken:      c.SpiffeToken,
+		AuthMode:         c.AuthMode,
+		JWTAudience:      c.JWTAudience,
+		OIDCIssuer:       c.OIDCIssuer,
+		OIDCClientID:     c.OIDCClientID,
+		AuthToken:        c.AuthToken,
+	}
+}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -21,9 +21,6 @@ const (
 	// DefaultEnvPrefix is the default environment variable prefix for client config.
 	DefaultEnvPrefix = dirclient.DefaultEnvPrefix
 
-	// DirctlContextEnv is the dirctl-specific context selection environment variable.
-	DirctlContextEnv = "DIRCTL_CONTEXT"
-
 	// ClientContextEnv is the DIRECTORY_CLIENT-prefixed context selection environment variable.
 	ClientContextEnv = "DIRECTORY_CLIENT_CONTEXT"
 
@@ -219,8 +216,8 @@ func ListContexts(path string) ([]ContextSummary, error) {
 	return summaries, nil
 }
 
-// CurrentContext returns the selected context name without resolving client settings.
-func CurrentContext(path string, contextOverride string) (*ResolvedContext, error) {
+// CurrentContext returns the persisted current_context without resolving client settings.
+func CurrentContext(path string) (*ResolvedContext, error) {
 	resolvedPath, explicitPath, err := resolvePath(path)
 	if err != nil {
 		return nil, err
@@ -231,21 +228,20 @@ func CurrentContext(path string, contextOverride string) (*ResolvedContext, erro
 		return nil, err
 	}
 
-	contextName, source := selectedContextName(ResolveOptions{Context: contextOverride}, file)
-	if contextName == "" {
+	if file.CurrentContext == "" {
 		return &ResolvedContext{
-			Source: source,
+			Source: "none",
 			Path:   resolvedPath,
 		}, nil
 	}
 
-	if _, ok := file.Contexts[contextName]; !ok {
-		return nil, fmt.Errorf("unknown client context %q in %s", contextName, resolvedPath)
+	if _, ok := file.Contexts[file.CurrentContext]; !ok {
+		return nil, fmt.Errorf("unknown client context %q in %s", file.CurrentContext, resolvedPath)
 	}
 
 	return &ResolvedContext{
-		Name:   contextName,
-		Source: source,
+		Name:   file.CurrentContext,
+		Source: "current_context",
 		Path:   resolvedPath,
 	}, nil
 }
@@ -381,10 +377,6 @@ func loadOptionalFile(path string, explicitPath bool) (*File, error) {
 func selectedContextName(opts ResolveOptions, file *File) (string, string) {
 	if opts.Context != "" {
 		return opts.Context, "option"
-	}
-
-	if value, ok := os.LookupEnv(DirctlContextEnv); ok {
-		return value, "env"
 	}
 
 	if value, ok := os.LookupEnv(ClientContextEnv); ok {

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -133,6 +133,67 @@ contexts:
 	})
 }
 
+func TestSetCurrentContext(t *testing.T) {
+	path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+  prod:
+    server_address: prod.gateway.example.com:443
+`)
+
+	resolved, err := SetCurrentContext(path, "prod")
+
+	require.NoError(t, err)
+	assert.Equal(t, "prod", resolved.Name)
+	assert.Equal(t, "current_context", resolved.Source)
+
+	file, err := LoadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", file.CurrentContext)
+}
+
+func TestCurrentContext(t *testing.T) {
+	resetClientEnv(t)
+	path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+  prod:
+    server_address: prod.gateway.example.com:443
+`)
+
+	t.Setenv(DirctlContextEnv, "prod")
+
+	current, err := CurrentContext(path, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, "prod", current.Name)
+	assert.Equal(t, "env", current.Source)
+}
+
+func TestValidateContexts(t *testing.T) {
+	path := writeConfig(t, `
+contexts:
+  valid:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+  invalid:
+    auth_mode: insecure
+`)
+
+	results, err := ValidateContexts(path, "")
+
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "invalid", results[0].Name)
+	require.ErrorContains(t, results[0].Error, "server_address is required")
+	assert.Equal(t, "valid", results[1].Name)
+	assert.NoError(t, results[1].Error)
+}
+
 func TestResolve(t *testing.T) {
 	t.Run("resolves explicit context", func(t *testing.T) {
 		resetClientEnv(t)

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -1,0 +1,422 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	dirclient "github.com/agntcy/dir/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultPath(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+	path, err := DefaultPath()
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "dirctl", "config.yaml"), path)
+}
+
+func TestLoadFile(t *testing.T) {
+	t.Run("loads schema", func(t *testing.T) {
+		path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://dev.idp.example.com
+    oidc_client_id: dirctl
+`)
+
+		file, err := LoadFile(path)
+
+		require.NoError(t, err)
+		assert.Equal(t, "dev", file.CurrentContext)
+		require.Contains(t, file.Contexts, "dev")
+		assert.Equal(t, "dev.gateway.example.com:443", file.Contexts["dev"].ServerAddress)
+	})
+
+	t.Run("rejects unknown fields", func(t *testing.T) {
+		path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    unexpected_field: value
+`)
+
+		file, err := LoadFile(path)
+
+		require.Error(t, err)
+		assert.Nil(t, file)
+		assert.Contains(t, err.Error(), "unexpected_field")
+	})
+
+	t.Run("rejects current context that is not configured", func(t *testing.T) {
+		path := writeConfig(t, `
+current_context: prod
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+`)
+
+		file, err := LoadFile(path)
+
+		require.Error(t, err)
+		assert.Nil(t, file)
+		assert.Contains(t, err.Error(), `current_context "prod"`)
+	})
+
+	t.Run("rejects empty context name", func(t *testing.T) {
+		path := writeConfig(t, `
+contexts:
+  "":
+    server_address: dev.gateway.example.com:443
+`)
+
+		file, err := LoadFile(path)
+
+		require.Error(t, err)
+		assert.Nil(t, file)
+		assert.Contains(t, err.Error(), "context name must not be empty")
+	})
+
+	t.Run("rejects path separators in context name", func(t *testing.T) {
+		path := writeConfig(t, `
+contexts:
+  dev/prod:
+    server_address: dev.gateway.example.com:443
+`)
+
+		file, err := LoadFile(path)
+
+		require.Error(t, err)
+		assert.Nil(t, file)
+		assert.Contains(t, err.Error(), "must not contain path separators")
+	})
+}
+
+func TestListContexts(t *testing.T) {
+	t.Run("lists configured contexts", func(t *testing.T) {
+		path := writeConfig(t, `
+current_context: prod
+contexts:
+  prod:
+    server_address: prod.gateway.example.com:443
+  dev:
+    server_address: dev.gateway.example.com:443
+`)
+
+		contexts, err := ListContexts(path)
+
+		require.NoError(t, err)
+		assert.Equal(t, []ContextSummary{
+			{Name: "dev"},
+			{Name: "prod", Current: true},
+		}, contexts)
+	})
+
+	t.Run("returns empty list when default config is missing", func(t *testing.T) {
+		resetClientEnv(t)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+		contexts, err := ListContexts("")
+
+		require.NoError(t, err)
+		assert.Empty(t, contexts)
+	})
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("resolves explicit context", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+current_context: prod
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://dev.idp.example.com
+    oidc_client_id: dirctl
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://prod.idp.example.com
+    oidc_client_id: dirctl
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{
+			Path:    path,
+			Context: "dev",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "dev.gateway.example.com:443", cfg.ServerAddress)
+		assert.Equal(t, "oidc", cfg.AuthMode)
+		assert.Equal(t, "https://dev.idp.example.com", cfg.OIDCIssuer)
+		assert.Equal(t, "dev", resolved.Name)
+		assert.Equal(t, "option", resolved.Source)
+		assert.Equal(t, path, resolved.Path)
+	})
+
+	t.Run("resolves current context", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+current_context: prod
+contexts:
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: insecure
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: path})
+
+		require.NoError(t, err)
+		assert.Equal(t, "prod.gateway.example.com:443", cfg.ServerAddress)
+		assert.Equal(t, "prod", resolved.Name)
+		assert.Equal(t, "current_context", resolved.Source)
+	})
+
+	t.Run("environment overrides context", func(t *testing.T) {
+		resetClientEnv(t)
+		t.Setenv("DIRECTORY_CLIENT_SERVER_ADDRESS", "env.gateway.example.com:443")
+		t.Setenv("DIRECTORY_CLIENT_AUTH_MODE", "insecure")
+
+		path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://dev.idp.example.com
+    oidc_client_id: dirctl
+`)
+
+		cfg, _, err := Resolve(ResolveOptions{Path: path})
+
+		require.NoError(t, err)
+		assert.Equal(t, "env.gateway.example.com:443", cfg.ServerAddress)
+		assert.Equal(t, "insecure", cfg.AuthMode)
+	})
+
+	t.Run("context environment selects context", func(t *testing.T) {
+		resetClientEnv(t)
+		t.Setenv(DirctlContextEnv, "dev")
+
+		path := writeConfig(t, `
+current_context: prod
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: insecure
+  prod:
+    server_address: prod.gateway.example.com:443
+    auth_mode: insecure
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: path})
+
+		require.NoError(t, err)
+		assert.Equal(t, "dev.gateway.example.com:443", cfg.ServerAddress)
+		assert.Equal(t, "dev", resolved.Name)
+		assert.Equal(t, "env", resolved.Source)
+	})
+
+	t.Run("works without config file when env provides required values", func(t *testing.T) {
+		resetClientEnv(t)
+		t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+		t.Setenv("DIRECTORY_CLIENT_SERVER_ADDRESS", "env.gateway.example.com:443")
+		t.Setenv("DIRECTORY_CLIENT_AUTH_MODE", "insecure")
+
+		cfg, resolved, err := Resolve(ResolveOptions{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "env.gateway.example.com:443", cfg.ServerAddress)
+		assert.Empty(t, resolved.Name)
+		assert.Equal(t, "none", resolved.Source)
+	})
+
+	t.Run("explicit overrides win", func(t *testing.T) {
+		resetClientEnv(t)
+		t.Setenv("DIRECTORY_CLIENT_SERVER_ADDRESS", "env.gateway.example.com:443")
+
+		path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://dev.idp.example.com
+    oidc_client_id: dirctl
+`)
+
+		cfg, _, err := Resolve(ResolveOptions{
+			Path: path,
+			Overrides: &dirclient.Config{
+				ServerAddress: "flag.gateway.example.com:443",
+				AuthMode:      "insecure",
+			},
+			OverrideFields: []string{"server_address", "auth_mode"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "flag.gateway.example.com:443", cfg.ServerAddress)
+		assert.Equal(t, "insecure", cfg.AuthMode)
+	})
+}
+
+func TestResolveErrors(t *testing.T) {
+	t.Run("explicit missing file errors", func(t *testing.T) {
+		resetClientEnv(t)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: filepath.Join(t.TempDir(), "missing.yaml")})
+
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Nil(t, resolved)
+		assert.Contains(t, err.Error(), "failed to open client config file")
+	})
+
+	t.Run("unknown context errors", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: path, Context: "prod"})
+
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Nil(t, resolved)
+		assert.Contains(t, err.Error(), `unknown client context "prod"`)
+	})
+
+	t.Run("missing server address errors", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+contexts:
+  dev:
+    auth_mode: insecure
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: path, Context: "dev"})
+
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Nil(t, resolved)
+		assert.Contains(t, err.Error(), "server_address is required")
+	})
+
+	t.Run("invalid auth mode errors", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: invalid
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: path, Context: "dev"})
+
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Nil(t, resolved)
+		assert.Contains(t, err.Error(), `unsupported auth_mode "invalid"`)
+	})
+
+	t.Run("oidc requires issuer without token", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: path, Context: "dev"})
+
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+		assert.Nil(t, resolved)
+		assert.Contains(t, err.Error(), "oidc_issuer is required")
+	})
+
+	t.Run("oidc allows issuer without client id for cached token usage", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://dev.idp.example.com
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{Path: path, Context: "dev"})
+
+		require.NoError(t, err)
+		assert.Equal(t, "oidc", cfg.AuthMode)
+		assert.Equal(t, "https://dev.idp.example.com", cfg.OIDCIssuer)
+		assert.Empty(t, cfg.OIDCClientID)
+		assert.Equal(t, "dev", resolved.Name)
+	})
+}
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+func resetClientEnv(t *testing.T) {
+	t.Helper()
+
+	keys := []string{
+		DirctlContextEnv,
+		ClientContextEnv,
+		"DIRECTORY_CLIENT_SERVER_ADDRESS",
+		"DIRECTORY_CLIENT_TLS_SKIP_VERIFY",
+		"DIRECTORY_CLIENT_TLS_CERT_FILE",
+		"DIRECTORY_CLIENT_TLS_KEY_FILE",
+		"DIRECTORY_CLIENT_TLS_CA_FILE",
+		"DIRECTORY_CLIENT_SPIFFE_SOCKET_PATH",
+		"DIRECTORY_CLIENT_SPIFFE_TOKEN",
+		"DIRECTORY_CLIENT_AUTH_MODE",
+		"DIRECTORY_CLIENT_JWT_AUDIENCE",
+		"DIRECTORY_CLIENT_OIDC_ISSUER",
+		"DIRECTORY_CLIENT_OIDC_CLIENT_ID",
+		"DIRECTORY_CLIENT_AUTH_TOKEN",
+	}
+
+	original := make(map[string]string, len(keys))
+
+	present := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		value, ok := os.LookupEnv(key)
+		original[key] = value
+		present[key] = ok
+		require.NoError(t, os.Unsetenv(key)) //nolint:usetesting // Need truly unset variables.
+	}
+
+	t.Cleanup(func() {
+		for _, key := range keys {
+			if !present[key] {
+				_ = os.Unsetenv(key) //nolint:usetesting // Restoring process env after manual unset.
+
+				continue
+			}
+
+			_ = os.Setenv(key, original[key]) //nolint:usetesting // Restoring process env after manual unset.
+		}
+	})
+}

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -165,13 +165,13 @@ contexts:
     server_address: prod.gateway.example.com:443
 `)
 
-	t.Setenv(DirctlContextEnv, "prod")
+	t.Setenv(ClientContextEnv, "prod")
 
-	current, err := CurrentContext(path, "")
+	current, err := CurrentContext(path)
 
 	require.NoError(t, err)
-	assert.Equal(t, "prod", current.Name)
-	assert.Equal(t, "env", current.Source)
+	assert.Equal(t, "dev", current.Name)
+	assert.Equal(t, "current_context", current.Source)
 }
 
 func TestValidateContexts(t *testing.T) {
@@ -268,7 +268,7 @@ contexts:
 
 	t.Run("context environment selects context", func(t *testing.T) {
 		resetClientEnv(t)
-		t.Setenv(DirctlContextEnv, "dev")
+		t.Setenv(ClientContextEnv, "dev")
 
 		path := writeConfig(t, `
 current_context: prod
@@ -443,7 +443,6 @@ func resetClientEnv(t *testing.T) {
 	t.Helper()
 
 	keys := []string{
-		DirctlContextEnv,
 		ClientContextEnv,
 		"DIRECTORY_CLIENT_SERVER_ADDRESS",
 		"DIRECTORY_CLIENT_TLS_SKIP_VERIFY",

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -330,6 +330,40 @@ contexts:
 		assert.Equal(t, "flag.gateway.example.com:443", cfg.ServerAddress)
 		assert.Equal(t, "insecure", cfg.AuthMode)
 	})
+
+	t.Run("resolves tls and spiffe fields", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+contexts:
+  secure:
+    server_address: secure.gateway.example.com:443
+    auth_mode: jwt
+    jwt_audience: directory
+    spiffe_socket_path: /tmp/spire-agent.sock
+    spiffe_token: spiffe-jwt
+    tls_skip_verify: true
+    tls_ca_file: /tmp/ca.pem
+    tls_cert_file: /tmp/client.pem
+    tls_key_file: /tmp/client-key.pem
+`)
+
+		cfg, resolved, err := Resolve(ResolveOptions{
+			Path:    path,
+			Context: "secure",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "secure", resolved.Name)
+		assert.Equal(t, "secure.gateway.example.com:443", cfg.ServerAddress)
+		assert.Equal(t, "jwt", cfg.AuthMode)
+		assert.Equal(t, "directory", cfg.JWTAudience)
+		assert.Equal(t, "/tmp/spire-agent.sock", cfg.SpiffeSocketPath)
+		assert.Equal(t, "spiffe-jwt", cfg.SpiffeToken)
+		assert.True(t, cfg.TlsSkipVerify)
+		assert.Equal(t, "/tmp/ca.pem", cfg.TlsCAFile)
+		assert.Equal(t, "/tmp/client.pem", cfg.TlsCertFile)
+		assert.Equal(t, "/tmp/client-key.pem", cfg.TlsKeyFile)
+	})
 }
 
 func TestResolveErrors(t *testing.T) {


### PR DESCRIPTION
Closes #1158

## Context CLI Summary

This PR adds a `dirctl context` command group for inspecting and switching reusable client configuration profiles:

- `dirctl context list` lists configured contexts and marks the persisted `current_context`.
- `dirctl context current` prints the persisted current context, with `--quiet` and `--json` variants for prompt/status integrations.
- `dirctl context set <name>` persists a configured context as the active default.
- `dirctl context show [name]` displays the effective resolved client configuration with sensitive values redacted.
- `dirctl context validate [name]` validates one or all configured contexts and reports actionable errors.

Contexts are selected by `--context`, `DIRECTORY_CLIENT_CONTEXT`, or the persisted `current_context`, and are resolved through the shared client config package for CLI and SDK reuse.

## Default Config Path

The default client config path is:

```text
$XDG_CONFIG_HOME/dirctl/config.yaml
```

If `XDG_CONFIG_HOME` is not set, the path falls back to:

```text
~/.config/dirctl/config.yaml
```

## Config Schema

The config file contains a persisted current context and a map of named contexts:

```yaml
current_context: <context-name>
contexts:
  <context-name>:
    server_address: <host:port>
    auth_mode: <insecure|none|jwt|x509|token|tls|oidc>
    spiffe_socket_path: <path>
    spiffe_token: <token>
    jwt_audience: <audience>
    tls_skip_verify: <true|false>
    tls_ca_file: <path>
    tls_cert_file: <path>
    tls_key_file: <path>
    oidc_issuer: <issuer-url>
    oidc_client_id: <client-id>
    auth_token: <bearer-token>
```

Only fields required for the selected auth mode need to be set. Sensitive values such as `auth_token` and `spiffe_token` are redacted by `dirctl context show`.

## Example Config

```yaml
current_context: dev
contexts:
  dev:
    server_address: dev.gateway.example.com:443
    auth_mode: oidc
    oidc_issuer: https://dev.idp.example.com
    oidc_client_id: dirctl

  prod:
    server_address: prod.gateway.example.com:443
    auth_mode: oidc
    oidc_issuer: https://prod.idp.example.com
    oidc_client_id: dirctl

  daemon:
    server_address: localhost:8888
    auth_mode: insecure
```