### PR TITLE
feat(dir): add SKILL.md file

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/agntcy/dir/server/naming/wellknown"
 	"github.com/agntcy/dir/server/publication"
 	"github.com/agntcy/dir/server/routing"
+	"github.com/agntcy/dir/server/skill"
 	"github.com/agntcy/dir/server/store"
 	"github.com/agntcy/dir/server/types"
 	"github.com/agntcy/dir/utils/logging"
@@ -514,6 +515,14 @@ func (s Server) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to start HTTP gateway: %w", err)
 		}
 	}
+
+	// Best-effort: publishing the DIR self-skill is a usability aid, not a
+	// service dependency, so a failure must not block startup.
+	go func() {
+		if err := skill.Publish(ctx, s.store, s.database, s.oasfValidator); err != nil {
+			logger.Warn("Failed to publish DIR skill record", "error", err)
+		}
+	}()
 
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -516,8 +516,7 @@ func (s Server) Start(ctx context.Context) error {
 		}
 	}
 
-	// Best-effort: publishing the DIR self-skill is a usability aid, not a
-	// service dependency, so a failure must not block startup.
+	// Best-effort, non-blocking: a failure here must not block startup.
 	go func() {
 		if err := skill.Publish(ctx, s.store, s.database, s.oasfValidator); err != nil {
 			logger.Warn("Failed to publish DIR skill record", "error", err)

--- a/server/skill/SKILL.md
+++ b/server/skill/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: agntcy-dir
+description: Use this skill to interact with an AGNTCY Directory (DIR) instance. DIR is a distributed peer-to-peer registry of AI agent records described in OASF. Use it to publish (push), discover (search), retrieve (pull), sign, and verify agent records.
+metadata:
+  author: AGNTCY Contributors
+  version: 1.0.0
+---
+
+# AGNTCY Directory (DIR)
+
+DIR is a distributed registry for AI agent records. Records describe agents using
+the [Open Agentic Schema Framework (OASF)](https://github.com/agntcy/oasf) and
+are content-addressed by CID.
+
+This skill explains how to talk to a running DIR node. You can use the MCP server,
+the `dirctl` CLI, the language SDKs, or the raw gRPC API — pick whichever channel
+your environment supports.
+
+## Vocabulary
+
+- **Record** — an OASF JSON document describing one agent (name, version, skills, locators, modules, signatures).
+- **CID** — Content Identifier; the SHA-based hash that uniquely names a record. Pushing the same record twice yields the same CID.
+- **Skill / Domain** — OASF taxonomy nodes describing what an agent does (e.g. `natural_language_processing/text_completion`) and where it operates.
+- **Module** — typed extension on a record (e.g. `core/language_model/agentskills`, `runtime/mcp`, `integration/a2a`).
+- **Locator** — pointer to a runnable artifact for the agent (`container_image`, `source_code`, `helm_chart`, `package`, `binary`, `url`).
+
+## Channels
+
+| Operation | MCP tool | CLI | Go SDK |
+|---|---|---|---|
+| Push a record | `agntcy_dir_push_record` | `dirctl push <file>` | `client.Push` |
+| Pull by CID | `agntcy_dir_pull_record` | `dirctl pull <cid>` | `client.Pull` |
+| Search local | `agntcy_dir_search_local` | `dirctl search` | `client.Search` |
+| Validate against OASF | `agntcy_oasf_validate_record` | `dirctl validate <file>` | — |
+| List OASF versions | `agntcy_oasf_list_versions` | — | — |
+| Sign a record | — | `dirctl sign --key=<cosign.key> <cid>` | `client.Sign` |
+| Verify a signature | `agntcy_dir_verify_record` | `dirctl verify <cid>` | `client.Verify` |
+| Verify name ownership | `agntcy_dir_verify_name` | `dirctl naming verify <cid>` | — |
+| Import MCP / A2A / SKILL.md | `agntcy_oasf_import_record` | `dirctl import --type=<mcp\|a2a\|agent-skill>` | — |
+
+## Workflow: publish an agent record
+
+1. Author or generate an OASF record JSON. Required top-level fields for the
+   1.0.0 schema: `name`, `schema_version`, `version`, `description`, `authors`,
+   `created_at` (RFC3339), `skills`. Optional: `domains`, `locators`, `modules`,
+   `annotations`.
+2. Validate against the OASF schema before pushing — the server rejects
+   malformed records with `InvalidArgument`.
+3. Push. The server returns the CID. Pushes are idempotent: pushing the same
+   bytes a second time returns the same CID without creating a duplicate.
+4. Optionally sign the record with cosign — produces a signature *referrer*
+   linked to the CID. Anyone can later verify signature and name ownership.
+
+```bash
+dirctl validate agent.json
+CID=$(dirctl push agent.json --output=raw)
+dirctl sign --key=cosign.key "$CID"
+```
+
+## Workflow: discover and pull a record
+
+1. Search by structured filters (names, versions, skills, locators, authors, …).
+   Filters use wildcards: `*` (any), `?` (one char), `[abc]` (set).
+2. The search returns CIDs. Pull each CID to get the full record JSON.
+
+```bash
+dirctl search --skill-name "*text_completion*" --limit 20
+dirctl pull <cid>
+```
+
+For natural-language searches via an LLM, prefer the `search_records` MCP prompt,
+which translates a free-text query into structured filters automatically.
+
+## OASF essentials
+
+- Schema versions in active use: `0.7.0`, `0.8.0`, `1.0.0`. Pick the latest your
+  tooling supports; `1.0.0` is the current default.
+- Module enum is closed in 1.0.0 — only these `name`s validate:
+  `language_model`, `prompt`, `core/language_model/agentskills`, `evaluation`,
+  `observability`, `a2a`, `acp`, `agentspec`, `mcp`. Custom payloads belong in
+  the top-level `annotations` map.
+- Skills and domains are taxonomies; resolve `id` ↔ `name` with the
+  `agntcy_oasf_get_schema_skills` and `agntcy_oasf_get_schema_domains` MCP tools
+  (or fetch the schema JSON directly).
+
+## Common pitfalls
+
+- A record's CID covers its bytes — any change (whitespace, key order) yields a
+  new CID. Re-push only when the record actually changes.
+- Names beginning with `http://` or `https://` opt into domain-based name
+  ownership verification (`/.well-known/jwks.json` on the host). Plain names
+  skip that path.
+- Search defaults to local-only. To find records on remote peers, use routing
+  search (`dirctl routing search …` / `client.SearchRouting`).
+- The server caps records at 4 MB and metadata at 100 KB. Keep large blobs in
+  external storage and reference them via locators.
+
+## Pointers
+
+- OASF schema: <https://schema.oasf.outshift.com/1.0.0>
+- DIR repo & CLI reference: <https://github.com/agntcy/dir>
+- DIR MCP server: <https://github.com/agntcy/dir-mcp>
+- Quickstart docs: <https://docs.agntcy.org/dir/dir-quickstart/>

--- a/server/skill/SKILL.md
+++ b/server/skill/SKILL.md
@@ -21,7 +21,7 @@ your environment supports.
 - **Record** — an OASF JSON document describing one agent (name, version, skills, locators, modules, signatures).
 - **CID** — Content Identifier; the SHA-based hash that uniquely names a record. Pushing the same record twice yields the same CID.
 - **Skill / Domain** — OASF taxonomy nodes describing what an agent does (e.g. `natural_language_processing/text_completion`) and where it operates.
-- **Module** — typed extension on a record (e.g. `core/language_model/agentskills`, `runtime/mcp`, `integration/a2a`).
+- **Module** — typed extension on a record (e.g. `core/language_model/agentskills`, `integration/mcp`, `integration/a2a`).
 - **Locator** — pointer to a runnable artifact for the agent (`container_image`, `source_code`, `helm_chart`, `package`, `binary`, `url`).
 
 ## Channels

--- a/server/skill/publisher.go
+++ b/server/skill/publisher.go
@@ -16,22 +16,12 @@ import (
 
 var logger = logging.Logger("server/skill")
 
-// Publish ensures the embedded SKILL.md is available as an OASF record.
-// Idempotent on name+version: a record matching the current build is not
-// re-pushed. Callers should treat errors as non-fatal — DIR must come up
-// even if the skill record cannot be published.
+// Publish pushes the embedded SKILL.md as an OASF record. Idempotent on
+// name+version. Callers must treat errors as non-fatal — DIR has to start
+// even if publishing fails.
 func Publish(ctx context.Context, store types.StoreAPI, db types.DatabaseAPI, validator corev1.Validator) error {
 	if store == nil || db == nil {
 		return errors.New("store and db must be provided")
-	}
-
-	record, err := BuildRecord(time.Now())
-	if err != nil {
-		return fmt.Errorf("build skill record: %w", err)
-	}
-
-	if err := validateRecord(ctx, record, validator); err != nil {
-		return err
 	}
 
 	if existingCID, ok := findExisting(db); ok {
@@ -44,13 +34,22 @@ func Publish(ctx context.Context, store types.StoreAPI, db types.DatabaseAPI, va
 		return nil
 	}
 
+	record, err := BuildRecord(time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("build skill record: %w", err)
+	}
+
+	if err := validateRecord(ctx, record, validator); err != nil {
+		return err
+	}
+
 	ref, err := store.Push(ctx, record)
 	if err != nil {
 		return fmt.Errorf("push skill record: %w", err)
 	}
 
-	// Mirror the gRPC store controller: keep the search index in sync so the
-	// record is discoverable immediately, without waiting for an external push.
+	// Update the search index in line with the gRPC store controller, so the
+	// record is discoverable without waiting for an external push.
 	decoded, decodeErr := record.Decode()
 	if decodeErr != nil {
 		logger.Warn("DIR skill record pushed but could not be decoded for search index",
@@ -68,7 +67,7 @@ func Publish(ctx context.Context, store types.StoreAPI, db types.DatabaseAPI, va
 		"cid", ref.GetCid(),
 		"name", RecordName,
 		"version", RecordVersion(),
-		"sha256", ContentSHA256(),
+		"digest", ContentDigest(),
 	)
 
 	return nil
@@ -98,8 +97,8 @@ func findExisting(db types.DatabaseAPI) (string, bool) {
 		types.WithLimit(1),
 	)
 	if err != nil {
-		// Treat as "not found"; a re-push of unchanged content is harmless
-		// because the store is content-addressed.
+		// Fall through and re-push; the store is content-addressed so an
+		// unchanged record is a no-op.
 		logger.Debug("skill record lookup failed, will attempt to publish anyway", "error", err)
 
 		return "", false

--- a/server/skill/publisher.go
+++ b/server/skill/publisher.go
@@ -1,0 +1,113 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package skill
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/server/types"
+	"github.com/agntcy/dir/utils/logging"
+)
+
+var logger = logging.Logger("server/skill")
+
+// Publish ensures the embedded SKILL.md is available as an OASF record.
+// Idempotent on name+version: a record matching the current build is not
+// re-pushed. Callers should treat errors as non-fatal — DIR must come up
+// even if the skill record cannot be published.
+func Publish(ctx context.Context, store types.StoreAPI, db types.DatabaseAPI, validator corev1.Validator) error {
+	if store == nil || db == nil {
+		return errors.New("store and db must be provided")
+	}
+
+	record, err := BuildRecord(time.Now())
+	if err != nil {
+		return fmt.Errorf("build skill record: %w", err)
+	}
+
+	if err := validateRecord(ctx, record, validator); err != nil {
+		return err
+	}
+
+	if existingCID, ok := findExisting(db); ok {
+		logger.Debug("DIR skill record already present, skipping publish",
+			"cid", existingCID,
+			"name", RecordName,
+			"version", RecordVersion(),
+		)
+
+		return nil
+	}
+
+	ref, err := store.Push(ctx, record)
+	if err != nil {
+		return fmt.Errorf("push skill record: %w", err)
+	}
+
+	// Mirror the gRPC store controller: keep the search index in sync so the
+	// record is discoverable immediately, without waiting for an external push.
+	decoded, decodeErr := record.Decode()
+	if decodeErr != nil {
+		logger.Warn("DIR skill record pushed but could not be decoded for search index",
+			"cid", ref.GetCid(),
+			"error", decodeErr,
+		)
+	} else if addErr := db.AddRecord(decoded); addErr != nil {
+		logger.Warn("DIR skill record pushed but search index update failed",
+			"cid", ref.GetCid(),
+			"error", addErr,
+		)
+	}
+
+	logger.Info("DIR skill record published",
+		"cid", ref.GetCid(),
+		"name", RecordName,
+		"version", RecordVersion(),
+		"sha256", ContentSHA256(),
+	)
+
+	return nil
+}
+
+func validateRecord(ctx context.Context, record *corev1.Record, validator corev1.Validator) error {
+	if validator == nil {
+		return nil
+	}
+
+	ok, msgs, err := record.ValidateWith(ctx, validator)
+	if err != nil {
+		return fmt.Errorf("validate skill record: %w", err)
+	}
+
+	if !ok {
+		return fmt.Errorf("skill record failed OASF validation: %v", msgs)
+	}
+
+	return nil
+}
+
+func findExisting(db types.DatabaseAPI) (string, bool) {
+	cids, err := db.GetRecordCIDs(
+		types.WithNames(RecordName),
+		types.WithVersions(RecordVersion()),
+		types.WithLimit(1),
+	)
+	if err != nil {
+		// Treat as "not found"; a re-push of unchanged content is harmless
+		// because the store is content-addressed.
+		logger.Debug("skill record lookup failed, will attempt to publish anyway", "error", err)
+
+		return "", false
+	}
+
+	if len(cids) == 0 {
+		return "", false
+	}
+
+	return cids[0], true
+}

--- a/server/skill/skill.go
+++ b/server/skill/skill.go
@@ -29,12 +29,21 @@ const (
 	AgentSkillsModuleName = "core/language_model/agentskills"
 	MCPServerName         = "agntcy-dir-mcp"
 
+	// OASF taxonomy IDs (verified against the 1.0.0 JSON schema). Mismatching
+	// these is a hard validation error, missing them is only a warning.
+	skillContextualComprehensionID uint32 = 10101
+	agentSkillsModuleID            uint32 = 10302
+	mcpModuleID                    uint32 = 202
+	domainAPIsIntegrationID        uint32 = 10204
+
 	// Used when the binary lacks an ldflags-stamped version (e.g. `go run`).
 	fallbackVersion = "0.0.0-dev"
 
 	// OASF requires `skills` to be non-empty; pick the closest taxonomy
 	// node for an instructional record.
 	skillContextualComprehensionName = "natural_language_processing/natural_language_understanding/contextual_comprehension"
+
+	domainAPIsIntegrationName = "technology/software_engineering/apis_integration"
 )
 
 // RecordVersion returns the record's `version`, stripping the commit suffix
@@ -76,7 +85,10 @@ func BuildRecord(now time.Time) (*corev1.Record, error) {
 		Authors:       []string{"https://github.com/agntcy/dir"},
 		CreatedAt:     now.UTC().Format(time.RFC3339),
 		Skills: []*typesv1.Skill{
-			{Name: skillContextualComprehensionName},
+			{Name: skillContextualComprehensionName, Id: skillContextualComprehensionID},
+		},
+		Domains: []*typesv1.Domain{
+			{Name: domainAPIsIntegrationName, Id: domainAPIsIntegrationID},
 		},
 		Modules: []*typesv1.Module{skillModule, mcpModule},
 	}), nil
@@ -108,6 +120,7 @@ func buildAgentSkillsModule(recordVer string, skillBytes []byte) (*typesv1.Modul
 
 	return &typesv1.Module{
 		Name: AgentSkillsModuleName,
+		Id:   agentSkillsModuleID,
 		Data: data,
 		Artifact: &typesv1.Descriptor{
 			MediaType: catalogv1.ProtocolAgentSkillsMdMediaType,
@@ -118,11 +131,12 @@ func buildAgentSkillsModule(recordVer string, skillBytes []byte) (*typesv1.Modul
 	}, nil
 }
 
-// Concrete connection command/args are TBD; finalize once dir-mcp deployment
-// is settled.
 func buildMCPModule() (*typesv1.Module, error) {
+	// `dirctl mcp serve` is the embedded MCP server that fronts this Directory.
 	connection, err := structpb.NewStruct(map[string]any{
-		"type": "stdio",
+		"type":    "stdio",
+		"command": "dirctl",
+		"args":    []any{"mcp", "serve"},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build mcp connection struct: %w", err)
@@ -142,6 +156,7 @@ func buildMCPModule() (*typesv1.Module, error) {
 
 	return &typesv1.Module{
 		Name: MCPModuleName,
+		Id:   mcpModuleID,
 		Data: data,
 	}, nil
 }

--- a/server/skill/skill.go
+++ b/server/skill/skill.go
@@ -1,66 +1,44 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
 
-// Package skill builds and publishes an OASF record describing how an AI agent
-// can interact with this Directory instance. The embedded SKILL.md is carried
-// inline at modules[0].artifact.data (base64) so a single Pull returns
-// everything needed to consume the skill.
+// Package skill builds and publishes an OASF record describing how an AI
+// agent can interact with this Directory instance.
 package skill
 
 import (
-	"crypto/sha256"
 	_ "embed"
-	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"time"
 
+	typesv1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1"
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/dir/api/version"
+	ocidigest "github.com/opencontainers/go-digest"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 //go:embed SKILL.md
-var markdown string
+var DirSkill string
 
 const (
-	// RecordName is the OASF record name consumers search for.
-	RecordName = "agntcy.dir/skill"
-
-	// SchemaVersion is the OASF schema version emitted.
+	RecordName    = "org.agntcy/directory"
 	SchemaVersion = "1.0.0"
 
-	// MediaType is the IANA media type of the embedded payload.
-	MediaType = "text/markdown"
+	MCPModuleName         = "integration/mcp"
+	AgentSkillsModuleName = "core/language_model/agentskills"
+	MCPServerName         = "agntcy-dir-mcp"
 
-	// SkillFileName is the value placed in agentskills.data.skill_file (a path,
-	// not the body).
-	SkillFileName = "SKILL.md"
-
-	agentskillsModuleName = "core/language_model/agentskills"
-	agentskillsModuleID   = 10302
-
-	// OASF requires at least one entry in `skills`. This taxonomy node is the
-	// closest fit for a documentation/instructional record.
-	skillContextualComprehensionID = 10101
-
-	// fallbackVersion is used when the binary was built without a version
-	// stamped in via ldflags (e.g. `go run`).
+	// Used when the binary lacks an ldflags-stamped version (e.g. `go run`).
 	fallbackVersion = "0.0.0-dev"
+
+	// OASF requires `skills` to be non-empty; pick the closest taxonomy
+	// node for an instructional record.
+	skillContextualComprehensionName = "natural_language_processing/natural_language_understanding/contextual_comprehension"
 )
 
-// Markdown returns the embedded SKILL.md content.
-func Markdown() string { return markdown }
-
-// ContentSHA256 returns the lowercase hex sha256 of the embedded markdown.
-func ContentSHA256() string {
-	sum := sha256.Sum256([]byte(markdown))
-
-	return hex.EncodeToString(sum[:])
-}
-
-// RecordVersion returns the OASF record's `version` field, mirroring the DIR
-// build version so each release publishes a distinct revision.
+// RecordVersion returns the record's `version`, stripping the commit suffix
+// that version.String() appends so it stays semver-shaped.
 func RecordVersion() string {
 	if version.Version != "" {
 		return version.Version
@@ -69,68 +47,101 @@ func RecordVersion() string {
 	return fallbackVersion
 }
 
-// BuildRecord constructs the OASF record. `now` is injected for deterministic
-// testing; production callers should pass time.Now().UTC().
+// ContentDigest returns the OCI-form sha256 digest of the embedded SKILL.md.
+func ContentDigest() string {
+	return ocidigest.FromString(DirSkill).String()
+}
+
+// BuildRecord constructs the typed OASF record. `now` is injected so tests
+// can pin time; production callers should pass time.Now().UTC().
 func BuildRecord(now time.Time) (*corev1.Record, error) {
-	recordVersion := RecordVersion()
-	contentBytes := []byte(markdown)
+	rv := RecordVersion()
+	skillBytes := []byte(DirSkill)
 
-	digest := "sha256:" + ContentSHA256()
-	encodedPayload := base64.StdEncoding.EncodeToString(contentBytes)
-
-	doc := map[string]any{
-		"name":           RecordName,
-		"schema_version": SchemaVersion,
-		"version":        recordVersion,
-		"description":    "Self-describing usage guide for this AGNTCY Directory (DIR) instance: how an AI agent can publish, search, pull, sign, and verify OASF agent records.",
-		"authors":        []string{"AGNTCY Contributors"},
-		"created_at":     now.UTC().Format(time.RFC3339),
-		// `domains` is Recommended, not Required; emit empty to silence the
-		// validator warning without binding to a specific domain.
-		"domains": []any{},
-		"skills": []map[string]any{
-			{
-				"name": "natural_language_processing/natural_language_understanding/contextual_comprehension",
-				"id":   skillContextualComprehensionID,
-			},
-		},
-		"modules": []map[string]any{
-			{
-				"name": agentskillsModuleName,
-				"id":   agentskillsModuleID,
-				"data": map[string]any{
-					"skill_file": SkillFileName,
-					"skill_manifest": map[string]any{
-						"name":        "agntcy-dir",
-						"description": "Use this skill to interact with an AGNTCY Directory (DIR) instance.",
-						"version":     recordVersion,
-						"frontmatter_metadata": map[string]any{
-							"author": "AGNTCY Contributors",
-						},
-					},
-				},
-				// agentskills.artifact is the OASF descriptor slot for inline
-				// module payloads. descriptor.data is bytestring_t, so the
-				// markdown is base64-encoded.
-				"artifact": map[string]any{
-					"media_type": MediaType,
-					"size":       len(contentBytes),
-					"digest":     digest,
-					"data":       encodedPayload,
-				},
-			},
-		},
-	}
-
-	raw, err := json.Marshal(doc)
+	skillModule, err := buildAgentSkillsModule(rv, skillBytes)
 	if err != nil {
-		return nil, fmt.Errorf("marshal skill record: %w", err)
+		return nil, err
 	}
 
-	record, err := corev1.UnmarshalRecord(raw)
+	mcpModule, err := buildMCPModule()
 	if err != nil {
-		return nil, fmt.Errorf("decode skill record: %w", err)
+		return nil, err
 	}
 
-	return record, nil
+	return corev1.New(&typesv1.Record{
+		Name:          RecordName,
+		SchemaVersion: SchemaVersion,
+		Version:       rv,
+		Description:   "Self-describing usage guide for this AGNTCY Directory (DIR) instance: how an AI agent can publish, search, pull, sign, and verify OASF agent records.",
+		Authors:       []string{"https://github.com/agntcy/dir"},
+		CreatedAt:     now.UTC().Format(time.RFC3339),
+		Skills: []*typesv1.Skill{
+			{Name: skillContextualComprehensionName},
+		},
+		Modules: []*typesv1.Module{skillModule, mcpModule},
+	}), nil
+}
+
+// Descriptor.Data is proto `bytes`, which the JSON wire layer base64-encodes
+// automatically — pass raw bytes, not a pre-encoded string.
+func buildAgentSkillsModule(recordVer string, skillBytes []byte) (*typesv1.Module, error) {
+	manifest, err := structpb.NewStruct(map[string]any{
+		"name":        "agntcy-dir",
+		"description": "Use this skill to interact with an AGNTCY Directory (DIR) instance.",
+		"version":     recordVer,
+		"frontmatter_metadata": map[string]any{
+			"author": "AGNTCY Contributors",
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build skill_manifest struct: %w", err)
+	}
+
+	data, err := structpb.NewStruct(map[string]any{
+		"skill_file": "SKILL.md",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build agentskills data struct: %w", err)
+	}
+
+	data.GetFields()["skill_manifest"] = structpb.NewStructValue(manifest)
+
+	return &typesv1.Module{
+		Name: AgentSkillsModuleName,
+		Data: data,
+		Artifact: &typesv1.Descriptor{
+			MediaType: catalogv1.ProtocolAgentSkillsMdMediaType,
+			Size:      uint64(len(skillBytes)),
+			Digest:    ocidigest.FromBytes(skillBytes).String(),
+			Data:      skillBytes,
+		},
+	}, nil
+}
+
+// Concrete connection command/args are TBD; finalize once dir-mcp deployment
+// is settled.
+func buildMCPModule() (*typesv1.Module, error) {
+	connection, err := structpb.NewStruct(map[string]any{
+		"type": "stdio",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build mcp connection struct: %w", err)
+	}
+
+	data, err := structpb.NewStruct(map[string]any{
+		"name":        MCPServerName,
+		"description": "MCP server fronting this AGNTCY Directory instance.",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build mcp data struct: %w", err)
+	}
+
+	data.GetFields()["connections"] = structpb.NewListValue(&structpb.ListValue{
+		Values: []*structpb.Value{structpb.NewStructValue(connection)},
+	})
+
+	return &typesv1.Module{
+		Name: MCPModuleName,
+		Data: data,
+	}, nil
 }

--- a/server/skill/skill.go
+++ b/server/skill/skill.go
@@ -1,0 +1,136 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package skill builds and publishes an OASF record describing how an AI agent
+// can interact with this Directory instance. The embedded SKILL.md is carried
+// inline at modules[0].artifact.data (base64) so a single Pull returns
+// everything needed to consume the skill.
+package skill
+
+import (
+	"crypto/sha256"
+	_ "embed"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/api/version"
+)
+
+//go:embed SKILL.md
+var markdown string
+
+const (
+	// RecordName is the OASF record name consumers search for.
+	RecordName = "agntcy.dir/skill"
+
+	// SchemaVersion is the OASF schema version emitted.
+	SchemaVersion = "1.0.0"
+
+	// MediaType is the IANA media type of the embedded payload.
+	MediaType = "text/markdown"
+
+	// SkillFileName is the value placed in agentskills.data.skill_file (a path,
+	// not the body).
+	SkillFileName = "SKILL.md"
+
+	agentskillsModuleName = "core/language_model/agentskills"
+	agentskillsModuleID   = 10302
+
+	// OASF requires at least one entry in `skills`. This taxonomy node is the
+	// closest fit for a documentation/instructional record.
+	skillContextualComprehensionID = 10101
+
+	// fallbackVersion is used when the binary was built without a version
+	// stamped in via ldflags (e.g. `go run`).
+	fallbackVersion = "0.0.0-dev"
+)
+
+// Markdown returns the embedded SKILL.md content.
+func Markdown() string { return markdown }
+
+// ContentSHA256 returns the lowercase hex sha256 of the embedded markdown.
+func ContentSHA256() string {
+	sum := sha256.Sum256([]byte(markdown))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// RecordVersion returns the OASF record's `version` field, mirroring the DIR
+// build version so each release publishes a distinct revision.
+func RecordVersion() string {
+	if version.Version != "" {
+		return version.Version
+	}
+
+	return fallbackVersion
+}
+
+// BuildRecord constructs the OASF record. `now` is injected for deterministic
+// testing; production callers should pass time.Now().UTC().
+func BuildRecord(now time.Time) (*corev1.Record, error) {
+	recordVersion := RecordVersion()
+	contentBytes := []byte(markdown)
+
+	digest := "sha256:" + ContentSHA256()
+	encodedPayload := base64.StdEncoding.EncodeToString(contentBytes)
+
+	doc := map[string]any{
+		"name":           RecordName,
+		"schema_version": SchemaVersion,
+		"version":        recordVersion,
+		"description":    "Self-describing usage guide for this AGNTCY Directory (DIR) instance: how an AI agent can publish, search, pull, sign, and verify OASF agent records.",
+		"authors":        []string{"AGNTCY Contributors"},
+		"created_at":     now.UTC().Format(time.RFC3339),
+		// `domains` is Recommended, not Required; emit empty to silence the
+		// validator warning without binding to a specific domain.
+		"domains": []any{},
+		"skills": []map[string]any{
+			{
+				"name": "natural_language_processing/natural_language_understanding/contextual_comprehension",
+				"id":   skillContextualComprehensionID,
+			},
+		},
+		"modules": []map[string]any{
+			{
+				"name": agentskillsModuleName,
+				"id":   agentskillsModuleID,
+				"data": map[string]any{
+					"skill_file": SkillFileName,
+					"skill_manifest": map[string]any{
+						"name":        "agntcy-dir",
+						"description": "Use this skill to interact with an AGNTCY Directory (DIR) instance.",
+						"version":     recordVersion,
+						"frontmatter_metadata": map[string]any{
+							"author": "AGNTCY Contributors",
+						},
+					},
+				},
+				// agentskills.artifact is the OASF descriptor slot for inline
+				// module payloads. descriptor.data is bytestring_t, so the
+				// markdown is base64-encoded.
+				"artifact": map[string]any{
+					"media_type": MediaType,
+					"size":       len(contentBytes),
+					"digest":     digest,
+					"data":       encodedPayload,
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal skill record: %w", err)
+	}
+
+	record, err := corev1.UnmarshalRecord(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode skill record: %w", err)
+	}
+
+	return record, nil
+}

--- a/tests/e2e/local/14_skill_record_test.go
+++ b/tests/e2e/local/14_skill_record_test.go
@@ -1,0 +1,80 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/agntcy/dir/tests/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// Duplicated as literals (rather than imported from server/skill) to keep the
+// e2e tests module independent of the server module and to assert the
+// wire-level contract consumers will rely on.
+const (
+	skillRecordName = "agntcy.dir/skill"
+	skillModuleName = "core/language_model/agentskills"
+)
+
+var _ = ginkgo.Describe("DIR self-published SKILL record", func() {
+	ginkgo.BeforeEach(func() {
+		utils.ResetCLIState()
+	})
+
+	ginkgo.It("should be discoverable by name and carry the SKILL.md bytes in its module artifact", func() {
+		var cid string
+
+		// Publishing happens asynchronously after Start returns; poll for it.
+		gomega.Eventually(func(g gomega.Gomega) {
+			out := testEnv.CLI.Search().
+				WithName(skillRecordName).
+				WithLimit(1).
+				WithArgs("--output", "raw").
+				ShouldSucceed()
+
+			cid = strings.TrimSpace(out)
+			g.Expect(cid).NotTo(gomega.BeEmpty(),
+				"DIR skill record should be searchable by name %q", skillRecordName)
+		}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(gomega.Succeed())
+
+		raw := testEnv.CLI.Pull(cid).WithArgs("--output", "json").ShouldSucceed()
+
+		var doc struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Modules     []struct {
+				Name     string `json:"name"`
+				Artifact struct {
+					MediaType string `json:"media_type"`
+					Data      string `json:"data"`
+					Digest    string `json:"digest"`
+					Size      int    `json:"size"`
+				} `json:"artifact"`
+			} `json:"modules"`
+		}
+
+		gomega.Expect(json.Unmarshal([]byte(raw), &doc)).To(gomega.Succeed())
+
+		gomega.Expect(doc.Name).To(gomega.Equal(skillRecordName))
+		gomega.Expect(doc.Description).NotTo(gomega.BeEmpty())
+
+		gomega.Expect(doc.Modules).NotTo(gomega.BeEmpty())
+		gomega.Expect(doc.Modules[0].Name).To(gomega.Equal(skillModuleName))
+
+		artifact := doc.Modules[0].Artifact
+		gomega.Expect(artifact.MediaType).To(gomega.Equal("text/markdown"))
+		gomega.Expect(artifact.Digest).To(gomega.HavePrefix("sha256:"))
+		gomega.Expect(artifact.Size).To(gomega.BeNumerically(">", 0))
+
+		decoded, err := base64.StdEncoding.DecodeString(artifact.Data)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(string(decoded)).To(gomega.ContainSubstring("# AGNTCY Directory"))
+		gomega.Expect(decoded).To(gomega.HaveLen(artifact.Size))
+	})
+})

--- a/tests/e2e/local/14_skill_record_test.go
+++ b/tests/e2e/local/14_skill_record_test.go
@@ -31,6 +31,8 @@ var _ = ginkgo.Describe("DIR self-published SKILL record", func() {
 		var cid string
 
 		// Publishing happens asynchronously after Start returns; poll for it.
+		// `search --output raw` formats results as `[<cid> <cid> ...]`; strip
+		// the brackets so the CID can be passed straight to `pull`.
 		gomega.Eventually(func(g gomega.Gomega) {
 			out := testEnv.CLI.Search().
 				WithName(skillRecordName).
@@ -38,9 +40,11 @@ var _ = ginkgo.Describe("DIR self-published SKILL record", func() {
 				WithArgs("--output", "raw").
 				ShouldSucceed()
 
-			cid = strings.TrimSpace(out)
+			cid = strings.Trim(strings.TrimSpace(out), "[]")
 			g.Expect(cid).NotTo(gomega.BeEmpty(),
 				"DIR skill record should be searchable by name %q", skillRecordName)
+			g.Expect(cid).NotTo(gomega.ContainSubstring(" "),
+				"search returned multiple CIDs; expected exactly one")
 		}).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(gomega.Succeed())
 
 		raw := testEnv.CLI.Pull(cid).WithArgs("--output", "json").ShouldSucceed()

--- a/tests/e2e/local/14_skill_record_test.go
+++ b/tests/e2e/local/14_skill_record_test.go
@@ -14,12 +14,13 @@ import (
 	"github.com/onsi/gomega"
 )
 
-// Duplicated as literals (rather than imported from server/skill) to keep the
-// e2e tests module independent of the server module and to assert the
-// wire-level contract consumers will rely on.
+// Hard-coded (not imported from server/skill) to keep the e2e module
+// independent and to assert the wire-level contract consumers rely on.
 const (
-	skillRecordName = "agntcy.dir/skill"
-	skillModuleName = "core/language_model/agentskills"
+	skillRecordName       = "org.agntcy/directory"
+	skillModuleName       = "core/language_model/agentskills"
+	mcpModuleName         = "integration/mcp"
+	skillArtifactMediaTyp = "application/agentskill+md"
 )
 
 var _ = ginkgo.Describe("DIR self-published SKILL record", func() {
@@ -27,12 +28,12 @@ var _ = ginkgo.Describe("DIR self-published SKILL record", func() {
 		utils.ResetCLIState()
 	})
 
-	ginkgo.It("should be discoverable by name and carry the SKILL.md bytes in its module artifact", func() {
+	ginkgo.It("should be discoverable by name and carry the SKILL.md bytes plus an MCP module", func() {
 		var cid string
 
-		// Publishing happens asynchronously after Start returns; poll for it.
-		// `search --output raw` formats results as `[<cid> <cid> ...]`; strip
-		// the brackets so the CID can be passed straight to `pull`.
+		// Publish runs asynchronously after Start; poll for it.
+		// `search --output raw` returns `[<cid> ...]`; strip the brackets
+		// so the value is a bare CID `pull` can accept.
 		gomega.Eventually(func(g gomega.Gomega) {
 			out := testEnv.CLI.Search().
 				WithName(skillRecordName).
@@ -68,17 +69,37 @@ var _ = ginkgo.Describe("DIR self-published SKILL record", func() {
 		gomega.Expect(doc.Name).To(gomega.Equal(skillRecordName))
 		gomega.Expect(doc.Description).NotTo(gomega.BeEmpty())
 
-		gomega.Expect(doc.Modules).NotTo(gomega.BeEmpty())
-		gomega.Expect(doc.Modules[0].Name).To(gomega.Equal(skillModuleName))
+		// Both modules must live on the same record.
+		moduleNames := make([]string, 0, len(doc.Modules))
+		for _, m := range doc.Modules {
+			moduleNames = append(moduleNames, m.Name)
+		}
 
-		artifact := doc.Modules[0].Artifact
-		gomega.Expect(artifact.MediaType).To(gomega.Equal("text/markdown"))
-		gomega.Expect(artifact.Digest).To(gomega.HavePrefix("sha256:"))
-		gomega.Expect(artifact.Size).To(gomega.BeNumerically(">", 0))
+		gomega.Expect(moduleNames).To(gomega.ContainElement(skillModuleName))
+		gomega.Expect(moduleNames).To(gomega.ContainElement(mcpModuleName))
 
-		decoded, err := base64.StdEncoding.DecodeString(artifact.Data)
+		skillArtifact := struct {
+			MediaType string `json:"media_type"`
+			Data      string `json:"data"`
+			Digest    string `json:"digest"`
+			Size      int    `json:"size"`
+		}{}
+
+		for _, m := range doc.Modules {
+			if m.Name == skillModuleName {
+				skillArtifact = m.Artifact
+
+				break
+			}
+		}
+
+		gomega.Expect(skillArtifact.MediaType).To(gomega.Equal(skillArtifactMediaTyp))
+		gomega.Expect(skillArtifact.Digest).To(gomega.HavePrefix("sha256:"))
+		gomega.Expect(skillArtifact.Size).To(gomega.BeNumerically(">", 0))
+
+		decoded, err := base64.StdEncoding.DecodeString(skillArtifact.Data)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(string(decoded)).To(gomega.ContainSubstring("# AGNTCY Directory"))
-		gomega.Expect(decoded).To(gomega.HaveLen(artifact.Size))
+		gomega.Expect(decoded).To(gomega.HaveLen(skillArtifact.Size))
 	})
 })


### PR DESCRIPTION
Closes #1612.

On apiserver startup, DIR now embeds its own `SKILL.md` and publishes it as a discoverable OASF 1.0.0 record (`name: agntcy.dir/skill`). Publish runs in a background goroutine — failures are logged but do not block startup. Idempotent on restart by name + version.

### How the SKILL.md content is stored

Stored inline at `modules[0].artifact.data` (base64) on the `core/language_model/agentskills` module.

### How an agent consumes it (and the discovery gap)

The mechanical flow is straightforward:

```
search by name "agntcy.dir/skill"  →  CID
pull CID                            →  OASF record
base64-decode modules[0].artifact.data
verify length == artifact.size, sha256 == artifact.digest
hand the markdown to the LLM as a skill (per the Agent Skills spec)
```

The catch is the very first step: the agent has to *know* to search for the name `agntcy.dir/skill`. This PR doesn't bridge that gap — the calling system (prompt, SDK, or surrounding tool) has to inject the convention.
