### PR TITLE
fix(helm): drop unused federatesWith spire config for services

### DIFF
--- a/install/charts/dir/apiserver/templates/clusterspiffeids.yaml
+++ b/install/charts/dir/apiserver/templates/clusterspiffeids.yaml
@@ -27,10 +27,4 @@ spec:
   dnsNameTemplates:
     {{- toYaml .Values.spire.dnsNameTemplates | nindent 4 }}
   {{- end }}
-  {{- if .Values.spire.federation }}
-  federatesWith:
-  {{ range .Values.spire.federation }}
-    - {{ .trustDomain }}
-  {{ end }}
-  {{- end }}
 {{- end }}

--- a/install/charts/dir/apiserver/templates/reconciler-clusterspiffeid.yaml
+++ b/install/charts/dir/apiserver/templates/reconciler-clusterspiffeid.yaml
@@ -23,10 +23,4 @@ spec:
     - k8s:sa:{{ include "chart.serviceAccountName" . }}
   spiffeIDTemplate: {{ "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}" }}
   autoPopulateDNSNames: true
-  {{- if .Values.spire.federation }}
-  federatesWith:
-  {{ range .Values.spire.federation }}
-    - {{ .trustDomain }}
-  {{ end }}
-  {{- end }}
 {{- end }}

--- a/install/charts/dirctl/templates/clusterspiffeids.yaml
+++ b/install/charts/dirctl/templates/clusterspiffeids.yaml
@@ -16,10 +16,4 @@ spec:
     - k8s:sa:{{ include "chart.serviceAccountName" . }}
   spiffeIDTemplate: {{ "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}" }}
   autoPopulateDNSNames: true
-  {{- if .Values.spire.federation }}
-  federatesWith:
-  {{ range .Values.spire.federation }}
-    - {{ .trustDomain }}
-  {{ end }}
-  {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR removes the `federatesWith` in k8s setup from Directory `ClusterSPIFFEID` issued for the common services, including `dir-ctl`, `dir-apiserver`, and `dir-reconciler`. This is because:
- When `federatesWith` is set, it allows these services to communicate across SPIFFE domains. This is never used nor needed for these services. Only custom workflows such as cronjobs or other services may need this, but they should be deployed separately from Directory. Directory still offers a way to setup `ClusterFederatedTrustDomain`, which is just a helper operation. It is the responsibility of the Ops teams to define `ClusterSPIFFEID` for their custom services.
- **When `federatesWith` is set, if there is a domain that is down, it will not be possible to mint/remint a new `ClusterSPIFFEID` for a specific service, which can bring a given service down**. This PR also resolves a bug where an external partner could bring down the DIR infra simply by shutting down the SPIRE federation endpoint.

Resources:
- https://github.com/spiffe/spire-controller-manager/issues/197
- https://github.com/spiffe/helm-charts/issues/454