### PR TITLE
refactor(dir/reconciler): enhance credential negotiation by introducing client config builder from context

### DIFF
--- a/reconciler/tasks/regsync/credentials.go
+++ b/reconciler/tasks/regsync/credentials.go
@@ -5,10 +5,15 @@ package regsync
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
 
 	storev1 "github.com/agntcy/dir/api/store/v1"
 	"github.com/agntcy/dir/client"
+	clientconfig "github.com/agntcy/dir/client/config"
 	authnconfig "github.com/agntcy/dir/server/authn/config"
 )
 
@@ -39,19 +44,9 @@ func (r *CredentialsResult) FullRepositoryURL() string {
 
 // NegotiateCredentials negotiates registry credentials with a remote Directory node.
 func NegotiateCredentials(ctx context.Context, remoteDirectoryURL string, authnConfig authnconfig.Config) (*CredentialsResult, error) {
-	// Build client config based on authn settings
-	clientConfig := &client.Config{
-		ServerAddress: remoteDirectoryURL,
-		AuthMode:      "insecure",
-	}
-
-	if authnConfig.Enabled {
-		clientConfig.AuthMode = string(authnConfig.Mode)
-		clientConfig.SpiffeSocketPath = authnConfig.SocketPath
-
-		if len(authnConfig.Audiences) > 0 {
-			clientConfig.JWTAudience = authnConfig.Audiences[0]
-		}
+	clientConfig, err := buildClientConfigForRemote(remoteDirectoryURL, authnConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build client config for %s: %w", remoteDirectoryURL, err)
 	}
 
 	dirClient, err := client.New(ctx, client.WithConfig(clientConfig))
@@ -85,4 +80,110 @@ func NegotiateCredentials(ctx context.Context, remoteDirectoryURL string, authnC
 			Insecure: resp.GetInsecure(),
 		},
 	}, nil
+}
+
+// buildClientConfigForRemote prepares the client.Config used to talk to a
+// remote Directory node.
+func buildClientConfigForRemote(remoteDirectoryURL string, authnConfig authnconfig.Config) (*client.Config, error) {
+	contextName, err := resolveContextByServerAddress(remoteDirectoryURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if contextName != "" {
+		cfg, _, err := clientconfig.Resolve(clientconfig.ResolveOptions{
+			Context:        contextName,
+			SkipValidation: true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve client context %q: %w", contextName, err)
+		}
+
+		logger.Info("Using dirctl client context for remote directory", "context", contextName, "remote_directory", remoteDirectoryURL, "auth_mode", cfg.AuthMode)
+
+		return cfg, nil
+	}
+
+	cfg := &client.Config{
+		ServerAddress: remoteDirectoryURL,
+		AuthMode:      "insecure",
+	}
+
+	if authnConfig.Enabled {
+		cfg.AuthMode = string(authnConfig.Mode)
+		cfg.SpiffeSocketPath = authnConfig.SocketPath
+
+		if len(authnConfig.Audiences) > 0 {
+			cfg.JWTAudience = authnConfig.Audiences[0]
+		}
+	}
+
+	return cfg, nil
+}
+
+// resolveContextByServerAddress returns the name of the dirctl client context
+// whose server_address matches the provided value.
+func resolveContextByServerAddress(serverAddress string) (string, error) {
+	file, err := clientconfig.LoadFile("")
+	if err != nil {
+		// A missing config file is a valid setup (e.g. headless daemons),
+		// so treat it the same as "no matching context".
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("failed to load dirctl client config: %w", err)
+	}
+
+	needle := canonicalServerAddress(serverAddress)
+
+	var matches []string
+
+	for name, ctx := range file.Contexts {
+		if canonicalServerAddress(ctx.ServerAddress) == needle {
+			matches = append(matches, name)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		return matches[0], nil
+	default:
+		sort.Strings(matches)
+
+		return "", fmt.Errorf("multiple client contexts match server_address %q: %v", serverAddress, matches)
+	}
+}
+
+// canonicalServerAddress normalizes a Directory server address for comparison.
+func canonicalServerAddress(s string) string {
+	s = strings.TrimSpace(s)
+
+	scheme := ""
+
+	switch {
+	case strings.HasPrefix(s, "https://"):
+		scheme = "https"
+		s = strings.TrimPrefix(s, "https://")
+	case strings.HasPrefix(s, "http://"):
+		scheme = "http"
+		s = strings.TrimPrefix(s, "http://")
+	}
+
+	if i := strings.IndexAny(s, "/?#"); i >= 0 {
+		s = s[:i]
+	}
+
+	if scheme != "" && !strings.Contains(s, ":") {
+		switch scheme {
+		case "https":
+			s += ":443"
+		case "http":
+			s += ":80"
+		}
+	}
+
+	return s
 }

--- a/reconciler/tasks/regsync/credentials.go
+++ b/reconciler/tasks/regsync/credentials.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	storev1 "github.com/agntcy/dir/api/store/v1"
@@ -145,16 +144,16 @@ func resolveContextByServerAddress(serverAddress string) (string, error) {
 		}
 	}
 
-	switch len(matches) {
-	case 0:
+	if len(matches) == 0 {
 		return "", nil
-	case 1:
-		return matches[0], nil
-	default:
-		sort.Strings(matches)
-
-		return "", fmt.Errorf("multiple client contexts match server_address %q: %v", serverAddress, matches)
 	}
+
+	if len(matches) > 1 {
+		logger.Debug("Multiple dirctl client contexts match server_address; using first",
+			"server_address", serverAddress, "selected", matches[0], "candidates", matches)
+	}
+
+	return matches[0], nil
 }
 
 // canonicalServerAddress normalizes a Directory server address for comparison.

--- a/reconciler/tasks/regsync/credentials_test.go
+++ b/reconciler/tasks/regsync/credentials_test.go
@@ -38,119 +38,145 @@ func TestCanonicalServerAddress(t *testing.T) {
 }
 
 func TestResolveContextByServerAddress(t *testing.T) {
-	t.Run("missing config returns empty", func(t *testing.T) {
-		withDirctlConfig(t, "")
-
-		name, err := resolveContextByServerAddress("https://dev.gateway.example.com")
-
-		require.NoError(t, err)
-		assert.Empty(t, name)
-	})
-
-	t.Run("no match returns empty", func(t *testing.T) {
-		withDirctlConfig(t, `
+	tests := []struct {
+		name   string
+		config string
+		in     string
+		want   string
+	}{
+		{
+			name:   "missing config returns empty",
+			config: "",
+			in:     "https://dev.gateway.example.com",
+			want:   "",
+		},
+		{
+			name: "no match returns empty",
+			config: `
 contexts:
   dev:
     server_address: dev.gateway.example.com:443
-`)
-
-		name, err := resolveContextByServerAddress("https://other.example.com")
-
-		require.NoError(t, err)
-		assert.Empty(t, name)
-	})
-
-	t.Run("exact match", func(t *testing.T) {
-		withDirctlConfig(t, `
+`,
+			in:   "https://other.example.com",
+			want: "",
+		},
+		{
+			name: "exact match",
+			config: `
 contexts:
   dev:
     server_address: https://dev.gateway.example.com
   prod:
     server_address: prod.gateway.example.com:443
-`)
-
-		name, err := resolveContextByServerAddress("https://dev.gateway.example.com")
-
-		require.NoError(t, err)
-		assert.Equal(t, "dev", name)
-	})
-
-	t.Run("scheme-insensitive match against host:port", func(t *testing.T) {
-		withDirctlConfig(t, `
+`,
+			in:   "https://dev.gateway.example.com",
+			want: "dev",
+		},
+		{
+			name: "scheme-insensitive match against host:port",
+			config: `
 contexts:
   dev:
     server_address: dev.gateway.example.com:443
-`)
-
-		name, err := resolveContextByServerAddress("https://dev.gateway.example.com/")
-
-		require.NoError(t, err)
-		assert.Equal(t, "dev", name)
-	})
-
-	t.Run("multiple matches return error", func(t *testing.T) {
-		withDirctlConfig(t, `
+`,
+			in:   "https://dev.gateway.example.com/",
+			want: "dev",
+		},
+		{
+			name: "multiple matches default to first sorted name",
+			config: `
 contexts:
   dev:
     server_address: https://dev.gateway.example.com
   dev-alias:
     server_address: dev.gateway.example.com:443
-`)
+`,
+			in:   "https://dev.gateway.example.com",
+			want: "dev",
+		},
+	}
 
-		name, err := resolveContextByServerAddress("https://dev.gateway.example.com")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withDirctlConfig(t, tt.config)
 
-		require.Error(t, err)
-		assert.Empty(t, name)
-		assert.Contains(t, err.Error(), "multiple client contexts")
-	})
+			got, err := resolveContextByServerAddress(tt.in)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestBuildClientConfigForRemote(t *testing.T) {
-	t.Run("no matching context falls back to insecure", func(t *testing.T) {
-		withDirctlConfig(t, "")
-
-		cfg, err := buildClientConfigForRemote("http://localhost:8888", authnconfig.Config{})
-
-		require.NoError(t, err)
-		assert.Equal(t, "http://localhost:8888", cfg.ServerAddress)
-		assert.Equal(t, "insecure", cfg.AuthMode)
-	})
-
-	t.Run("no matching context honours authn config", func(t *testing.T) {
-		withDirctlConfig(t, "")
-
-		cfg, err := buildClientConfigForRemote("http://localhost:8888", authnconfig.Config{
-			Enabled:    true,
-			Mode:       authnconfig.AuthModeJWT,
-			SocketPath: "/run/spire/agent.sock",
-			Audiences:  []string{"directory"},
-		})
-
-		require.NoError(t, err)
-		assert.Equal(t, "jwt", cfg.AuthMode)
-		assert.Equal(t, "/run/spire/agent.sock", cfg.SpiffeSocketPath)
-		assert.Equal(t, "directory", cfg.JWTAudience)
-	})
-
-	t.Run("matching context overrides authn config", func(t *testing.T) {
-		withDirctlConfig(t, `
+	tests := []struct {
+		name        string
+		config      string
+		remote      string
+		authn       authnconfig.Config
+		wantAddress string
+		wantMode    string
+		wantToken   string
+		wantSocket  string
+		wantAud     string
+	}{
+		{
+			name:        "no matching context falls back to insecure",
+			config:      "",
+			remote:      "http://localhost:8888",
+			authn:       authnconfig.Config{},
+			wantAddress: "http://localhost:8888",
+			wantMode:    "insecure",
+		},
+		{
+			name:   "no matching context honours authn config",
+			config: "",
+			remote: "http://localhost:8888",
+			authn: authnconfig.Config{
+				Enabled:    true,
+				Mode:       authnconfig.AuthModeJWT,
+				SocketPath: "/run/spire/agent.sock",
+				Audiences:  []string{"directory"},
+			},
+			wantAddress: "http://localhost:8888",
+			wantMode:    "jwt",
+			wantSocket:  "/run/spire/agent.sock",
+			wantAud:     "directory",
+		},
+		{
+			name: "matching context overrides authn config",
+			config: `
 contexts:
   remote:
     server_address: dev.gateway.example.com:443
     auth_mode: oidc
     auth_token: cached-token
-`)
+`,
+			remote: "https://dev.gateway.example.com",
+			authn: authnconfig.Config{
+				Enabled: true,
+				Mode:    authnconfig.AuthModeX509,
+			},
+			wantAddress: "dev.gateway.example.com:443",
+			wantMode:    "oidc",
+			wantToken:   "cached-token",
+		},
+	}
 
-		cfg, err := buildClientConfigForRemote("https://dev.gateway.example.com", authnconfig.Config{
-			Enabled: true,
-			Mode:    authnconfig.AuthModeX509,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withDirctlConfig(t, tt.config)
+
+			cfg, err := buildClientConfigForRemote(tt.remote, tt.authn)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAddress, cfg.ServerAddress)
+			assert.Equal(t, tt.wantMode, cfg.AuthMode)
+			assert.Equal(t, tt.wantToken, cfg.AuthToken)
+			assert.Equal(t, tt.wantSocket, cfg.SpiffeSocketPath)
+			assert.Equal(t, tt.wantAud, cfg.JWTAudience)
 		})
-
-		require.NoError(t, err)
-		assert.Equal(t, "dev.gateway.example.com:443", cfg.ServerAddress)
-		assert.Equal(t, "oidc", cfg.AuthMode)
-		assert.Equal(t, "cached-token", cfg.AuthToken)
-	})
+	}
 }
 
 // withDirctlConfig points dirctl's default config path to a temp directory.

--- a/reconciler/tasks/regsync/credentials_test.go
+++ b/reconciler/tasks/regsync/credentials_test.go
@@ -1,0 +1,175 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package regsync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	authnconfig "github.com/agntcy/dir/server/authn/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalServerAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"plain host:port", "localhost:8888", "localhost:8888"},
+		{"https url adds default port", "https://dev.gateway.example.com", "dev.gateway.example.com:443"},
+		{"http url adds default port", "http://localhost", "localhost:80"},
+		{"explicit port wins over scheme default", "https://dev.gateway.example.com:8443", "dev.gateway.example.com:8443"},
+		{"trailing slash stripped", "https://dev.gateway.example.com/", "dev.gateway.example.com:443"},
+		{"path stripped", "https://dev.gateway.example.com/api", "dev.gateway.example.com:443"},
+		{"whitespace trimmed", "  https://dev.gateway.example.com  ", "dev.gateway.example.com:443"},
+		{"bare host left as-is", "dev.gateway.example.com", "dev.gateway.example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canonicalServerAddress(tt.in))
+		})
+	}
+}
+
+func TestResolveContextByServerAddress(t *testing.T) {
+	t.Run("missing config returns empty", func(t *testing.T) {
+		withDirctlConfig(t, "")
+
+		name, err := resolveContextByServerAddress("https://dev.gateway.example.com")
+
+		require.NoError(t, err)
+		assert.Empty(t, name)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		withDirctlConfig(t, `
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+`)
+
+		name, err := resolveContextByServerAddress("https://other.example.com")
+
+		require.NoError(t, err)
+		assert.Empty(t, name)
+	})
+
+	t.Run("exact match", func(t *testing.T) {
+		withDirctlConfig(t, `
+contexts:
+  dev:
+    server_address: https://dev.gateway.example.com
+  prod:
+    server_address: prod.gateway.example.com:443
+`)
+
+		name, err := resolveContextByServerAddress("https://dev.gateway.example.com")
+
+		require.NoError(t, err)
+		assert.Equal(t, "dev", name)
+	})
+
+	t.Run("scheme-insensitive match against host:port", func(t *testing.T) {
+		withDirctlConfig(t, `
+contexts:
+  dev:
+    server_address: dev.gateway.example.com:443
+`)
+
+		name, err := resolveContextByServerAddress("https://dev.gateway.example.com/")
+
+		require.NoError(t, err)
+		assert.Equal(t, "dev", name)
+	})
+
+	t.Run("multiple matches return error", func(t *testing.T) {
+		withDirctlConfig(t, `
+contexts:
+  dev:
+    server_address: https://dev.gateway.example.com
+  dev-alias:
+    server_address: dev.gateway.example.com:443
+`)
+
+		name, err := resolveContextByServerAddress("https://dev.gateway.example.com")
+
+		require.Error(t, err)
+		assert.Empty(t, name)
+		assert.Contains(t, err.Error(), "multiple client contexts")
+	})
+}
+
+func TestBuildClientConfigForRemote(t *testing.T) {
+	t.Run("no matching context falls back to insecure", func(t *testing.T) {
+		withDirctlConfig(t, "")
+
+		cfg, err := buildClientConfigForRemote("http://localhost:8888", authnconfig.Config{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8888", cfg.ServerAddress)
+		assert.Equal(t, "insecure", cfg.AuthMode)
+	})
+
+	t.Run("no matching context honours authn config", func(t *testing.T) {
+		withDirctlConfig(t, "")
+
+		cfg, err := buildClientConfigForRemote("http://localhost:8888", authnconfig.Config{
+			Enabled:    true,
+			Mode:       authnconfig.AuthModeJWT,
+			SocketPath: "/run/spire/agent.sock",
+			Audiences:  []string{"directory"},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "jwt", cfg.AuthMode)
+		assert.Equal(t, "/run/spire/agent.sock", cfg.SpiffeSocketPath)
+		assert.Equal(t, "directory", cfg.JWTAudience)
+	})
+
+	t.Run("matching context overrides authn config", func(t *testing.T) {
+		withDirctlConfig(t, `
+contexts:
+  remote:
+    server_address: dev.gateway.example.com:443
+    auth_mode: oidc
+    auth_token: cached-token
+`)
+
+		cfg, err := buildClientConfigForRemote("https://dev.gateway.example.com", authnconfig.Config{
+			Enabled: true,
+			Mode:    authnconfig.AuthModeX509,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "dev.gateway.example.com:443", cfg.ServerAddress)
+		assert.Equal(t, "oidc", cfg.AuthMode)
+		assert.Equal(t, "cached-token", cfg.AuthToken)
+	})
+}
+
+// withDirctlConfig points dirctl's default config path to a temp directory.
+// When content is empty no file is written, simulating a missing config.
+func withDirctlConfig(t *testing.T, content string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	// Override HOME so DefaultPath() never falls back to the developer's
+	// real config when XDG_CONFIG_HOME is silently ignored by tooling.
+	t.Setenv("HOME", dir)
+
+	if content == "" {
+		return
+	}
+
+	configDir := filepath.Join(dir, "dirctl")
+	require.NoError(t, os.MkdirAll(configDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(content), 0o600))
+}


### PR DESCRIPTION
The regsync reconciler previously dialed every remote Directory node as `insecure`, which fails against TLS/OIDC-protected remotes. It now picks up the user's matching `dirctl` client context (auth mode, OIDC issuer, cached token, SPIFFE settings) when negotiating credentials.

- Added `buildClientConfigForRemote`: resolves a matching dirctl context first, falls back to the previous `authnConfig`-based insecure path.
- Added `resolveContextByServerAddress`: scans `~/.config/dirctl/config.yaml`, treats a missing file as no-match, errors on ambiguous matches.
- Added `canonicalServerAddress`: normalizes addresses (strips scheme/path, injects default `:80`/`:443`) so URL and `host:port` forms compare equal.