### PR TITLE
fix(dirctl): latest brew formulae missing env

### DIFF
--- a/.github/workflows/reusable-brew-update.yaml
+++ b/.github/workflows/reusable-brew-update.yaml
@@ -144,6 +144,8 @@ jobs:
 
           dirctl --help
 
+          dirctl completion bash > /dev/null
+
       - name: Create PR
         if: ${{ steps.brew-formula.outputs.DIFF_FOUND == 1 && steps.test-brew-formula.outcome == 'success' && inputs.dry-run == false }}
         run: |

--- a/HomebrewFormula/README.md
+++ b/HomebrewFormula/README.md
@@ -5,6 +5,11 @@
     brew tap agntcy/dir https://github.com/agntcy/dir/
 ```
 
+## Trust the formulae for getting updates
+```bash
+    brew trust agntcy/dir
+```
+
 ## How to install the latest dirctl formula
 ```bash
     brew install dirctl

--- a/HomebrewFormula/dirctl/dirctl.rb
+++ b/HomebrewFormula/dirctl/dirctl.rb
@@ -16,6 +16,7 @@ class Dirctl < Formula
               bin.install "dirctl-darwin-arm64" => "dirctl"
 
               system "chmod", "+x", bin/"dirctl"
+              ENV["DIRECTORY_CLIENT_SERVER_ADDRESS"] = "127.0.0.1:8888"
               generate_completions_from_executable(bin/"dirctl", "completion", shells: [:bash, :zsh, :fish])
           end
       end
@@ -28,6 +29,7 @@ class Dirctl < Formula
               bin.install "dirctl-darwin-amd64" => "dirctl"
 
               system "chmod", "+x", bin/"dirctl"
+              ENV["DIRECTORY_CLIENT_SERVER_ADDRESS"] = "127.0.0.1:8888"
               generate_completions_from_executable(bin/"dirctl", "completion", shells: [:bash, :zsh, :fish])
           end
       end
@@ -42,6 +44,7 @@ class Dirctl < Formula
               bin.install "dirctl-linux-arm64" => "dirctl"
 
               system "chmod", "+x", bin/"dirctl"
+              ENV["DIRECTORY_CLIENT_SERVER_ADDRESS"] = "127.0.0.1:8888"
               generate_completions_from_executable(bin/"dirctl", "completion", shells: [:bash, :zsh, :fish])
           end
       end
@@ -54,6 +57,7 @@ class Dirctl < Formula
               bin.install "dirctl-linux-amd64" => "dirctl"
 
               system "chmod", "+x", bin/"dirctl"
+              ENV["DIRECTORY_CLIENT_SERVER_ADDRESS"] = "127.0.0.1:8888"
               generate_completions_from_executable(bin/"dirctl", "completion", shells: [:bash, :zsh, :fish])
           end
       end


### PR DESCRIPTION
This PR re-revert a commit which removes the fix for the latest brew formulae to patch the binary required env var.