### PR TITLE
feat(dir/server): expose an AI Finder HTTP API over a grpc-gateway sidecar

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/agntcy/dir/reconciler v1.4.0
 	github.com/agntcy/dir/server v1.4.0
 	github.com/agntcy/dir/utils v1.4.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.5
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557
 	github.com/ipfs/go-cid v0.6.1
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -202,8 +202,8 @@ github.com/agntcy/dir-runtime/store v1.3.1 h1:CPIV60I5MAJG5hPK6Vv+MhHiYFmaf7tCxq
 github.com/agntcy/dir-runtime/store v1.3.1/go.mod h1:ywWhrOu30CoZnsfXdY5hh5vBadZqUNGfeH/xIcPVYag=
 github.com/agntcy/dir-runtime/utils v1.3.1 h1:sEXS9TlFyK3d0NIZzaMQqW8cRjm/FgYTC1aWHte8JOo=
 github.com/agntcy/dir-runtime/utils v1.3.1/go.mod h1:ugJUOWpR+kOxVv22snmYSMMNqTh1c6leZ9CJcEZRMpo=
-github.com/agntcy/oasf-sdk/pkg v1.0.5 h1:Sv8K9tqdfl4gfl30spFh9MYkqnzXcTByCsb2uZsNWE4=
-github.com/agntcy/oasf-sdk/pkg v1.0.5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557 h1:cU0wG7uw1CCv3RBKFW8HG0j3CXVfxdUkgTtQ50PxHoY=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/install/charts/dir/apiserver/templates/configmap.yaml
+++ b/install/charts/dir/apiserver/templates/configmap.yaml
@@ -29,6 +29,10 @@ data:
     {{- $metricsConfig := dict "enabled" .Values.metrics.enabled "address" (printf ":%d" (.Values.metrics.port | int)) }}
     {{- $_ := set $config "metrics" $metricsConfig }}
     {{- end }}
+    {{- if .Values.httpGateway }}
+    {{- $gwConfig := dict "enabled" .Values.httpGateway.enabled "listen_address" (printf "0.0.0.0:%d" (.Values.httpGateway.port | int)) }}
+    {{- $_ := set $config "http_gateway" $gwConfig }}
+    {{- end }}
     {{- $config | toYaml | nindent 4 }}
 
   authz_policies.csv: |

--- a/install/charts/dir/apiserver/templates/deployment.yaml
+++ b/install/charts/dir/apiserver/templates/deployment.yaml
@@ -120,6 +120,11 @@ spec:
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.httpGateway.enabled }}
+            - name: http-gateway
+              containerPort: {{ .Values.httpGateway.port }}
+              protocol: TCP
+            {{- end }}
           {{- if or (eq .Values.config.authn.enabled true) (eq .Values.spire.enabled true) }}
           livenessProbe:
             tcpSocket:

--- a/install/charts/dir/apiserver/templates/http-gateway-ingress.yaml
+++ b/install/charts/dir/apiserver/templates/http-gateway-ingress.yaml
@@ -1,0 +1,45 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+---
+
+{{- if and .Values.httpGateway.enabled .Values.httpGateway.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "chart.fullname" . }}-http-gateway
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.httpGateway.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.httpGateway.ingress.className }}
+  ingressClassName: {{ .Values.httpGateway.ingress.className }}
+  {{- end }}
+  {{- if .Values.httpGateway.ingress.tls }}
+  tls:
+    {{- range .Values.httpGateway.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpGateway.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "chart.fullname" $ }}-http-gateway
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/install/charts/dir/apiserver/templates/http-gateway-service.yaml
+++ b/install/charts/dir/apiserver/templates/http-gateway-service.yaml
@@ -1,0 +1,27 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.httpGateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "chart.fullname" . }}-http-gateway
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.httpGateway.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.httpGateway.service.type }}
+  ports:
+    - port: {{ .Values.httpGateway.port }}
+      targetPort: http-gateway
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.httpGateway.service.type "NodePort") .Values.httpGateway.service.nodePort }}
+      nodePort: {{ .Values.httpGateway.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/install/charts/dir/apiserver/templates/service.yaml
+++ b/install/charts/dir/apiserver/templates/service.yaml
@@ -26,5 +26,11 @@ spec:
       nodePort: {{ .Values.service.metricsNodePort }}
       {{- end }}
     {{- end }}
+    {{- if .Values.httpGateway.enabled }}
+    - port: {{ .Values.httpGateway.port }}
+      targetPort: http-gateway
+      protocol: TCP
+      name: http-gateway
+    {{- end }}
   selector:
     {{- include "chart.selectorLabels" . | nindent 4 }}

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -409,6 +409,48 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# HTTP Gateway configuration (grpc-gateway)
+# Exposes gRPC services over HTTP/JSON via grpc-gateway sidecar
+# Values are automatically injected into the server configuration
+httpGateway:
+  # Enable the HTTP gateway
+  # Default: false
+  enabled: false
+
+  # Port for the HTTP gateway endpoint
+  # Used for both the application listen address and Kubernetes service/ingress port
+  # Default: 8889
+  port: 8889
+
+  # Service configuration for HTTP gateway traffic (separate from gRPC service)
+  service:
+    # Service type for HTTP gateway traffic
+    # Options: ClusterIP, NodePort, LoadBalancer
+    # Default: ClusterIP
+    type: ClusterIP
+
+    # Optional: Fixed NodePort (only used when type is NodePort)
+    # nodePort: 30889
+
+    # Optional: Additional custom annotations
+    annotations: {}
+
+  # Ingress configuration for HTTP gateway
+  ingress:
+    # Enable Ingress resource for the HTTP gateway
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 # OpenShift Route configuration (optional)
 # Creates an OpenShift Route to expose the gRPC API externally.
 # Only applicable on OpenShift clusters. Disabled by default.

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -12,6 +12,37 @@ apiserver:
   service:
     type: NodePort # Default for local/dev - change to ClusterIP for cloud with Ingress
 
+  # HTTP Gateway configuration (grpc-gateway)
+  # Exposes gRPC services over HTTP/JSON via grpc-gateway sidecar
+  # The values are automatically injected into the server configuration
+  httpGateway:
+    # Enable the HTTP gateway
+    # Default: false
+    enabled: false
+
+    # Port for the HTTP gateway endpoint
+    # Default: 8889
+    port: 8889
+
+    # Service configuration for HTTP gateway traffic (separate from gRPC service)
+    service:
+      # Service type: ClusterIP, NodePort, LoadBalancer
+      type: ClusterIP
+      # nodePort: 30889
+      annotations: {}
+
+    # Ingress configuration for HTTP gateway
+    ingress:
+      enabled: false
+      className: ""
+      annotations: {}
+      hosts:
+        - host: chart-example.local
+          paths:
+            - path: /
+              pathType: Prefix
+      tls: []
+
   # Prometheus metrics configuration
   # This section configures BOTH the application metrics server AND Kubernetes service
   # The values are automatically injected into the server configuration

--- a/reconciler/go.mod
+++ b/reconciler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/agntcy/dir/client v1.4.0
 	github.com/agntcy/dir/server v1.4.0
 	github.com/agntcy/dir/utils v1.4.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.5
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557
 	github.com/csirmazbendeguz/regclient v0.0.0-20260429082137-82ab6d426079
 	github.com/sigstore/sigstore v1.10.7
 	github.com/spf13/viper v1.21.0

--- a/reconciler/go.sum
+++ b/reconciler/go.sum
@@ -49,8 +49,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ThalesGroup/crypto11 v1.6.1 h1:8A8dZPAJPkQnuE55rRkaFWKuLvZ0fklrtJuOd1r92yU=
 github.com/ThalesGroup/crypto11 v1.6.1/go.mod h1:JcRp7axGx5fDqzAcco/jC1BYMHCvd+hKPwpdoaMNHMQ=
-github.com/agntcy/oasf-sdk/pkg v1.0.5 h1:Sv8K9tqdfl4gfl30spFh9MYkqnzXcTByCsb2uZsNWE4=
-github.com/agntcy/oasf-sdk/pkg v1.0.5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557 h1:cU0wG7uw1CCv3RBKFW8HG0j3CXVfxdUkgTtQ50PxHoY=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/reconciler/tasks/signature/task_test.go
+++ b/reconciler/tasks/signature/task_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	routingv1 "github.com/agntcy/dir/api/routing/v1"
 	signv1 "github.com/agntcy/dir/api/sign/v1"
@@ -200,6 +201,10 @@ func (f *fakeSignatureDB) GetRecordCIDs(opts ...types.FilterOption) ([]string, e
 
 func (f *fakeSignatureDB) GetRecords(opts ...types.FilterOption) ([]types.Record, error) {
 	return nil, nil
+}
+
+func (f *fakeSignatureDB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.CatalogEntry, bool, error) {
+	return nil, false, nil
 }
 func (f *fakeSignatureDB) RemoveRecord(cid string) error          { return nil }
 func (f *fakeSignatureDB) SetRecordSigned(recordCID string) error { return nil }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -103,6 +103,14 @@ const (
 
 	// DefaultMetricsAddress is the default listen address for the metrics HTTP server.
 	DefaultMetricsAddress = ":9090"
+
+	// HTTP gateway (grpc-gateway) configuration.
+
+	// DefaultHTTPGatewayEnabled controls whether the REST gateway runs by default.
+	DefaultHTTPGatewayEnabled = false
+
+	// DefaultHTTPGatewayAddress is the default gateway listen address.
+	DefaultHTTPGatewayAddress = ":8889"
 )
 
 var logger = logging.Logger("config")
@@ -152,6 +160,29 @@ type Config struct {
 
 	// Naming holds name verification cache config (TTL for naming API; reconciler name task performs re-verification).
 	Naming naming.Config `json:"naming,omitzero" mapstructure:"naming"`
+
+	// HTTPGateway exposes the gRPC services over HTTP/JSON via grpc-gateway.
+	HTTPGateway HTTPGatewayConfig `json:"http_gateway,omitzero" mapstructure:"http_gateway"`
+}
+
+// HTTPGatewayConfig configures the in-process grpc-gateway sidecar.
+// It is disabled by default.
+type HTTPGatewayConfig struct {
+	// Enabled toggles the HTTP gateway sidecar.
+	Enabled bool `json:"enabled,omitempty" mapstructure:"enabled"`
+
+	// ListenAddress is the HTTP gateway listen address (e.g. ":8889").
+	ListenAddress string `json:"listen_address,omitempty" mapstructure:"listen_address"`
+}
+
+// WithDefaults returns a copy with empty fields filled from package defaults.
+func (c HTTPGatewayConfig) WithDefaults() HTTPGatewayConfig {
+	out := c
+	if out.ListenAddress == "" {
+		out.ListenAddress = DefaultHTTPGatewayAddress
+	}
+
+	return out
 }
 
 type SyncConfig struct {

--- a/server/controller/ai_finder.go
+++ b/server/controller/ai_finder.go
@@ -1,0 +1,85 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
+	"github.com/agntcy/dir/server/types"
+	"github.com/agntcy/dir/utils/logging"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var aiFinderLogger = logging.Logger("controller/ai-finder")
+
+// aiFinderController adapts the AI Finder query language to the catalog query
+// layer. GetWellKnownCatalog is served by the embedded Unimplemented server.
+type aiFinderController struct {
+	catalogv1.UnimplementedAIFinderServiceServer
+
+	db types.CatalogDatabaseAPI
+}
+
+func NewAIFinderController(db types.CatalogDatabaseAPI) catalogv1.AIFinderServiceServer {
+	return &aiFinderController{db: db}
+}
+
+// ListAgents parses the filter, order, and paging arguments, queries the
+// catalog, and returns one page of entries with a continuation token.
+func (c *aiFinderController) ListAgents(ctx context.Context, req *catalogv1.ListAgentsRequest) (*catalogv1.ListAgentsResponse, error) {
+	if req == nil {
+		req = &catalogv1.ListAgentsRequest{}
+	}
+
+	aiFinderLogger.Debug("ListAgents called", "filter", req.GetFilter(), "order_by", req.GetOrderBy(), "page_size", req.GetPageSize())
+
+	parsedFilter, err := parseAgentFilter(req.GetFilter())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid filter: %v", err)
+	}
+
+	// publisherId is part of the grammar but not yet indexed.
+	if len(parsedFilter.PublisherIDs) > 0 {
+		return nil, status.Error(codes.Unimplemented, "publisherId filter is not yet supported") //nolint:wrapcheck
+	}
+
+	order, err := parseOrderBy(req.GetOrderBy())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid order_by: %v", err)
+	}
+
+	offset, err := decodePageToken(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+	}
+
+	pageSize := int(clampPageSize(req.GetPageSize()))
+
+	opts, ok := buildRecordFilterOptions(parsedFilter, order, pageSize, offset)
+	if !ok {
+		// type= matched no indexed module: zero rows, not an error.
+		return &catalogv1.ListAgentsResponse{}, nil
+	}
+
+	entries, hasMore, err := c.db.GetCatalogEntries(opts...)
+	if err != nil {
+		aiFinderLogger.Error("failed to list catalog entries", "error", err)
+
+		return nil, status.Error(codes.Internal, "failed to list catalog entries") //nolint:wrapcheck
+	}
+
+	var nextPageToken string
+	if hasMore {
+		// Advance by the page size: the number of records consumed,
+		// regardless of how many projected to an entry.
+		nextPageToken = encodePageToken(offset + pageSize)
+	}
+
+	return &catalogv1.ListAgentsResponse{
+		Results:       entries,
+		NextPageToken: nextPageToken,
+	}, nil
+}

--- a/server/controller/ai_finder_filter.go
+++ b/server/controller/ai_finder_filter.go
@@ -1,0 +1,405 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/agntcy/dir/server/types"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
+)
+
+// AI Finder filter grammar:
+//
+//	filter = clause { WS+ "AND" WS+ clause } ;
+//	clause = field "=" value ;
+//	field  = "displayName" | "type" | "publisherId" | "createdAfter" | "updatedAfter" ;
+//	value  = token { "," token } ;
+//	token  = unquoted_token | quoted_string ;
+//
+// Logical AND across fields, comma-OR within a field's value list; each field
+// may appear at most once.
+
+const (
+	// filterMaxLen mirrors the proto validator (max_len=2048).
+	filterMaxLen = 2048
+
+	// rfc3339UTC is the timestamp format used for createdAfter/updatedAfter
+	// clauses emitted to the data layer.
+	rfc3339UTC = "2006-01-02T15:04:05Z07:00"
+)
+
+// agentFilter is the parsed representation of the ListAgents filter query.
+type agentFilter struct {
+	DisplayName  string
+	Types        []string
+	PublisherIDs []string
+	CreatedAfter time.Time
+	UpdatedAfter time.Time
+}
+
+// oasfModuleForMediaType maps a media type onto the OASF module name the
+// registry indexes, or ("", false) for unknown types.
+func oasfModuleForMediaType(mediaType string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(mediaType)) {
+	case translator.A2ACatalogMediaType:
+		return translator.A2AModuleName, true
+	case translator.MCPCatalogMediaType:
+		return translator.MCPModuleName, true
+	case "application/ai-skill", translator.AgentSkillsCatalogMediaType:
+		return translator.AgentSkillsModuleName, true
+	default:
+		return "", false
+	}
+}
+
+// parseAgentFilter parses the filter syntax. Any unsupported syntax
+// (parentheses, OR keywords, unknown or duplicate fields, missing values) is
+// rejected so callers map it to INVALID_ARGUMENT. Empty input is a no-op.
+func parseAgentFilter(input string) (agentFilter, error) {
+	if len(input) > filterMaxLen {
+		return agentFilter{}, fmt.Errorf("filter expression too long (%d > %d)", len(input), filterMaxLen)
+	}
+
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return agentFilter{}, nil
+	}
+
+	clauses, err := splitFilterClauses(trimmed)
+	if err != nil {
+		return agentFilter{}, err
+	}
+
+	var out agentFilter
+
+	seen := map[string]struct{}{}
+
+	for _, clause := range clauses {
+		field, rawValue, ok := splitAtFirstEqual(clause)
+		if !ok {
+			return agentFilter{}, fmt.Errorf("filter clause %q must contain '='", clause)
+		}
+
+		field = strings.TrimSpace(field)
+		rawValue = strings.TrimSpace(rawValue)
+
+		if field == "" {
+			return agentFilter{}, fmt.Errorf("filter clause %q has empty field name", clause)
+		}
+
+		if rawValue == "" {
+			return agentFilter{}, fmt.Errorf("filter field %q has empty value", field)
+		}
+
+		if _, dup := seen[field]; dup {
+			return agentFilter{}, fmt.Errorf("filter field %q appears more than once", field)
+		}
+
+		seen[field] = struct{}{}
+
+		values, err := parseValueList(rawValue)
+		if err != nil {
+			return agentFilter{}, fmt.Errorf("filter field %q: %w", field, err)
+		}
+
+		if err := applyClause(&out, field, values); err != nil {
+			return agentFilter{}, err
+		}
+	}
+
+	return out, nil
+}
+
+// buildRecordFilterOptions translates a parsed filter, order, and paging into
+// FilterOptions for the catalog query layer. The bool is false when type= was
+// set but no requested media type maps to an indexed module (zero rows).
+func buildRecordFilterOptions(f agentFilter, order []orderByClause, pageSize, offset int) ([]types.FilterOption, bool) {
+	opts := []types.FilterOption{
+		types.WithLimit(pageSize),
+		types.WithOffset(offset),
+	}
+
+	if f.DisplayName != "" {
+		opts = append(opts, types.WithNames("*"+f.DisplayName+"*"))
+	}
+
+	if len(f.Types) > 0 {
+		var modules []string
+
+		for _, mt := range f.Types {
+			if module, ok := oasfModuleForMediaType(mt); ok {
+				modules = append(modules, module)
+			}
+		}
+
+		if len(modules) == 0 {
+			return nil, false
+		}
+
+		opts = append(opts, types.WithModuleNames(modules...))
+	}
+
+	// createdAfter / updatedAfter both resolve to a strict '>' comparison on
+	// the only OASF-supplied record timestamp.
+	if !f.CreatedAfter.IsZero() {
+		opts = append(opts, types.WithCreatedAts(">"+f.CreatedAfter.UTC().Format(rfc3339UTC)))
+	}
+
+	if !f.UpdatedAfter.IsZero() {
+		opts = append(opts, types.WithCreatedAts(">"+f.UpdatedAfter.UTC().Format(rfc3339UTC)))
+	}
+
+	if len(order) > 0 {
+		clauses := make([]types.RecordOrderClause, 0, len(order))
+		for _, o := range order {
+			clauses = append(clauses, types.RecordOrderClause{Column: o.Column, Desc: o.Desc})
+		}
+
+		opts = append(opts, types.WithOrderBy(clauses...))
+	}
+
+	return opts, true
+}
+
+// splitFilterClauses splits on the case-sensitive "AND" keyword between
+// whitespace, respecting double-quoted tokens. AND is the only connector.
+func splitFilterClauses(s string) ([]string, error) {
+	var (
+		clauses []string
+		current strings.Builder
+		inQuote bool
+	)
+
+	flush := func() {
+		if text := strings.TrimSpace(current.String()); text != "" {
+			clauses = append(clauses, text)
+		}
+
+		current.Reset()
+	}
+
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+
+		if r == '"' {
+			inQuote = !inQuote
+
+			current.WriteRune(r)
+
+			continue
+		}
+
+		if !inQuote && unicode.IsSpace(r) && matchKeywordAt(runes, i+countLeadingSpaces(runes[i:]), "AND") {
+			flush()
+
+			i += countLeadingSpaces(runes[i:]) + len("AND") - 1
+
+			continue
+		}
+
+		current.WriteRune(r)
+	}
+
+	if inQuote {
+		return nil, errors.New("unterminated quoted string in filter")
+	}
+
+	flush()
+
+	if len(clauses) == 0 {
+		return nil, errors.New("filter contained no clauses")
+	}
+
+	return clauses, nil
+}
+
+// countLeadingSpaces counts whitespace runes at the start of r.
+func countLeadingSpaces(r []rune) int {
+	n := 0
+
+	for _, c := range r {
+		if !unicode.IsSpace(c) {
+			break
+		}
+
+		n++
+	}
+
+	return n
+}
+
+// matchKeywordAt reports whether the runes at idx match keyword followed by a
+// whitespace boundary or end of input.
+func matchKeywordAt(r []rune, idx int, keyword string) bool {
+	kw := []rune(keyword)
+	if idx+len(kw) > len(r) {
+		return false
+	}
+
+	for i, c := range kw {
+		if r[idx+i] != c {
+			return false
+		}
+	}
+
+	end := idx + len(kw)
+	if end == len(r) {
+		return true
+	}
+
+	return unicode.IsSpace(r[end])
+}
+
+// splitAtFirstEqual returns (left, right, true) on the first '=' outside a
+// quoted string, or ("", "", false) when no '=' is present.
+func splitAtFirstEqual(s string) (string, string, bool) {
+	inQuote := false
+
+	for i, r := range s {
+		switch {
+		case r == '"':
+			inQuote = !inQuote
+		case r == '=' && !inQuote:
+			return s[:i], s[i+1:], true
+		}
+	}
+
+	return "", "", false
+}
+
+// parseValueList splits "a,b,\"c, d\"" into ["a", "b", "c, d"]. Quoted values
+// may contain commas, whitespace and '='; unquoted values may not contain '='
+// and are trimmed.
+//
+//nolint:cyclop
+func parseValueList(s string) ([]string, error) {
+	var (
+		out     []string
+		current strings.Builder
+		inQuote bool
+	)
+
+	flush := func() error {
+		token := current.String()
+		if !inQuote {
+			token = strings.TrimSpace(token)
+		}
+
+		if token == "" {
+			return errors.New("empty value in value list")
+		}
+
+		out = append(out, token)
+
+		current.Reset()
+
+		return nil
+	}
+
+	for i := range len(s) {
+		c := s[i]
+
+		switch {
+		case c == '"':
+			if inQuote {
+				inQuote = false
+			} else {
+				if current.Len() != 0 && strings.TrimSpace(current.String()) != "" {
+					return nil, errors.New("unexpected '\"' inside unquoted token")
+				}
+
+				current.Reset()
+
+				inQuote = true
+			}
+		case c == ',' && !inQuote:
+			if err := flush(); err != nil {
+				return nil, err
+			}
+		case c == '=' && !inQuote:
+			return nil, errors.New("unexpected '=' in value (quote the value if it is intended)")
+		default:
+			current.WriteByte(c)
+		}
+	}
+
+	if inQuote {
+		return nil, errors.New("unterminated quoted value")
+	}
+
+	if err := flush(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// applyClause routes a parsed clause into the matching agentFilter field.
+//
+//nolint:cyclop
+func applyClause(out *agentFilter, field string, values []string) error {
+	switch field {
+	case "displayName":
+		if len(values) != 1 {
+			return fmt.Errorf("filter field %q accepts a single value, got %d", field, len(values))
+		}
+
+		out.DisplayName = values[0]
+
+		return nil
+
+	case "type":
+		out.Types = values
+
+		return nil
+
+	case "publisherId":
+		out.PublisherIDs = values
+
+		return nil
+
+	case "createdAfter":
+		ts, err := singleTimestamp(field, values)
+		if err != nil {
+			return err
+		}
+
+		out.CreatedAfter = ts
+
+		return nil
+
+	case "updatedAfter":
+		ts, err := singleTimestamp(field, values)
+		if err != nil {
+			return err
+		}
+
+		out.UpdatedAfter = ts
+
+		return nil
+
+	default:
+		return fmt.Errorf("unknown filter field %q (allowed: displayName, type, publisherId, createdAfter, updatedAfter)", field)
+	}
+}
+
+// singleTimestamp validates a single-value RFC3339 clause.
+func singleTimestamp(field string, values []string) (time.Time, error) {
+	if len(values) != 1 {
+		return time.Time{}, fmt.Errorf("filter field %q accepts a single value, got %d", field, len(values))
+	}
+
+	ts, err := time.Parse(time.RFC3339, values[0])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("filter field %q: invalid ISO 8601 timestamp %q: %w", field, values[0], err)
+	}
+
+	return ts.UTC(), nil
+}

--- a/server/controller/ai_finder_paging.go
+++ b/server/controller/ai_finder_paging.go
@@ -1,0 +1,166 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// AI Finder paging and ordering helpers.
+
+const (
+	// agentListDefaultPageSize is applied when page_size is omitted or zero.
+	agentListDefaultPageSize uint32 = 20
+
+	// agentListMaxPageSize bounds the page size; larger values are clamped.
+	agentListMaxPageSize uint32 = 100
+
+	// agentListMaxOrderByClauses caps the number of sort fields.
+	agentListMaxOrderByClauses = 8
+
+	// agentPageTokenMaxLen bounds the on-wire page-token length.
+	agentPageTokenMaxLen = 64
+)
+
+// clampPageSize applies the default and maximum page size.
+func clampPageSize(requested uint32) uint32 {
+	switch {
+	case requested == 0:
+		return agentListDefaultPageSize
+	case requested > agentListMaxPageSize:
+		return agentListMaxPageSize
+	default:
+		return requested
+	}
+}
+
+// orderByClause is a single parsed sort directive. Column is a validated
+// logical name, never raw user input.
+type orderByClause struct {
+	Column string
+	Desc   bool
+}
+
+// orderByColumnAllowList maps API sort fields onto the logical column names
+// understood by the catalog query layer.
+var orderByColumnAllowList = map[string]string{
+	"name":         "name",
+	"display_name": "name",
+	"displayname":  "name",
+	"version":      "version",
+	"created_at":   "created_at",
+	"createdat":    "created_at",
+	"updated_at":   "created_at",
+	"updatedat":    "created_at",
+}
+
+// parseOrderBy parses the order_by query string, e.g. "name, created_at DESC".
+// Empty input yields the default ordering (created_at DESC).
+func parseOrderBy(input string) ([]orderByClause, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return defaultAgentOrder(), nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	if len(parts) > agentListMaxOrderByClauses {
+		return nil, fmt.Errorf("order_by contains %d clauses; maximum is %d", len(parts), agentListMaxOrderByClauses)
+	}
+
+	clauses := make([]orderByClause, 0, len(parts))
+	seen := map[string]struct{}{}
+
+	for _, raw := range parts {
+		clause := strings.TrimSpace(raw)
+		if clause == "" {
+			return nil, errors.New("empty order_by clause")
+		}
+
+		tokens := strings.Fields(clause)
+
+		var (
+			field string
+			desc  bool
+		)
+
+		switch len(tokens) {
+		case 1:
+			field = tokens[0]
+		case 2: //nolint:mnd
+			field = tokens[0]
+
+			switch strings.ToUpper(tokens[1]) {
+			case "ASC":
+				desc = false
+			case "DESC":
+				desc = true
+			default:
+				return nil, fmt.Errorf("invalid order_by direction %q (expected ASC or DESC)", tokens[1])
+			}
+		default:
+			return nil, fmt.Errorf("invalid order_by clause %q", clause)
+		}
+
+		column, ok := orderByColumnAllowList[strings.ToLower(field)]
+		if !ok {
+			return nil, fmt.Errorf("unknown order_by field %q", field)
+		}
+
+		if _, dup := seen[column]; dup {
+			return nil, fmt.Errorf("order_by field %q appears more than once", field)
+		}
+
+		seen[column] = struct{}{}
+		clauses = append(clauses, orderByClause{Column: column, Desc: desc})
+	}
+
+	return clauses, nil
+}
+
+// defaultAgentOrder sorts newest-first when order_by is omitted.
+func defaultAgentOrder() []orderByClause {
+	return []orderByClause{{Column: "created_at", Desc: true}}
+}
+
+// encodePageToken serialises a positive offset into an opaque continuation
+// token. A non-positive offset yields an empty token.
+func encodePageToken(offset int) string {
+	if offset <= 0 {
+		return ""
+	}
+
+	return base64.RawURLEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+// decodePageToken parses a previously issued token. Empty input is valid and
+// yields offset 0; malformed tokens are rejected.
+func decodePageToken(s string) (int, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	if len(s) > agentPageTokenMaxLen {
+		return 0, fmt.Errorf("page_token too long (%d > %d)", len(s), agentPageTokenMaxLen)
+	}
+
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid page_token encoding: %w", err)
+	}
+
+	offset, err := strconv.Atoi(string(raw))
+	if err != nil {
+		return 0, fmt.Errorf("invalid page_token payload: %w", err)
+	}
+
+	if offset < 0 {
+		return 0, errors.New("page_token offset must be non-negative")
+	}
+
+	return offset, nil
+}

--- a/server/controller/ai_finder_test.go
+++ b/server/controller/ai_finder_test.go
@@ -1,0 +1,225 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
+	"github.com/agntcy/dir/server/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeCatalogDB implements types.CatalogDatabaseAPI, capturing the filters it
+// was called with and returning canned results.
+type fakeCatalogDB struct {
+	entries    []*catalogv1.CatalogEntry
+	hasMore    bool
+	err        error
+	calls      int
+	gotFilters types.RecordFilters
+}
+
+func (f *fakeCatalogDB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.CatalogEntry, bool, error) {
+	f.calls++
+
+	cfg := types.RecordFilters{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	f.gotFilters = cfg
+
+	return f.entries, f.hasMore, f.err
+}
+
+func entry(id string) *catalogv1.CatalogEntry {
+	return &catalogv1.CatalogEntry{Identifier: id, DisplayName: id, MediaType: "application/a2a-agent-card+json"}
+}
+
+func TestListAgents_DefaultsAndResults(t *testing.T) {
+	db := &fakeCatalogDB{entries: []*catalogv1.CatalogEntry{entry("a"), entry("b")}}
+	ctrl := NewAIFinderController(db)
+
+	resp, err := ctrl.ListAgents(context.Background(), &catalogv1.ListAgentsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp.GetResults(), 2)
+	assert.Empty(t, resp.GetNextPageToken(), "no more results means no token")
+
+	// Defaults: page size 20, newest-first ordering.
+	assert.Equal(t, 20, db.gotFilters.Limit)
+	assert.Equal(t, 0, db.gotFilters.Offset)
+	require.Len(t, db.gotFilters.OrderBy, 1)
+	assert.Equal(t, types.RecordOrderClause{Column: "created_at", Desc: true}, db.gotFilters.OrderBy[0])
+}
+
+func TestListAgents_NextPageToken(t *testing.T) {
+	db := &fakeCatalogDB{entries: []*catalogv1.CatalogEntry{entry("a")}, hasMore: true}
+	ctrl := NewAIFinderController(db)
+
+	resp, err := ctrl.ListAgents(context.Background(), &catalogv1.ListAgentsRequest{PageSize: 5})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.GetNextPageToken())
+
+	offset, err := decodePageToken(resp.GetNextPageToken())
+	require.NoError(t, err)
+	assert.Equal(t, 5, offset, "next offset advances by the page size")
+}
+
+func TestListAgents_PageTokenAppliesOffset(t *testing.T) {
+	db := &fakeCatalogDB{}
+	ctrl := NewAIFinderController(db)
+
+	_, err := ctrl.ListAgents(context.Background(), &catalogv1.ListAgentsRequest{
+		PageSize:  10,
+		PageToken: encodePageToken(30),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 30, db.gotFilters.Offset)
+	assert.Equal(t, 10, db.gotFilters.Limit)
+}
+
+func TestListAgents_FilterTranslation(t *testing.T) {
+	db := &fakeCatalogDB{}
+	ctrl := NewAIFinderController(db)
+
+	_, err := ctrl.ListAgents(context.Background(), &catalogv1.ListAgentsRequest{
+		Filter: `displayName=weather AND type=application/a2a-agent-card+json AND createdAfter=2024-01-01T00:00:00Z`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"*weather*"}, db.gotFilters.Names)
+	assert.Equal(t, []string{"integration/a2a"}, db.gotFilters.ModuleNames)
+	assert.Equal(t, []string{">2024-01-01T00:00:00Z"}, db.gotFilters.CreatedAts)
+}
+
+func TestListAgents_UnknownTypeYieldsZeroRows(t *testing.T) {
+	db := &fakeCatalogDB{}
+	ctrl := NewAIFinderController(db)
+
+	resp, err := ctrl.ListAgents(context.Background(), &catalogv1.ListAgentsRequest{Filter: "type=application/unknown+json"})
+	require.NoError(t, err)
+	assert.Empty(t, resp.GetResults())
+	assert.Zero(t, db.calls, "unknown type short-circuits without hitting the DB")
+}
+
+func TestListAgents_Errors(t *testing.T) {
+	ctrl := NewAIFinderController(&fakeCatalogDB{})
+
+	tests := []struct {
+		name string
+		req  *catalogv1.ListAgentsRequest
+		code codes.Code
+	}{
+		{"bad filter", &catalogv1.ListAgentsRequest{Filter: "displayName"}, codes.InvalidArgument},
+		{"bad order_by", &catalogv1.ListAgentsRequest{OrderBy: "bogus"}, codes.InvalidArgument},
+		{"bad page_token", &catalogv1.ListAgentsRequest{PageToken: "!!!not-base64!!!"}, codes.InvalidArgument},
+		{"publisherId unsupported", &catalogv1.ListAgentsRequest{Filter: "publisherId=acme"}, codes.Unimplemented},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ctrl.ListAgents(context.Background(), tc.req)
+			require.Error(t, err)
+			assert.Equal(t, tc.code, status.Code(err))
+		})
+	}
+}
+
+func TestListAgents_DBError(t *testing.T) {
+	db := &fakeCatalogDB{err: assert.AnError}
+	ctrl := NewAIFinderController(db)
+
+	_, err := ctrl.ListAgents(context.Background(), &catalogv1.ListAgentsRequest{})
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+}
+
+func TestParseAgentFilter(t *testing.T) {
+	t.Run("empty is a no-op", func(t *testing.T) {
+		f, err := parseAgentFilter("")
+		require.NoError(t, err)
+		assert.Equal(t, agentFilter{}, f)
+	})
+
+	t.Run("AND across fields, comma-OR within", func(t *testing.T) {
+		f, err := parseAgentFilter(`type=a,b AND displayName=foo`)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", f.DisplayName)
+		assert.Equal(t, []string{"a", "b"}, f.Types)
+	})
+
+	t.Run("quoted value keeps commas and spaces", func(t *testing.T) {
+		f, err := parseAgentFilter(`displayName="hello, world"`)
+		require.NoError(t, err)
+		assert.Equal(t, "hello, world", f.DisplayName)
+	})
+
+	invalid := []struct {
+		name  string
+		input string
+	}{
+		{"no equals", "displayName"},
+		{"unknown field", "color=red"},
+		{"duplicate field", "displayName=a AND displayName=b"},
+		{"empty value", "displayName="},
+		{"multi-value displayName", "displayName=a,b"},
+		{"bad timestamp", "createdAfter=not-a-date"},
+		{"unterminated quote", `displayName="oops`},
+	}
+	for _, tc := range invalid {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseAgentFilter(tc.input)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseOrderBy(t *testing.T) {
+	t.Run("empty yields default", func(t *testing.T) {
+		got, err := parseOrderBy("")
+		require.NoError(t, err)
+		assert.Equal(t, defaultAgentOrder(), got)
+	})
+
+	t.Run("fields with directions", func(t *testing.T) {
+		got, err := parseOrderBy("display_name, created_at DESC")
+		require.NoError(t, err)
+		assert.Equal(t, []orderByClause{{Column: "name", Desc: false}, {Column: "created_at", Desc: true}}, got)
+	})
+
+	invalid := []string{"unknown_field", "name BADDIR", "name, name", "a,b,c,d,e,f,g,h,i"}
+	for _, in := range invalid {
+		t.Run(in, func(t *testing.T) {
+			_, err := parseOrderBy(in)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestPageTokenRoundTrip(t *testing.T) {
+	assert.Empty(t, encodePageToken(0))
+
+	tok := encodePageToken(42)
+	require.NotEmpty(t, tok)
+
+	offset, err := decodePageToken(tok)
+	require.NoError(t, err)
+	assert.Equal(t, 42, offset)
+
+	got, err := decodePageToken("")
+	require.NoError(t, err)
+	assert.Zero(t, got)
+
+	_, err = decodePageToken("###")
+	require.Error(t, err)
+}
+
+func TestClampPageSize(t *testing.T) {
+	assert.Equal(t, uint32(20), clampPageSize(0))
+	assert.Equal(t, uint32(50), clampPageSize(50))
+	assert.Equal(t, uint32(100), clampPageSize(1000))
+}

--- a/server/database/catalog_test.go
+++ b/server/database/catalog_test.go
@@ -1,0 +1,152 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package database
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agntcy/dir/server/types"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// catalogModuleFixture is a types.Module carrying structured data, which the
+// shared testModule fixture does not.
+type catalogModuleFixture struct {
+	id   uint64
+	name string
+	data map[string]any
+}
+
+func (m *catalogModuleFixture) GetID() uint64           { return m.id }
+func (m *catalogModuleFixture) GetName() string         { return m.name }
+func (m *catalogModuleFixture) GetData() map[string]any { return m.data }
+
+func catalogRecord(cid, name, createdAt string, modules []types.Module) *testRecord {
+	return &testRecord{
+		cid: cid,
+		data: &testRecordData{
+			name:          name,
+			version:       "1.0.0",
+			description:   "a " + name + " agent",
+			schemaVersion: "0.5.0",
+			createdAt:     createdAt,
+			skills:        []types.Skill{&testSkill{id: 1, name: "test_skill"}},
+			modules:       modules,
+		},
+	}
+}
+
+var (
+	a2aRecord = catalogRecord("cid-a2a", "alpha", "2024-01-01T00:00:00Z", []types.Module{
+		&catalogModuleFixture{id: 1, name: translator.A2AModuleName, data: map[string]any{"protocol_version": "1.0"}},
+	})
+
+	mcpRecord = catalogRecord("cid-mcp", "bravo", "2024-02-01T00:00:00Z", []types.Module{
+		&catalogModuleFixture{id: 2, name: translator.MCPModuleName, data: map[string]any{"name": "mcp-server"}},
+	})
+
+	containerRecord = catalogRecord("cid-both", "charlie", "2024-03-01T00:00:00Z", []types.Module{
+		&catalogModuleFixture{id: 2, name: translator.MCPModuleName, data: map[string]any{"name": "mcp-server"}},
+		&catalogModuleFixture{id: 1, name: translator.A2AModuleName, data: map[string]any{"protocol_version": "1.0"}},
+	})
+
+	unprojectableRecord = catalogRecord("cid-none", "delta", "2024-04-01T00:00:00Z", []types.Module{
+		&catalogModuleFixture{id: 9, name: "integration/acp"},
+	})
+)
+
+func TestGetCatalogEntries_LeafProjection(t *testing.T) {
+	db := setupTestDB(t)
+	require.NoError(t, db.AddRecord(a2aRecord))
+
+	entries, hasMore, err := db.GetCatalogEntries()
+	require.NoError(t, err)
+	assert.False(t, hasMore)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, translator.A2ACatalogMediaType, entry.GetMediaType())
+	assert.Equal(t, "urn:ai:org.agntcy:cid:cid-a2a", entry.GetIdentifier())
+	assert.Equal(t, "alpha", entry.GetDisplayName())
+	assert.Equal(t, "a alpha agent", entry.GetDescription())
+	assert.NotNil(t, entry.GetData(), "leaf entry should embed module data")
+	assert.Contains(t, strings.Join(entry.GetTags(), " "), "test_skill")
+}
+
+func TestGetCatalogEntries_ContainerProjection(t *testing.T) {
+	db := setupTestDB(t)
+	require.NoError(t, db.AddRecord(containerRecord))
+
+	entries, _, err := db.GetCatalogEntries()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, translator.CatalogContainerMediaType, entry.GetMediaType())
+	assert.Equal(t, "urn:ai:org.agntcy:cid:cid-both", entry.GetIdentifier())
+	assert.NotNil(t, entry.GetData(), "container entry should embed a nested catalog")
+}
+
+func TestGetCatalogEntries_SkipsUnprojectable(t *testing.T) {
+	db := setupTestDB(t)
+	require.NoError(t, db.AddRecord(unprojectableRecord))
+	require.NoError(t, db.AddRecord(a2aRecord))
+
+	entries, hasMore, err := db.GetCatalogEntries()
+	require.NoError(t, err)
+	assert.False(t, hasMore)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "urn:ai:org.agntcy:cid:cid-a2a", entries[0].GetIdentifier())
+}
+
+func TestGetCatalogEntries_Pagination(t *testing.T) {
+	db := setupTestDB(t)
+	for _, r := range []types.Record{a2aRecord, mcpRecord, containerRecord} {
+		require.NoError(t, db.AddRecord(r))
+	}
+
+	first, hasMore, err := db.GetCatalogEntries(types.WithLimit(2))
+	require.NoError(t, err)
+	assert.True(t, hasMore, "first page of 2/3 should report more results")
+	assert.Len(t, first, 2)
+
+	second, hasMore, err := db.GetCatalogEntries(types.WithLimit(2), types.WithOffset(2))
+	require.NoError(t, err)
+	assert.False(t, hasMore, "second page exhausts the result set")
+	assert.Len(t, second, 1)
+}
+
+func TestGetCatalogEntries_Ordering(t *testing.T) {
+	db := setupTestDB(t)
+	for _, r := range []types.Record{containerRecord, a2aRecord, mcpRecord} {
+		require.NoError(t, db.AddRecord(r))
+	}
+
+	entries, _, err := db.GetCatalogEntries(types.WithOrderBy(types.RecordOrderClause{Column: "name"}))
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+
+	names := []string{entries[0].GetDisplayName(), entries[1].GetDisplayName(), entries[2].GetDisplayName()}
+	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, names)
+}
+
+func TestGetCatalogEntries_UnsupportedSortColumn(t *testing.T) {
+	db := setupTestDB(t)
+	require.NoError(t, db.AddRecord(a2aRecord))
+
+	_, _, err := db.GetCatalogEntries(types.WithOrderBy(types.RecordOrderClause{Column: "drop table"}))
+	require.Error(t, err)
+}
+
+func TestGetCatalogEntries_NilOption(t *testing.T) {
+	db := setupTestDB(t)
+
+	var nilOpt types.FilterOption
+
+	_, _, err := db.GetCatalogEntries(nilOpt)
+	require.Error(t, err)
+}

--- a/server/database/database_test.go
+++ b/server/database/database_test.go
@@ -22,12 +22,12 @@ func (r *testRecord) GetCid() string                           { return r.cid }
 func (r *testRecord) GetRecordData() (types.RecordData, error) { return r.data, nil }
 
 type testRecordData struct {
-	name, version, schemaVersion, createdAt string
-	authors                                 []string
-	skills                                  []types.Skill
-	locators                                []types.Locator
-	modules                                 []types.Module
-	domains                                 []types.Domain
+	name, version, description, schemaVersion, createdAt string
+	authors                                              []string
+	skills                                               []types.Skill
+	locators                                             []types.Locator
+	modules                                              []types.Module
+	domains                                              []types.Domain
 }
 
 func (d *testRecordData) GetName() string                   { return d.name }
@@ -39,7 +39,7 @@ func (d *testRecordData) GetSkills() []types.Skill          { return d.skills }
 func (d *testRecordData) GetLocators() []types.Locator      { return d.locators }
 func (d *testRecordData) GetModules() []types.Module        { return d.modules }
 func (d *testRecordData) GetDomains() []types.Domain        { return d.domains }
-func (d *testRecordData) GetDescription() string            { return "" }
+func (d *testRecordData) GetDescription() string            { return d.description }
 func (d *testRecordData) GetAnnotations() map[string]string { return nil }
 func (d *testRecordData) GetSignature() types.Signature     { return nil }
 func (d *testRecordData) GetPreviousRecordCid() string      { return "" }

--- a/server/database/gorm/catalog.go
+++ b/server/database/gorm/catalog.go
@@ -1,0 +1,198 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package gorm
+
+import (
+	"fmt"
+
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
+	"github.com/agntcy/dir/server/types"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+	"gorm.io/gorm"
+)
+
+// defaultCatalogPageSize is applied when the caller does not set a limit.
+const defaultCatalogPageSize = 20
+
+// catalogSortColumns allow-lists the columns a controller may sort by,
+// mapping the logical name to the qualified column so caller-supplied sort
+// keys are never interpolated into the query verbatim.
+var catalogSortColumns = map[string]string{
+	"created_at":     "records.oasf_created_at",
+	"name":           "records.name",
+	"version":        "records.version",
+	"schema_version": "records.schema_version",
+	"record_cid":     "records.record_cid",
+}
+
+// GetCatalogEntries returns the AI Catalog entries matching the given record
+// filters, using peek-ahead pagination (Limit+1) to report hasMore. Records
+// with no AI Catalog projection are skipped rather than failing the page.
+func (d *DB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.CatalogEntry, bool, error) {
+	cfg := &types.RecordFilters{}
+
+	for _, opt := range opts {
+		if opt == nil {
+			return nil, false, fmt.Errorf("nil filter option provided")
+		}
+
+		opt(cfg)
+	}
+
+	pageSize := cfg.Limit
+	if pageSize <= 0 {
+		pageSize = defaultCatalogPageSize
+	}
+
+	// Eager-load the associations the projection walks; DISTINCT drops the
+	// duplicate rows introduced by the filter JOINs.
+	query := d.gormDB.
+		Model(&Record{}).
+		Select("records.*").
+		Distinct().
+		Preload("Modules").
+		Preload("Skills").
+		Preload("Domains").
+		Preload("Annotations").
+		Limit(pageSize + 1)
+
+	if cfg.Offset > 0 {
+		query = query.Offset(cfg.Offset)
+	}
+
+	query = d.handleFilterOptions(query, cfg)
+
+	query, err := applyCatalogOrder(query, cfg)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var records []Record
+	if err := query.Find(&records).Error; err != nil {
+		return nil, false, fmt.Errorf("query catalog records: %w", err)
+	}
+
+	hasMore := len(records) > pageSize
+	if hasMore {
+		records = records[:pageSize]
+	}
+
+	entries := make([]*catalogv1.CatalogEntry, 0, len(records))
+
+	for i := range records {
+		entry, err := recordToCatalogEntry(&records[i])
+		if err != nil {
+			// Expected for records without a known catalog module.
+			logger.Debug("skipping record without catalog projection", "record_cid", records[i].RecordCID, "error", err)
+
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, hasMore, nil
+}
+
+// applyCatalogOrder appends the allow-listed ORDER BY clauses plus a
+// primary-key tiebreaker for stable paging, defaulting to newest-first.
+func applyCatalogOrder(query *gorm.DB, cfg *types.RecordFilters) (*gorm.DB, error) {
+	if len(cfg.OrderBy) == 0 {
+		query = query.Order("records.oasf_created_at DESC")
+	}
+
+	for _, o := range cfg.OrderBy {
+		column, ok := catalogSortColumns[o.Column]
+		if !ok {
+			return nil, fmt.Errorf("unsupported sort column %q", o.Column)
+		}
+
+		direction := "ASC"
+		if o.Desc {
+			direction = "DESC"
+		}
+
+		query = query.Order(fmt.Sprintf("%s %s", column, direction))
+	}
+
+	return query.Order("records.record_cid ASC"), nil
+}
+
+// recordToCatalogEntry reconstructs the OASF record from its associations and
+// delegates the AI Catalog projection to the oasf-sdk translator.
+func recordToCatalogEntry(r *Record) (*catalogv1.CatalogEntry, error) {
+	record, err := recordToStruct(r)
+	if err != nil {
+		return nil, fmt.Errorf("build record struct: %w", err)
+	}
+
+	catalog, err := translator.RecordToCatalog(record, translator.WithCatalogCID(r.RecordCID))
+	if err != nil {
+		return nil, fmt.Errorf("project record to catalog: %w", err)
+	}
+
+	return catalogEntryFromStruct(catalog)
+}
+
+// recordToStruct rebuilds the subset of the OASF record the projection reads:
+// identity fields plus the Modules/Skills/Domains/Annotations associations.
+func recordToStruct(r *Record) (*structpb.Struct, error) {
+	modules := make([]any, 0, len(r.Modules))
+
+	for _, m := range r.Modules {
+		module := map[string]any{"name": m.Name}
+		if len(m.Data) > 0 {
+			module["data"] = m.Data
+		}
+
+		modules = append(modules, module)
+	}
+
+	skills := make([]any, 0, len(r.Skills))
+	for _, s := range r.Skills {
+		skills = append(skills, map[string]any{"name": s.Name})
+	}
+
+	domains := make([]any, 0, len(r.Domains))
+	for _, d := range r.Domains {
+		domains = append(domains, map[string]any{"name": d.Name})
+	}
+
+	annotations := make(map[string]any, len(r.Annotations))
+	for _, a := range r.Annotations {
+		annotations[a.Key] = a.Value
+	}
+
+	fields := map[string]any{
+		"name":           r.Name,
+		"version":        r.Version,
+		"description":    r.Description,
+		"schema_version": r.SchemaVersion,
+		"created_at":     r.OASFCreatedAt,
+		"modules":        modules,
+		"skills":         skills,
+		"domains":        domains,
+		"annotations":    annotations,
+	}
+
+	return structpb.NewStruct(fields) //nolint:wrapcheck
+}
+
+// catalogEntryFromStruct converts the translator's structpb output into the
+// typed CatalogEntry message.
+func catalogEntryFromStruct(s *structpb.Struct) (*catalogv1.CatalogEntry, error) {
+	raw, err := protojson.Marshal(s)
+	if err != nil {
+		return nil, fmt.Errorf("marshal catalog entry: %w", err)
+	}
+
+	var entry catalogv1.CatalogEntry
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(raw, &entry); err != nil {
+		return nil, fmt.Errorf("decode catalog entry: %w", err)
+	}
+
+	return &entry, nil
+}

--- a/server/database/gorm/module.go
+++ b/server/database/gorm/module.go
@@ -16,6 +16,13 @@ type Module struct {
 	RecordCID string `gorm:"column:record_cid;not null;index"`
 	Name      string `gorm:"not null"`
 	ModuleID  uint64 `gorm:"column:module_id"`
+
+	// Data is the module's structured payload (e.g. the A2A agent card or
+	// MCP server definition).
+	//
+	// TODO: this is a temporary solution. The module data will be stored as a
+	// separate artifact in the future and will need to be retrieved differently.
+	Data map[string]any `gorm:"column:data;serializer:json"`
 }
 
 func (module *Module) GetName() string {
@@ -27,8 +34,7 @@ func (module *Module) GetID() uint64 {
 }
 
 func (module *Module) GetData() map[string]any {
-	// Database modules don't store data, return empty map
-	return make(map[string]any)
+	return module.Data
 }
 
 // convertModules transforms interface types to Database structs.
@@ -39,6 +45,7 @@ func convertModules(modules []types.Module, recordCID string) []Module {
 			RecordCID: recordCID,
 			Name:      module.GetName(),
 			ModuleID:  module.GetID(),
+			Data:      module.GetData(),
 		}
 	}
 

--- a/server/database/gorm/record.go
+++ b/server/database/gorm/record.go
@@ -20,6 +20,7 @@ type Record struct {
 	RecordCID     string   `gorm:"column:record_cid;primarykey;not null"`
 	Name          string   `gorm:"not null"`
 	Version       string   `gorm:"not null"`
+	Description   string   `gorm:"column:description"`
 	SchemaVersion string   `gorm:"column:schema_version"`
 	OASFCreatedAt string   `gorm:"column:oasf_created_at"`
 	Authors       []string `gorm:"column:authors;serializer:json"` // Stored as JSON array
@@ -82,8 +83,7 @@ func (r *RecordDataAdapter) GetVersion() string {
 }
 
 func (r *RecordDataAdapter) GetDescription() string {
-	// Database records don't store description
-	return ""
+	return r.record.Description
 }
 
 func (r *RecordDataAdapter) GetAuthors() []string {
@@ -166,6 +166,7 @@ func (d *DB) AddRecord(record types.Record) error {
 		RecordCID:     cid,
 		Name:          recordData.GetName(),
 		Version:       recordData.GetVersion(),
+		Description:   recordData.GetDescription(),
 		SchemaVersion: recordData.GetSchemaVersion(),
 		OASFCreatedAt: recordData.GetCreatedAt(),
 		Authors:       recordData.GetAuthors(),

--- a/server/gateway/gateway.go
+++ b/server/gateway/gateway.go
@@ -1,0 +1,173 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gateway hosts the in-process grpc-gateway sidecar that exposes
+// annotated gRPC services as HTTP/JSON. It dials the gRPC server over
+// loopback so existing interceptors (authn, authz, rate limit, logging,
+// metrics) still apply to HTTP requests. Disabled by default.
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
+	"github.com/agntcy/dir/utils/logging"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var logger = logging.Logger("gateway")
+
+const (
+	httpReadTimeout       = 10 * time.Second
+	httpReadHeaderTimeout = 5 * time.Second
+	httpWriteTimeout      = 30 * time.Second
+	httpIdleTimeout       = 60 * time.Second
+)
+
+// Server owns the gateway mux, the loopback gRPC client conn, and the HTTP listener.
+type Server struct {
+	httpServer *http.Server
+	grpcConn   *grpc.ClientConn
+	address    string
+}
+
+// Options configures the gateway sidecar.
+type Options struct {
+	// HTTPAddress is the address the HTTP gateway binds to (e.g. ":8889").
+	HTTPAddress string
+
+	// GRPCEndpoint is the loopback address of the gRPC server to proxy to.
+	GRPCEndpoint string
+
+	// RegisterHandlers registers each annotated service with the gateway mux
+	// (e.g. RegisterAIFinder).
+	RegisterHandlers func(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error
+}
+
+// New constructs a gateway server. Call Start to begin serving.
+func New(ctx context.Context, opts Options) (*Server, error) {
+	if opts.HTTPAddress == "" {
+		return nil, errors.New("gateway http address is required")
+	}
+
+	if opts.GRPCEndpoint == "" {
+		return nil, errors.New("gateway grpc endpoint is required")
+	}
+
+	if opts.RegisterHandlers == nil {
+		return nil, errors.New("gateway register handlers function is required")
+	}
+
+	// Loopback dial only, so insecure credentials are appropriate. grpc.NewClient
+	// is non-blocking, so the gateway can be constructed before the gRPC server
+	// accepts connections.
+	conn, err := grpc.NewClient(
+		opts.GRPCEndpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC client for %q: %w", opts.GRPCEndpoint, err)
+	}
+
+	// Field names use protojson's lowerCamelCase default (specVersion, mediaType)
+	// to match the AI Catalog spec.
+	jsonMarshaler := &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			UseProtoNames:   false,
+			EmitUnpopulated: true,
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		},
+	}
+
+	// HTTPBodyMarshaler emits google.api.HttpBody payloads as raw bytes with the
+	// supplied Content-Type (for export-style endpoints) and falls back to JSON
+	// for all other messages.
+	httpBodyMarshaler := &runtime.HTTPBodyMarshaler{Marshaler: jsonMarshaler}
+
+	mux := runtime.NewServeMux(
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, httpBodyMarshaler),
+	)
+
+	if err := opts.RegisterHandlers(ctx, mux, conn); err != nil {
+		_ = conn.Close()
+
+		return nil, fmt.Errorf("failed to register grpc-gateway handlers: %w", err)
+	}
+
+	httpServer := &http.Server{
+		Addr:              opts.HTTPAddress,
+		Handler:           mux,
+		ReadTimeout:       httpReadTimeout,
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		WriteTimeout:      httpWriteTimeout,
+		IdleTimeout:       httpIdleTimeout,
+	}
+
+	return &Server{
+		httpServer: httpServer,
+		grpcConn:   conn,
+		address:    opts.HTTPAddress,
+	}, nil
+}
+
+// Start binds the listen address and serves in a background goroutine. Binding
+// is synchronous so immediate failures (port in use) surface from Start.
+func (s *Server) Start() error {
+	listener, err := net.Listen("tcp", s.address) //nolint:noctx
+	if err != nil {
+		return fmt.Errorf("failed to listen on %q: %w", s.address, err)
+	}
+
+	go func() {
+		logger.Info("HTTP gateway serving", "address", s.address)
+
+		if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("HTTP gateway error", "error", err)
+		}
+	}()
+
+	logger.Info("HTTP gateway started", "address", s.address)
+
+	return nil
+}
+
+// Stop gracefully shuts the gateway and closes the loopback connection.
+func (s *Server) Stop(ctx context.Context) error {
+	logger.Info("Stopping HTTP gateway", "address", s.address)
+
+	var firstErr error
+
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		firstErr = fmt.Errorf("failed to shutdown HTTP gateway: %w", err)
+	}
+
+	if err := s.grpcConn.Close(); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("failed to close gateway gRPC conn: %w", err)
+	}
+
+	if firstErr == nil {
+		logger.Info("HTTP gateway stopped")
+	}
+
+	return firstErr
+}
+
+// RegisterAIFinder is a RegisterHandlers implementation that exposes the
+// AI Finder service over HTTP.
+func RegisterAIFinder(ctx context.Context, mux *runtime.ServeMux, conn *grpc.ClientConn) error {
+	if err := catalogv1.RegisterAIFinderServiceHandler(ctx, mux, conn); err != nil {
+		return fmt.Errorf("register AIFinderService handler: %w", err)
+	}
+
+	return nil
+}

--- a/server/gateway/gateway_test.go
+++ b/server/gateway/gateway_test.go
@@ -1,0 +1,115 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/api/httpbody"
+	"google.golang.org/grpc"
+)
+
+func noopRegister(context.Context, *runtime.ServeMux, *grpc.ClientConn) error { return nil }
+
+func TestNew_Validation(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+	}{
+		{
+			name: "missing http address",
+			opts: Options{GRPCEndpoint: "127.0.0.1:8888", RegisterHandlers: noopRegister},
+		},
+		{
+			name: "missing grpc endpoint",
+			opts: Options{HTTPAddress: ":8889", RegisterHandlers: noopRegister},
+		},
+		{
+			name: "missing register handlers",
+			opts: Options{HTTPAddress: ":8889", GRPCEndpoint: "127.0.0.1:8888"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, err := New(context.Background(), tt.opts)
+			require.Error(t, err)
+			assert.Nil(t, server)
+		})
+	}
+}
+
+func TestNew_RegistrationFailure(t *testing.T) {
+	wantErr := errors.New("boom")
+
+	server, err := New(context.Background(), Options{
+		HTTPAddress:  ":0",
+		GRPCEndpoint: "127.0.0.1:8888",
+		RegisterHandlers: func(context.Context, *runtime.ServeMux, *grpc.ClientConn) error {
+			return wantErr
+		},
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, server)
+}
+
+func TestNew_RegisterAIFinder(t *testing.T) {
+	// Routes wire up even though the gRPC service is not served yet (lazy conn).
+	server, err := New(context.Background(), Options{
+		HTTPAddress:      ":0",
+		GRPCEndpoint:     "127.0.0.1:8888",
+		RegisterHandlers: RegisterAIFinder,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	t.Cleanup(func() { _ = server.Stop(context.Background()) })
+}
+
+func TestStartStop(t *testing.T) {
+	server, err := New(context.Background(), Options{
+		HTTPAddress:      ":0",
+		GRPCEndpoint:     "127.0.0.1:8888",
+		RegisterHandlers: noopRegister,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, server.Start())
+	require.NoError(t, server.Stop(context.Background()))
+}
+
+// TestHTTPBodyMarshaler verifies the HttpBody contract New() installs: raw
+// bytes verbatim with the supplied Content-Type, JSON fallback otherwise.
+func TestHTTPBodyMarshaler(t *testing.T) {
+	marshaler := &runtime.HTTPBodyMarshaler{Marshaler: &runtime.JSONPb{}}
+
+	t.Run("returns Data bytes verbatim for HttpBody", func(t *testing.T) {
+		body := &httpbody.HttpBody{
+			ContentType: "text/markdown; charset=utf-8",
+			Data:        []byte("# SKILL.md\n\nhello\n"),
+		}
+
+		got, err := marshaler.Marshal(body)
+		require.NoError(t, err)
+		assert.Equal(t, body.GetData(), got)
+	})
+
+	t.Run("uses ContentType from HttpBody", func(t *testing.T) {
+		body := &httpbody.HttpBody{
+			ContentType: "application/json",
+			Data:        []byte("{\"ok\":true}\n"),
+		}
+
+		assert.Equal(t, "application/json", marshaler.ContentType(body))
+	})
+
+	t.Run("falls back to JSONPb for non-HttpBody messages", func(t *testing.T) {
+		assert.Equal(t, "application/json", marshaler.ContentType("not an HttpBody"))
+	})
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -18,7 +18,7 @@ require (
 	buf.build/go/protovalidate v1.2.0
 	github.com/agntcy/dir/api v1.4.0
 	github.com/agntcy/dir/utils v1.4.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.5
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3

--- a/server/go.mod
+++ b/server/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/glebarez/sqlite v1.11.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/ipfs/go-datastore v0.9.1
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/libp2p/go-libp2p v0.48.0
@@ -36,6 +37,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/stretchr/testify v1.11.1
+	google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gorm.io/driver/postgres v1.6.0
@@ -57,7 +59,6 @@ require (
 	github.com/pion/turn/v5 v5.0.3 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/smarty/assertions v1.16.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348 // indirect
 	modernc.org/libc v1.72.2 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -60,8 +60,8 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/agntcy/oasf-sdk/pkg v1.0.5 h1:Sv8K9tqdfl4gfl30spFh9MYkqnzXcTByCsb2uZsNWE4=
-github.com/agntcy/oasf-sdk/pkg v1.0.5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557 h1:cU0wG7uw1CCv3RBKFW8HG0j3CXVfxdUkgTtQ50PxHoY=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=

--- a/server/go.sum
+++ b/server/go.sum
@@ -257,6 +257,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBH
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/server/server.go
+++ b/server/server.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	eventsv1 "github.com/agntcy/dir/api/events/v1"
 	namingv1 "github.com/agntcy/dir/api/naming/v1"
@@ -313,6 +314,7 @@ func New(ctx context.Context, cfg *config.Config, opts ...ServerOption) (*Server
 		namingProvider,
 		controller.WithVerificationTTL(options.Config().Naming.GetTTL()),
 	))
+	catalogv1.RegisterAIFinderServiceServer(grpcServer, controller.NewAIFinderController(databaseAPI))
 
 	// Register health service
 	healthChecker.Register(grpcServer)

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/agntcy/dir/server/controller"
 	"github.com/agntcy/dir/server/database"
 	"github.com/agntcy/dir/server/events"
+	"github.com/agntcy/dir/server/gateway"
 	"github.com/agntcy/dir/server/healthcheck"
 	"github.com/agntcy/dir/server/metrics"
 	grpclogging "github.com/agntcy/dir/server/middleware/logging"
@@ -67,6 +68,7 @@ type Server struct {
 	health             *healthcheck.Checker
 	grpcServer         *grpc.Server
 	metricsServer      *metrics.Server
+	httpGateway        *gateway.Server
 }
 
 // buildConnectionOptions creates gRPC server options for connection management.
@@ -325,6 +327,29 @@ func New(ctx context.Context, cfg *config.Config, opts ...ServerOption) (*Server
 		logger.Info("gRPC metrics registered")
 	}
 
+	// Build the HTTP gateway sidecar if enabled.
+	var httpGateway *gateway.Server
+
+	if cfg.HTTPGateway.Enabled {
+		gwCfg := cfg.HTTPGateway.WithDefaults()
+
+		// The gateway dials the gRPC server over loopback, so keep the
+		// configured port but force the host to 127.0.0.1.
+		_, grpcPort, _ := net.SplitHostPort(cfg.ListenAddress)
+		grpcEndpoint := net.JoinHostPort("127.0.0.1", grpcPort)
+
+		httpGateway, err = gateway.New(ctx, gateway.Options{
+			HTTPAddress:      gwCfg.ListenAddress,
+			GRPCEndpoint:     grpcEndpoint,
+			RegisterHandlers: gateway.RegisterAIFinder,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP gateway: %w", err)
+		}
+
+		logger.Info("HTTP gateway configured", "address", gwCfg.ListenAddress, "grpc_endpoint", grpcEndpoint)
+	}
+
 	return &Server{
 		options:            options,
 		store:              storeAPI,
@@ -338,6 +363,7 @@ func New(ctx context.Context, cfg *config.Config, opts ...ServerOption) (*Server
 		health:             healthChecker,
 		grpcServer:         grpcServer,
 		metricsServer:      metricsServer,
+		httpGateway:        httpGateway,
 	}, nil
 }
 
@@ -416,6 +442,16 @@ func (s Server) Close(ctx context.Context) {
 		}
 	}
 
+	// Stop HTTP gateway before grpcServer.GracefulStop to close its loopback conn first.
+	if s.httpGateway != nil {
+		stopCtx, cancel := context.WithTimeout(ctx, 10*time.Second) //nolint:mnd
+		defer cancel()
+
+		if err := s.httpGateway.Stop(stopCtx); err != nil {
+			logger.Error("Failed to stop HTTP gateway", "error", err)
+		}
+	}
+
 	s.grpcServer.GracefulStop()
 }
 
@@ -466,6 +502,13 @@ func (s Server) Start(ctx context.Context) error {
 			logger.Error("Failed to start server", "error", err)
 		}
 	}()
+
+	// Start the HTTP gateway sidecar when configured.
+	if s.httpGateway != nil {
+		if err := s.httpGateway.Start(); err != nil {
+			return fmt.Errorf("failed to start HTTP gateway: %w", err)
+		}
+	}
 
 	return nil
 }

--- a/server/types/database.go
+++ b/server/types/database.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
 	routingv1 "github.com/agntcy/dir/api/routing/v1"
 	storev1 "github.com/agntcy/dir/api/store/v1"
 )
@@ -26,6 +27,9 @@ type DatabaseAPI interface {
 
 	// SignatureVerificationDatabaseAPI handles management of signature verifications.
 	SignatureVerificationDatabaseAPI
+
+	// CatalogDatabaseAPI handles deterministic browsing of AI Catalog entries.
+	CatalogDatabaseAPI
 
 	// Close closes the database connection and releases any resources.
 	Close() error
@@ -104,6 +108,14 @@ type NameVerificationDatabaseAPI interface {
 	// GetRecordsNeedingVerification retrieves signed records with verifiable names
 	// that either don't have a verification or have an expired verification.
 	GetRecordsNeedingVerification(ttl time.Duration) ([]Record, error)
+}
+
+// CatalogDatabaseAPI exposes the deterministic-browsing query backing the
+// AI Finder GET /v1/agents endpoint.
+type CatalogDatabaseAPI interface {
+	// GetCatalogEntries returns the AI Catalog entries matching the given
+	// record filters, along with whether more results exist beyond the page.
+	GetCatalogEntries(opts ...FilterOption) (entries []*catalogv1.CatalogEntry, hasMore bool, err error)
 }
 
 type SignatureVerificationDatabaseAPI interface {

--- a/server/types/search.go
+++ b/server/types/search.go
@@ -23,6 +23,14 @@ type RecordFilters struct {
 	Trusted          *bool // Filter by trusted status (signature verification passed)
 	AnnotationKeys   []string
 	AnnotationValues []string
+
+	OrderBy []RecordOrderClause // Order by directives applied in sequence.
+}
+
+// RecordOrderClause is a single ORDER BY directive.
+type RecordOrderClause struct {
+	Column string
+	Desc   bool
 }
 
 type FilterOption func(*RecordFilters)
@@ -108,6 +116,13 @@ func WithDomainNames(names ...string) FilterOption {
 func WithCreatedAts(createdAts ...string) FilterOption {
 	return func(sc *RecordFilters) {
 		sc.CreatedAts = append(sc.CreatedAts, createdAts...)
+	}
+}
+
+// WithOrderBy appends ORDER BY directives.
+func WithOrderBy(clauses ...RecordOrderClause) FilterOption {
+	return func(sc *RecordFilters) {
+		sc.OrderBy = append(sc.OrderBy, clauses...)
 	}
 }
 

--- a/tests/e2e/local/13_ai_finder_test.go
+++ b/tests/e2e/local/13_ai_finder_test.go
@@ -1,0 +1,117 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/agntcy/dir/tests/e2e/shared/testdata"
+	"github.com/agntcy/dir/tests/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// AI Finder ListAgents over the HTTP gateway (GET /v1/agents).
+//
+// Uses ExpectedRecordV100JSON ("burger_seller_agent"), which carries
+// integration/mcp and integration/a2a modules and therefore projects to an
+// AI Catalog entry. The gateway is only deployed in the host "local"
+// environment, so these specs skip elsewhere.
+var _ = ginkgo.Describe("AI Finder ListAgents HTTP API", func() {
+	ginkgo.BeforeEach(func() {
+		utils.ResetCLIState()
+	})
+
+	var (
+		tempDir    string
+		recordPath string
+		recordCID  string
+	)
+
+	ginkgo.Context("with a published record", ginkgo.Ordered, func() {
+		ginkgo.BeforeAll(func() {
+			if testEnv.Config.GatewayAddress == "" {
+				ginkgo.Skip("HTTP gateway address not configured for this environment")
+			}
+
+			var err error
+
+			tempDir, err = os.MkdirTemp("", "ai-finder-test")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			recordPath = filepath.Join(tempDir, "record_100.json")
+			err = os.WriteFile(recordPath, testdata.ExpectedRecordV100JSON, 0o600)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			recordCID = testEnv.CLI.Push(recordPath).WithArgs("--output", "raw").ShouldSucceed()
+			gomega.Expect(recordCID).NotTo(gomega.BeEmpty())
+		})
+
+		ginkgo.AfterAll(func() {
+			if tempDir != "" {
+				_ = os.RemoveAll(tempDir)
+			}
+		})
+
+		ginkgo.It("lists the published agent", func(ctx ginkgo.SpecContext) {
+			gomega.Eventually(func(g gomega.Gomega) {
+				status, body := getAgents(ctx, "")
+				g.Expect(status).To(gomega.Equal(http.StatusOK))
+				g.Expect(body).To(gomega.ContainSubstring(recordCID))
+				g.Expect(body).To(gomega.ContainSubstring("burger_seller_agent"))
+			}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("filters by displayName", func(ctx ginkgo.SpecContext) {
+			query := url.Values{"filter": {"displayName=burger_seller_agent"}}.Encode()
+
+			status, body := getAgents(ctx, query)
+			gomega.Expect(status).To(gomega.Equal(http.StatusOK))
+			gomega.Expect(body).To(gomega.ContainSubstring(recordCID))
+		})
+
+		ginkgo.It("returns no results for a non-matching filter", func(ctx ginkgo.SpecContext) {
+			query := url.Values{"filter": {"displayName=does-not-exist"}}.Encode()
+
+			status, body := getAgents(ctx, query)
+			gomega.Expect(status).To(gomega.Equal(http.StatusOK))
+			gomega.Expect(body).NotTo(gomega.ContainSubstring(recordCID))
+		})
+
+		ginkgo.It("rejects an invalid filter with HTTP 400", func(ctx ginkgo.SpecContext) {
+			query := url.Values{"filter": {"displayName"}}.Encode()
+
+			status, _ := getAgents(ctx, query)
+			gomega.Expect(status).To(gomega.Equal(http.StatusBadRequest))
+		})
+	})
+})
+
+// getAgents issues GET /v1/agents against the deployed HTTP gateway and
+// returns the status code and response body.
+func getAgents(ctx context.Context, rawQuery string) (int, string) {
+	target := testEnv.Config.GatewayAddress + "/v1/agents"
+	if rawQuery != "" {
+		target += "?" + rawQuery
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	resp, err := http.DefaultClient.Do(req)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return resp.StatusCode, string(body)
+}

--- a/tests/e2e/local/config/config.go
+++ b/tests/e2e/local/config/config.go
@@ -10,6 +10,11 @@ type Config struct {
 	// MetricsAddress is the address the metric endpoint binds to.
 	MetricsAddress string `json:"metrics_address,omitempty" mapstructure:"metrics_address"`
 
+	// GatewayAddress is the base URL of the HTTP gateway (e.g.
+	// "http://localhost:19892"). Empty when the gateway is not deployed in
+	// this environment, in which case AI Finder HTTP tests are skipped.
+	GatewayAddress string `json:"gateway_address,omitempty" mapstructure:"gateway_address"`
+
 	// CliPath is the path to the CLI binary.
 	CliPath string `json:"cli_path,omitempty" mapstructure:"cli_path"`
 

--- a/tests/e2e/local/testenv/kind/dir-chart-values.yaml
+++ b/tests/e2e/local/testenv/kind/dir-chart-values.yaml
@@ -26,3 +26,10 @@ apiserver:
         interval: "5s"
       signature:
         interval: "5s"
+
+  httpGateway:
+    enabled: true
+    port: 8889
+    service:
+      type: NodePort
+      nodePort: 30889

--- a/tests/e2e/local/testenv/kind/kind-cluster.yaml
+++ b/tests/e2e/local/testenv/kind/kind-cluster.yaml
@@ -9,3 +9,6 @@ nodes:
     # DIR metrics server
     - hostPort: 18889
       containerPort: 30090
+    # DIR HTTP gateway
+    - hostPort: 18892
+      containerPort: 30889

--- a/tests/e2e/local/testenv/local/dir-daemon-config.yaml
+++ b/tests/e2e/local/testenv/local/dir-daemon-config.yaml
@@ -15,6 +15,9 @@ server:
   metrics:
     enabled: true
     address: "localhost:19889"
+  http_gateway:
+    enabled: true
+    listen_address: "localhost:19892"
   routing:
     refresh_interval: "1s"
     listen_address: "/ip4/127.0.0.1/tcp/0"

--- a/tests/e2e/local/testenv/local/test-config.yaml
+++ b/tests/e2e/local/testenv/local/test-config.yaml
@@ -1,6 +1,7 @@
 local:
   server_address: "localhost:19888"
   metrics_address: "http://localhost:19889/metrics"
+  gateway_address: "http://localhost:19892"
   # cli_path: "/path/to/cli"
   cli_extra_args:
   - "--server-addr=localhost:19888"

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/agntcy/dir/reconciler v1.4.0 // indirect
 	github.com/agntcy/dir/server v1.4.0
 	github.com/agntcy/dir/utils v1.4.0 // indirect
-	github.com/agntcy/oasf-sdk/pkg v1.0.5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -202,8 +202,8 @@ github.com/agntcy/dir-runtime/store v1.3.1 h1:CPIV60I5MAJG5hPK6Vv+MhHiYFmaf7tCxq
 github.com/agntcy/dir-runtime/store v1.3.1/go.mod h1:ywWhrOu30CoZnsfXdY5hh5vBadZqUNGfeH/xIcPVYag=
 github.com/agntcy/dir-runtime/utils v1.3.1 h1:sEXS9TlFyK3d0NIZzaMQqW8cRjm/FgYTC1aWHte8JOo=
 github.com/agntcy/dir-runtime/utils v1.3.1/go.mod h1:ugJUOWpR+kOxVv22snmYSMMNqTh1c6leZ9CJcEZRMpo=
-github.com/agntcy/oasf-sdk/pkg v1.0.5 h1:Sv8K9tqdfl4gfl30spFh9MYkqnzXcTByCsb2uZsNWE4=
-github.com/agntcy/oasf-sdk/pkg v1.0.5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557 h1:cU0wG7uw1CCv3RBKFW8HG0j3CXVfxdUkgTtQ50PxHoY=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260603092510-c72d9654e557/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
Adds the AI Finder discovery surface (`GET /v1/agents`) so clients can browse catalog entries over HTTP/JSON with spec-correct filtering, ordering, and paging. The feature spans a new grpc-gateway sidecar, a catalog query layer in the database, and a thin controller that adapts the AI Finder query language to it; the gateway is opt-in and disabled by default.

- Adds an in-process grpc-gateway `Server` (`server/gateway`) that transcodes annotated gRPC services to HTTP/JSON over a loopback dial, with an `HttpBody` marshaler and configurable, default-off `HTTPGateway` server config.
- Adds the catalog query layer: `CatalogDatabaseAPI.GetCatalogEntries` with eager-loaded associations, peek-ahead pagination, allow-listed sort columns, and SDK-driven projection, plus persistence of module `data` and record `description` needed by the projection.
- Adds the `AIFinderService` `ListAgents` controller: an Appendix-A filter grammar parser (AND across fields, comma-OR within a field), `order_by` allow-list, page-size clamping, and base64 opaque page tokens, with errors mapped to `INVALID_ARGUMENT`.
- Registers `AIFinderService` on the gRPC server and wires the gateway sidecar in `server.go`.
- Adds unit tests for the parser, paging, controller (against a fake DB), and the catalog query layer (SQLite), plus a `tests/e2e/local` spec that pushes a record and queries `/v1/agents` against a deployed directory (skips where the gateway isn't deployed).