### PR TITLE
chore(cli/importer): bump dir-importer and adapt CLI to the new enricher config API

### DIFF
--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -129,13 +129,9 @@ jobs:
                   "serve"
                 ],
                 "env": {
-                  "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com"
-                },
-                "allowedTools": [
-                  "agntcy_oasf_get_schema",
-                  "agntcy_oasf_get_schema_skills",
-                  "agntcy_oasf_get_schema_domains"
-                ]
+                  "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com",
+                  "DIRECTORY_CLIENT_AUTH_MODE": "insecure"
+                }
               }
             },
             "model": "azure:gpt-4o",

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -3,11 +3,6 @@ name: Import MCP Records
 on:
   workflow_dispatch:
     inputs:
-      image_version:
-        required: true
-        type: string
-        default: v1.3.0
-        description: "dirctl version to use"
       import_config:
         description: "JSON config file path or inline JSON content"
         type: string
@@ -102,11 +97,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup dirctl
+      - name: Build dirctl from source
         id: setup-dirctl
-        uses: ./.github/actions/setup-dirctl
-        with:
-          version: ${{ inputs.image_version }}
+        uses: ./.github/actions/build-dirctl
 
       - name: Install Task
         uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1.1.0

--- a/cli/cmd/import/enricher.json
+++ b/cli/cmd/import/enricher.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "dir-mcp-server": {
+      "command": "dirctl",
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "env": {
+        "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com"
+      }
+    }
+  },
+  "model": "azure:gpt-4o",
+  "max-steps": 10
+}

--- a/cli/cmd/import/enricher.json
+++ b/cli/cmd/import/enricher.json
@@ -7,7 +7,8 @@
         "serve"
       ],
       "env": {
-        "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com"
+        "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com",
+        "DIRECTORY_CLIENT_AUTH_MODE": "insecure"
       }
     }
   },

--- a/cli/cmd/import/import.go
+++ b/cli/cmd/import/import.go
@@ -85,6 +85,10 @@ func runImport(cmd *cobra.Command) error {
 		}
 	}
 
+	if err := opts.loadEnrichConfig(); err != nil {
+		return fmt.Errorf("invalid enricher configuration: %w", err)
+	}
+
 	if err := opts.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}

--- a/cli/cmd/import/options.go
+++ b/cli/cmd/import/options.go
@@ -4,19 +4,49 @@
 package importcmd
 
 import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+
 	"github.com/agntcy/dir-importer/config"
 	enricherconfig "github.com/agntcy/dir-importer/enricher/config"
 	scannerconfig "github.com/agntcy/dir-importer/scanner/config"
 	signcmd "github.com/agntcy/dir/cli/cmd/sign"
 )
 
+//go:embed enricher.json
+var defaultEnrichConfig []byte
+
 var opts = &options{}
 
 type options struct {
 	config.Config
-	TypeFlag      string
-	Sign          bool
-	OutputCIDFile string
+	TypeFlag         string
+	Sign             bool
+	OutputCIDFile    string
+	EnrichConfigFile string
+}
+
+// loadEnrichConfig populates the in-memory ToolHost config (model, mcpServers,
+// max-steps).
+func (o *options) loadEnrichConfig() error {
+	data := defaultEnrichConfig
+
+	if o.EnrichConfigFile != "" {
+		fileData, err := os.ReadFile(o.EnrichConfigFile)
+		if err != nil {
+			return fmt.Errorf("enricher config file not found: %w", err)
+		}
+
+		data = fileData
+	}
+
+	if err := json.Unmarshal(data, &o.Enricher.ToolHost); err != nil {
+		return fmt.Errorf("failed to parse enricher config: %w", err)
+	}
+
+	return nil
 }
 
 func init() {
@@ -32,7 +62,7 @@ func init() {
 	flags.IntVar(&opts.Limit, "limit", 0, "Maximum number of records to import (0 = no limit)")
 
 	// Enrichment flags
-	flags.StringVar(&opts.Enricher.ConfigFile, "enrich-config", enricherconfig.DefaultConfigFile, "Path to enricher configuration (JSON: model, mcpServers, max-steps)")
+	flags.StringVar(&opts.EnrichConfigFile, "enrich-config", "", "Path to enricher configuration (JSON: model, mcpServers, max-steps); defaults to the built-in config")
 	flags.StringVar(&opts.Enricher.SkillsPromptTemplate, "enrich-skills-prompt", "", "Path to custom skills prompt template file")
 	flags.StringVar(&opts.Enricher.DomainsPromptTemplate, "enrich-domains-prompt", "", "Path to custom domains prompt template file")
 	flags.IntVar(&opts.Enricher.RequestsPerMinute, "enrich-rate-limit", enricherconfig.DefaultRequestsPerMinute, "Maximum LLM API requests per minute (to avoid rate limit errors)")

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -113,6 +113,7 @@ func init() {
 	network.Command.PersistentPreRunE = skipClientSetup
 	validate.Command.PersistentPreRunE = skipClientSetup
 	version.Command.PersistentPreRunE = skipClientSetup
+	mcp.Command.PersistentPreRunE = skipClientSetup
 
 	RootCmd.AddCommand(
 		// auth commands

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260427075301-21bf512e44c9.1
-	github.com/agntcy/dir-importer v1.3.1-0.20260513134649-3276412ac13b
+	github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a
 	github.com/agntcy/dir-mcp v1.3.0
 	github.com/agntcy/dir-runtime/discovery v1.3.1
 	github.com/agntcy/dir-runtime/server v1.3.1
@@ -499,7 +499,7 @@ require (
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v5 v5.1.0 // indirect
 	github.com/libp2p/zeroconf/v2 v2.2.0 // indirect
-	github.com/mark3labs/mcp-go v0.53.0 // indirect
+	github.com/mark3labs/mcp-go v0.54.1 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/miekg/dns v1.1.72 // indirect

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260427075301-21bf512e44c9.1
-	github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a
+	github.com/agntcy/dir-importer v1.4.0
 	github.com/agntcy/dir-mcp v1.3.0
 	github.com/agntcy/dir-runtime/discovery v1.3.1
 	github.com/agntcy/dir-runtime/server v1.3.1

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -190,8 +190,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a h1:uwEac+e0IKcPXgbM7F0f+pT6+QSGevtywjZLoOEBA54=
-github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a/go.mod h1:2IiVw8bUz6mW2qtwb0/iGIMvNXfHBpZ7XhCyWPTRyZU=
+github.com/agntcy/dir-importer v1.4.0 h1:LYvYFVK76uuhdJe5XcQXRNARFOPX/BrGz6FjA7Zzzx4=
+github.com/agntcy/dir-importer v1.4.0/go.mod h1:2IiVw8bUz6mW2qtwb0/iGIMvNXfHBpZ7XhCyWPTRyZU=
 github.com/agntcy/dir-mcp v1.3.0 h1:xG7qkcsile69u0I7x3VrSvyVKT0NuBlgDK29WrHo5dg=
 github.com/agntcy/dir-mcp v1.3.0/go.mod h1:4GqrwnqlzBvzkrnd0DV3N0iq7rRANtOlQ2aMIzrLQHo=
 github.com/agntcy/dir-runtime/discovery v1.3.1 h1:z+NHyGrm0bU0fbFz426OXg3bFwXqipp1F9YDsETxpUE=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -190,8 +190,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.3.1-0.20260513134649-3276412ac13b h1:BmhkPF1nUFhRrR8wz5txVQ1EyOKdwYP5dVaPqLug0Rg=
-github.com/agntcy/dir-importer v1.3.1-0.20260513134649-3276412ac13b/go.mod h1:EYqzt4Cqz+1iid4/aTWUNbzqVLvRStyy2VCEqe8l6FM=
+github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a h1:uwEac+e0IKcPXgbM7F0f+pT6+QSGevtywjZLoOEBA54=
+github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a/go.mod h1:2IiVw8bUz6mW2qtwb0/iGIMvNXfHBpZ7XhCyWPTRyZU=
 github.com/agntcy/dir-mcp v1.3.0 h1:xG7qkcsile69u0I7x3VrSvyVKT0NuBlgDK29WrHo5dg=
 github.com/agntcy/dir-mcp v1.3.0/go.mod h1:4GqrwnqlzBvzkrnd0DV3N0iq7rRANtOlQ2aMIzrLQHo=
 github.com/agntcy/dir-runtime/discovery v1.3.1 h1:z+NHyGrm0bU0fbFz426OXg3bFwXqipp1F9YDsETxpUE=
@@ -1174,8 +1174,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/marcopolo/simnet v0.0.4 h1:50Kx4hS9kFGSRIbrt9xUS3NJX33EyPqHVmpXvaKLqrY=
 github.com/marcopolo/simnet v0.0.4/go.mod h1:tfQF1u2DmaB6WHODMtQaLtClEf3a296CKQLq5gAsIS0=
-github.com/mark3labs/mcp-go v0.53.0 h1:nzjUi/L448XxwrfmVjiZ03vWgYOWVBrJK0wkZH7fVWo=
-github.com/mark3labs/mcp-go v0.53.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
+github.com/mark3labs/mcp-go v0.54.1 h1:Ap/ptEB9FtWzFKM8NDsTA7QDxerQOC06eZigrTldVj0=
+github.com/mark3labs/mcp-go v0.54.1/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/masahiro331/go-disk v0.0.0-20260423015231-f7a470ebd472 h1:QAY4If99Ee10TUP4mdcB6Qlm036ayfYruTLjvlaczbs=

--- a/tests/e2e/local/10_export_test.go
+++ b/tests/e2e/local/10_export_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
+	typesv1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1"
 	importer "github.com/agntcy/dir-importer"
 	importerconfig "github.com/agntcy/dir-importer/config"
-	"github.com/agntcy/dir-importer/enricher"
 	"github.com/agntcy/dir-importer/factory"
 	"github.com/agntcy/dir-importer/types"
 	"github.com/agntcy/dir/tests/e2e/shared/testdata"
@@ -22,10 +22,16 @@ import (
 	"github.com/onsi/gomega"
 )
 
-// importerWithStaticEnricher wraps importer.New, injecting a StaticEnricher so that
-// e2e tests can import records without an LLM.
+// importerWithStaticEnricher wraps importer.New, forcing the built-in static
+// enricher (SkipEnricher) so that e2e tests can import records without an LLM.
 func importerWithStaticEnricher(ctx context.Context, client importerconfig.ClientInterface, cfg importerconfig.Config) (types.Importer, error) {
-	cfg.EnricherOverride = enricher.NewStaticEnricher()
+	cfg.Enricher.SkipEnricher = true
+	cfg.Enricher.Skills = []*typesv1.Skill{
+		{Name: "natural_language_processing/natural_language_understanding/contextual_comprehension", Id: 10101},
+	}
+	cfg.Enricher.Domains = []*typesv1.Domain{
+		{Name: "technology/software_engineering", Id: 102},
+	}
 
 	return importer.New(ctx, client, cfg) //nolint:wrapcheck
 }
@@ -232,13 +238,9 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command"
 			cardPath := filepath.Join(tempDir, "agent-card.json")
 			gomega.Expect(os.WriteFile(cardPath, testdata.A2AAgentCard, 0o600)).To(gomega.Succeed())
 
-			// Dummy config satisfies enricher validation; the actual enricher is replaced via factory.
-			enrichCfg := filepath.Join(tempDir, "mcphost.json")
-			gomega.Expect(os.WriteFile(enrichCfg, []byte(`{}`), 0o600)).To(gomega.Succeed())
-
 			cidFile := filepath.Join(tempDir, "imported.cids")
 
-			testEnv.CLI.Import("a2a", cardPath).WithArgs("--force", "--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldEventuallySucceed(60 * time.Second)
+			testEnv.CLI.Import("a2a", cardPath).WithArgs("--force", "--output-cids="+cidFile).ShouldEventuallySucceed(60 * time.Second)
 
 			cidData, err := os.ReadFile(cidFile)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -410,13 +412,9 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests for the export command"
 			gomega.Expect(os.MkdirAll(skillDir, 0o755)).To(gomega.Succeed())
 			gomega.Expect(os.WriteFile(filepath.Join(skillDir, "SKILL.md"), testdata.SkillMarkdown, 0o600)).To(gomega.Succeed())
 
-			// Dummy config satisfies enricher validation; the actual enricher is replaced via factory.
-			enrichCfg := filepath.Join(tempDir, "mcphost.json")
-			gomega.Expect(os.WriteFile(enrichCfg, []byte(`{}`), 0o600)).To(gomega.Succeed())
-
 			cidFile := filepath.Join(tempDir, "imported.cids")
 
-			testEnv.CLI.Import("agent-skill", skillDir).WithArgs("--force", "--enrich-config="+enrichCfg, "--output-cids="+cidFile).ShouldSucceed()
+			testEnv.CLI.Import("agent-skill", skillDir).WithArgs("--force", "--output-cids="+cidFile).ShouldSucceed()
 
 			cidData, err := os.ReadFile(cidFile)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.3.1-0.20260513134649-3276412ac13b
+	github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a
 	github.com/agntcy/dir/api v1.4.0
 	github.com/agntcy/dir/cli v1.4.0
 	github.com/agntcy/dir/client v1.4.0
@@ -366,7 +366,7 @@ require (
 	github.com/libp2p/zeroconf/v2 v2.2.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lunixbochs/struc v0.0.0-20241101090106-8d528fa2c543 // indirect
-	github.com/mark3labs/mcp-go v0.53.0 // indirect
+	github.com/mark3labs/mcp-go v0.54.1 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/masahiro331/go-disk v0.0.0-20260423015231-f7a470ebd472 // indirect
 	github.com/masahiro331/go-ebs-file v0.0.0-20260422020928-9d24e29aac27 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a
+	github.com/agntcy/dir-importer v1.4.0
 	github.com/agntcy/dir/api v1.4.0
 	github.com/agntcy/dir/cli v1.4.0
 	github.com/agntcy/dir/client v1.4.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -190,8 +190,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.3.1-0.20260513134649-3276412ac13b h1:BmhkPF1nUFhRrR8wz5txVQ1EyOKdwYP5dVaPqLug0Rg=
-github.com/agntcy/dir-importer v1.3.1-0.20260513134649-3276412ac13b/go.mod h1:EYqzt4Cqz+1iid4/aTWUNbzqVLvRStyy2VCEqe8l6FM=
+github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a h1:uwEac+e0IKcPXgbM7F0f+pT6+QSGevtywjZLoOEBA54=
+github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a/go.mod h1:2IiVw8bUz6mW2qtwb0/iGIMvNXfHBpZ7XhCyWPTRyZU=
 github.com/agntcy/dir-mcp v1.3.0 h1:xG7qkcsile69u0I7x3VrSvyVKT0NuBlgDK29WrHo5dg=
 github.com/agntcy/dir-mcp v1.3.0/go.mod h1:4GqrwnqlzBvzkrnd0DV3N0iq7rRANtOlQ2aMIzrLQHo=
 github.com/agntcy/dir-runtime/discovery v1.3.1 h1:z+NHyGrm0bU0fbFz426OXg3bFwXqipp1F9YDsETxpUE=
@@ -1183,8 +1183,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/marcopolo/simnet v0.0.4 h1:50Kx4hS9kFGSRIbrt9xUS3NJX33EyPqHVmpXvaKLqrY=
 github.com/marcopolo/simnet v0.0.4/go.mod h1:tfQF1u2DmaB6WHODMtQaLtClEf3a296CKQLq5gAsIS0=
-github.com/mark3labs/mcp-go v0.53.0 h1:nzjUi/L448XxwrfmVjiZ03vWgYOWVBrJK0wkZH7fVWo=
-github.com/mark3labs/mcp-go v0.53.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
+github.com/mark3labs/mcp-go v0.54.1 h1:Ap/ptEB9FtWzFKM8NDsTA7QDxerQOC06eZigrTldVj0=
+github.com/mark3labs/mcp-go v0.54.1/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -190,8 +190,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a h1:uwEac+e0IKcPXgbM7F0f+pT6+QSGevtywjZLoOEBA54=
-github.com/agntcy/dir-importer v1.3.2-0.20260601142056-5078e03e6e6a/go.mod h1:2IiVw8bUz6mW2qtwb0/iGIMvNXfHBpZ7XhCyWPTRyZU=
+github.com/agntcy/dir-importer v1.4.0 h1:LYvYFVK76uuhdJe5XcQXRNARFOPX/BrGz6FjA7Zzzx4=
+github.com/agntcy/dir-importer v1.4.0/go.mod h1:2IiVw8bUz6mW2qtwb0/iGIMvNXfHBpZ7XhCyWPTRyZU=
 github.com/agntcy/dir-mcp v1.3.0 h1:xG7qkcsile69u0I7x3VrSvyVKT0NuBlgDK29WrHo5dg=
 github.com/agntcy/dir-mcp v1.3.0/go.mod h1:4GqrwnqlzBvzkrnd0DV3N0iq7rRANtOlQ2aMIzrLQHo=
 github.com/agntcy/dir-runtime/discovery v1.3.1 h1:z+NHyGrm0bU0fbFz426OXg3bFwXqipp1F9YDsETxpUE=


### PR DESCRIPTION
Bumps `github.com/agntcy/dir-importer` to `v1.4.0`, which reworked the enricher configuration: the file-path-based `Enricher.ConfigFile` was removed in favor of an in-memory `Enricher.ToolHost`, and the `EnricherOverride` hook was replaced by a built-in `SkipEnricher` static-enrichment path. This adapts the `dirctl import` command and e2e tests to the new API, and makes the importer's enricher MCP server start without Directory client configuration.

- Bumps `dir-importer` (and transitively `mark3labs/mcp-go` to `v0.54.1`) in `cli` and `tests` go modules.
- Loads the enricher tool-host config in the CLI (`loadEnrichConfig`): reads `--enrich-config` when set, otherwise unmarshals an embedded default; the importer no longer reads this file itself.
- Adds `cli/cmd/import/enricher.json` embedded via `go:embed` so the default tool-host config (model, `dir-mcp-server`, `max-steps`) works regardless of the binary's working directory.
- Skips CLI client setup for the `mcp` command (like `network`/`validate`/`version`), so `dirctl mcp serve` no longer requires a server address — the MCP server manages its own Directory client.
- Pins the enricher's MCP server to `DIRECTORY_CLIENT_AUTH_MODE=insecure` (embedded and CI configs) so OASF-only enrichment starts without Directory credentials or ambiguous cached-token errors.
- Updates the export e2e test to force the importer's built-in static enricher via `cfg.Enricher.SkipEnricher`, dropping the obsolete `EnricherOverride`/`NewStaticEnricher` injection and dummy config files.
- Builds `dirctl` from source in the import workflow (`build-dirctl`) instead of downloading a release, removes the `image_version` input, and drops the unsupported `allowedTools` block from the generated config.