### PR TITLE
fix(ci): harden import-records workflow for nightly catalog sync

### DIFF
--- a/.github/actions/sign-record/README.md
+++ b/.github/actions/sign-record/README.md
@@ -1,6 +1,6 @@
 # Sign OASF Records Action
 
-Sign record CIDs using GitHub OIDC (keyless). Use after **push-record**. Only supported in GitHub Actions; the job must have `permissions: id-token: write`.
+Sign record CIDs using GitHub OIDC (keyless). Use after **push-record** or **dirctl import**. Only supported in GitHub Actions; the job must have `permissions: id-token: write`.
 
 ## Usage
 
@@ -10,8 +10,10 @@ Sign record CIDs using GitHub OIDC (keyless). Use after **push-record**. Only su
   with:
     cids: ${{ steps.push.outputs.cids }}
     server_addr: ${{ vars.DIRECTORY_ADDRESS }}
-    github_token: ${{ secrets.GITHUB_TOKEN }}
+    auth_token: ${{ steps.oidc-dir.outputs.token }}
     oidc_client_id: https://github.com/${{ github.repository }}/.github/workflows/my-workflow.yaml@${{ github.ref }}
+    max_retries: 3
+    cleanup_on_failure: true
 ```
 
 ## Inputs
@@ -20,8 +22,12 @@ Sign record CIDs using GitHub OIDC (keyless). Use after **push-record**. Only su
 |-------|-------------|----------|---------|
 | `cids` | JSON object (file→CID) from push-record, or newline-separated CIDs | Yes | - |
 | `server_addr` | Directory server address (host:port). Omit to use dirctl default. | No | `""` |
-| `github_token` | Optional GitHub PAT for Directory authentication | No | `""` |
+| `auth_token` | Optional OIDC bearer token for Directory authentication | No | `""` |
 | `oidc_client_id` | Workflow URL for keyless signing. Job must have `id-token: write`. | Yes | - |
+| `dirctl_path` | Optional absolute path to the dirctl binary | No | PATH lookup |
+| `max_retries` | Sign attempts per CID (fresh Sigstore OIDC token each attempt) | No | `3` |
+| `retry_delay_seconds` | Base delay between retries, multiplied by attempt number | No | `30` |
+| `cleanup_on_failure` | Delete unsigned records with `dirctl delete` after all retries fail | No | `false` |
 
 ## Outputs
 
@@ -29,4 +35,16 @@ Sign record CIDs using GitHub OIDC (keyless). Use after **push-record**. Only su
 |--------|-------------|---------|
 | `success` | Whether all CIDs were signed successfully | `true` |
 | `signed` | Number of CIDs successfully signed | `3` |
-| `failed` | Number of CIDs that failed to sign | `0` |
+| `cleaned` | Number of unsigned CIDs deleted after sign failure | `1` |
+| `failed` | Number of CIDs still unsigned (sign and cleanup both failed) | `0` |
+| `failed_cids` | Newline-separated CIDs that remain unsigned | - |
+| `cleaned_cids` | Newline-separated CIDs deleted after sign failure | - |
+
+## Retry and cleanup behavior
+
+For each CID the action:
+
+1. Attempts `dirctl sign` up to `max_retries` times, fetching a fresh Sigstore OIDC token before each attempt.
+2. Waits `retry_delay_seconds * attempt` between retries.
+3. If signing still fails and `cleanup_on_failure` is `true`, runs `dirctl delete` so a future import can push the record again.
+4. Exits with code 1 if any CID remains unsigned on the server.

--- a/.github/actions/sign-record/action.yaml
+++ b/.github/actions/sign-record/action.yaml
@@ -30,6 +30,18 @@ inputs:
     description: Optional absolute path to the dirctl binary. Defaults to PATH lookup.
     required: false
     default: ""
+  max_retries:
+    description: Number of sign attempts per CID (fresh Sigstore OIDC token each attempt)
+    required: false
+    default: "3"
+  retry_delay_seconds:
+    description: Base delay in seconds between sign retries (multiplied by attempt number)
+    required: false
+    default: "30"
+  cleanup_on_failure:
+    description: Delete unsigned records with dirctl delete when signing fails after all retries
+    required: false
+    default: "false"
 
 outputs:
   success:
@@ -38,9 +50,18 @@ outputs:
   signed:
     description: Number of CIDs successfully signed
     value: ${{ steps.sign.outputs.signed }}
+  cleaned:
+    description: Number of unsigned CIDs deleted after sign failure
+    value: ${{ steps.sign.outputs.cleaned }}
   failed:
-    description: Number of CIDs that failed to sign
+    description: Number of CIDs that failed to sign and were not cleaned up
     value: ${{ steps.sign.outputs.failed }}
+  failed_cids:
+    description: Newline-separated CIDs that remain unsigned on the server
+    value: ${{ steps.sign.outputs.failed_cids }}
+  cleaned_cids:
+    description: Newline-separated CIDs deleted after sign failure
+    value: ${{ steps.sign.outputs.cleaned_cids }}
 
 runs:
   using: "composite"
@@ -54,6 +75,9 @@ runs:
         AUTH_TOKEN: ${{ inputs.auth_token }}
         OIDC_CLIENT_ID: ${{ inputs.oidc_client_id }}
         DIRCTL_PATH: ${{ inputs.dirctl_path }}
+        MAX_RETRIES: ${{ inputs.max_retries }}
+        RETRY_DELAY_SECONDS: ${{ inputs.retry_delay_seconds }}
+        CLEANUP_ON_FAILURE: ${{ inputs.cleanup_on_failure }}
       run: |
         chmod +x "${{ github.action_path }}/sign.sh"
         "${{ github.action_path }}/sign.sh"

--- a/.github/actions/sign-record/sign.sh
+++ b/.github/actions/sign-record/sign.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 : "${OIDC_CLIENT_ID:?OIDC_CLIENT_ID is required}"
 SERVER_ADDR="${SERVER_ADDR:-}"
 AUTH_TOKEN="${AUTH_TOKEN:-}"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+CLEANUP_ON_FAILURE="${CLEANUP_ON_FAILURE:-false}"
+RETRY_DELAY_SECONDS="${RETRY_DELAY_SECONDS:-30}"
 
 if [ -n "${DIRCTL_PATH:-}" ]; then
   DIRCTL_BIN="${DIRCTL_PATH}"
@@ -23,13 +26,24 @@ if [ ! -x "${DIRCTL_BIN}" ]; then
   exit 1
 fi
 
+if ! [[ "$MAX_RETRIES" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::MAX_RETRIES must be a positive integer (got: ${MAX_RETRIES})" >&2
+  exit 1
+fi
+
 SIGNED=0
 FAILED=0
+CLEANED=0
 ALL_SUCCESS=true
+FAILED_CIDS_FILE="$(mktemp)"
+CLEANED_CIDS_FILE="$(mktemp)"
+trap 'rm -f "$FAILED_CIDS_FILE" "$CLEANED_CIDS_FILE"' EXIT
 
 echo "=== Sign Records (OIDC) ==="
 echo "dirctl: ${DIRCTL_BIN}"
 echo "Server address: ${SERVER_ADDR:-"(dirctl default)"}"
+echo "Max retries per CID: ${MAX_RETRIES}"
+echo "Cleanup on failure: ${CLEANUP_ON_FAILURE}"
 echo ""
 
 if [ -z "${OIDC_CLIENT_ID:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
@@ -57,53 +71,154 @@ if [ ${#CID_ARRAY[@]} -eq 0 ]; then
   exit 1
 fi
 
-echo "Obtaining OIDC token..."
-OIDC_TOKEN=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-  "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value')
-if [ -z "$OIDC_TOKEN" ] || [ "$OIDC_TOKEN" = "null" ]; then
-  echo "::error::Failed to obtain OIDC token. Ensure the job has permissions: id-token: write"
-  exit 1
-fi
+fetch_sigstore_oidc_token() {
+  local token
+  token=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+    "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r '.value')
+  if [ -z "$token" ] || [ "$token" = "null" ]; then
+    return 1
+  fi
+  printf '%s' "$token"
+}
+
+append_dirctl_auth_args() {
+  local -n cmd_ref=$1
+  [ -n "$SERVER_ADDR" ] && cmd_ref+=(--server-addr "$SERVER_ADDR")
+  [ -n "$AUTH_TOKEN" ] && cmd_ref+=(--auth-mode=oidc "--auth-token=$AUTH_TOKEN")
+}
+
+sign_cid_once() {
+  local cid=$1
+  local oidc_token=$2
+  local -a sign_cmd=(
+    "${DIRCTL_BIN}" sign "$cid"
+    "--oidc-token=${oidc_token}"
+    --oidc-provider-url=https://token.actions.githubusercontent.com
+    "--oidc-client-id=${OIDC_CLIENT_ID}"
+  )
+  append_dirctl_auth_args sign_cmd
+  "${sign_cmd[@]}"
+}
+
+delete_cid() {
+  local cid=$1
+  local -a delete_cmd=("${DIRCTL_BIN}" delete "$cid")
+  append_dirctl_auth_args delete_cmd
+  "${delete_cmd[@]}"
+}
+
+retry_delay() {
+  local attempt=$1
+  local delay=$((RETRY_DELAY_SECONDS * attempt))
+  echo "Waiting ${delay}s before retry..."
+  sleep "$delay"
+}
 
 echo "Signing ${#CID_ARRAY[@]} record(s)"
 echo ""
 
 for CID in "${CID_ARRAY[@]}"; do
   echo "----------------------------------------"
-  echo "Signing: $CID"
+  echo "Processing: $CID"
   echo "----------------------------------------"
-  set +e
-  SIGN_CMD=("${DIRCTL_BIN}" sign "$CID" "--oidc-token=$OIDC_TOKEN" --oidc-provider-url=https://token.actions.githubusercontent.com "--oidc-client-id=$OIDC_CLIENT_ID")
-  [ -n "$SERVER_ADDR" ] && SIGN_CMD+=(--server-addr "$SERVER_ADDR")
-  [ -n "$AUTH_TOKEN" ] && SIGN_CMD+=(--auth-mode=oidc "--auth-token=$AUTH_TOKEN")
-  OUTPUT=$("${SIGN_CMD[@]}" 2>&1)
-  EXIT=$?
-  set -e
-  if [ $EXIT -eq 0 ]; then
-    echo "Successfully signed"
-    echo "::notice::Signed CID: $CID"
-    SIGNED=$((SIGNED + 1))
+
+  signed=false
+  last_sign_output=""
+
+  for ((attempt = 1; attempt <= MAX_RETRIES; attempt++)); do
+    echo "Sign attempt ${attempt}/${MAX_RETRIES}"
+
+    set +e
+    OIDC_TOKEN=$(fetch_sigstore_oidc_token)
+    token_exit=$?
+    set -e
+    if [ $token_exit -ne 0 ] || [ -z "$OIDC_TOKEN" ]; then
+      last_sign_output="Failed to obtain Sigstore OIDC token"
+      echo "::warning::${last_sign_output} (attempt ${attempt}/${MAX_RETRIES})"
+    else
+      set +e
+      last_sign_output=$(sign_cid_once "$CID" "$OIDC_TOKEN" 2>&1)
+      sign_exit=$?
+      set -e
+      if [ $sign_exit -eq 0 ]; then
+        echo "Successfully signed"
+        echo "::notice::Signed CID: $CID"
+        SIGNED=$((SIGNED + 1))
+        signed=true
+        break
+      fi
+      echo "::warning::Failed to sign $CID (attempt ${attempt}/${MAX_RETRIES}): ${last_sign_output}"
+    fi
+
+    if [ "$attempt" -lt "$MAX_RETRIES" ]; then
+      retry_delay "$attempt"
+    fi
+  done
+
+  if [ "$signed" = true ]; then
+    echo ""
+    continue
+  fi
+
+  echo "::error::All sign attempts failed for $CID"
+
+  if [ "$CLEANUP_ON_FAILURE" = "true" ]; then
+    echo "Attempting cleanup: deleting unsigned record $CID"
+    set +e
+    delete_output=$(delete_cid "$CID" 2>&1)
+    delete_exit=$?
+    set -e
+    if [ $delete_exit -eq 0 ]; then
+      echo "Deleted unsigned record $CID so a future import can retry push"
+      echo "::notice::Cleaned up unsigned CID: $CID"
+      echo "$CID" >> "$CLEANED_CIDS_FILE"
+      CLEANED=$((CLEANED + 1))
+    else
+      echo "::error::Failed to delete $CID after sign failure: ${delete_output}"
+      echo "$CID" >> "$FAILED_CIDS_FILE"
+      FAILED=$((FAILED + 1))
+      ALL_SUCCESS=false
+    fi
   else
-    echo "::error::Failed to sign $CID: $OUTPUT"
+    echo "$CID" >> "$FAILED_CIDS_FILE"
     FAILED=$((FAILED + 1))
     ALL_SUCCESS=false
   fi
+
   echo ""
 done
 
 echo "=== Sign Summary ==="
 echo "Signed: $SIGNED"
-echo "Failed: $FAILED"
+echo "Cleaned up (deleted after sign failure): $CLEANED"
+echo "Failed (unsigned and not cleaned): $FAILED"
 echo ""
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "success=$ALL_SUCCESS" >> "$GITHUB_OUTPUT"
   echo "signed=$SIGNED" >> "$GITHUB_OUTPUT"
+  echo "cleaned=$CLEANED" >> "$GITHUB_OUTPUT"
   echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+
+  if [ -s "$FAILED_CIDS_FILE" ]; then
+    {
+      echo 'failed_cids<<EOF'
+      cat "$FAILED_CIDS_FILE"
+      echo 'EOF'
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  if [ -s "$CLEANED_CIDS_FILE" ]; then
+    {
+      echo 'cleaned_cids<<EOF'
+      cat "$CLEANED_CIDS_FILE"
+      echo 'EOF'
+    } >> "$GITHUB_OUTPUT"
+  fi
 fi
 
 if [ "$ALL_SUCCESS" = false ]; then
-  echo "::error::One or more records failed to sign" >&2
+  echo "::error::One or more records could not be signed (and cleanup did not succeed for all failures)" >&2
   exit 1
 fi
 

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -228,7 +228,7 @@ jobs:
 
       - name: Import MCP Records
         id: import
-        timeout-minutes: 300
+        timeout-minutes: 360
         env:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_BASE_URL: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
@@ -432,7 +432,7 @@ jobs:
 
       - name: Import Agent Skills
         id: import
-        timeout-minutes: 300
+        timeout-minutes: 360
         env:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_BASE_URL: ${{ secrets.AZURE_OPENAI_ENDPOINT }}

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -196,26 +196,11 @@ jobs:
         run: chmod +x .bin/mcp-scanner
 
       - name: Create Enricher Config
+        env:
+          DIRCTL_PATH: ${{ steps.setup-dirctl.outputs.dirctl_path }}
         run: |
-          cat <<'EOF' > mcphost_ci.json
-          {
-            "mcpServers": {
-              "dir-mcp-server": {
-                "command": "${{ steps.setup-dirctl.outputs.dirctl_path }}",
-                "args": [
-                  "mcp",
-                  "serve"
-                ],
-                "env": {
-                  "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com",
-                  "DIRECTORY_CLIENT_AUTH_MODE": "insecure"
-                }
-              }
-            },
-            "model": "azure:gpt-4o",
-            "max-steps": 10
-          }
-          EOF
+          sed "s|__DIRCTL_PATH__|${DIRCTL_PATH}|g" \
+            .github/workflows/scripts/mcphost_ci.json.template > mcphost_ci.json
 
       - name: Fetch Directory OIDC token
         id: oidc-dir-import
@@ -422,26 +407,11 @@ jobs:
           echo "repo_dir=$REPO_DIR" >> $GITHUB_OUTPUT
 
       - name: Create Enricher Config
+        env:
+          DIRCTL_PATH: ${{ steps.setup-dirctl.outputs.dirctl_path }}
         run: |
-          cat <<'EOF' > mcphost_ci.json
-          {
-            "mcpServers": {
-              "dir-mcp-server": {
-                "command": "${{ steps.setup-dirctl.outputs.dirctl_path }}",
-                "args": [
-                  "mcp",
-                  "serve"
-                ],
-                "env": {
-                  "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com",
-                  "DIRECTORY_CLIENT_AUTH_MODE": "insecure"
-                }
-              }
-            },
-            "model": "azure:gpt-4o",
-            "max-steps": 10
-          }
-          EOF
+          sed "s|__DIRCTL_PATH__|${DIRCTL_PATH}|g" \
+            .github/workflows/scripts/mcphost_ci.json.template > mcphost_ci.json
 
       - name: Fetch Directory OIDC token
         id: oidc-dir-import

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -133,10 +133,6 @@ jobs:
           path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
           retention-days: 7
 
-      - name: Install Task
-        if: ${{ needs.setup-matrix.outputs.scanner_enabled == 'true' && needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
-        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
-
       - name: Install mcp-scanner
         if: ${{ needs.setup-matrix.outputs.scanner_enabled == 'true' && needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
         run: |

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -108,8 +108,29 @@ jobs:
           echo "Generated MCP matrix with $MCP_COUNT entries"
           echo "Generated agent-skill matrix with $AGENT_SKILLS_COUNT entries"
 
-  import-mcp:
+  build-dirctl:
     needs: setup-matrix
+    if: |
+      (needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]') ||
+      (needs.setup-matrix.outputs.run_agent_skills_import == 'true' && needs.setup-matrix.outputs.agent_skills_matrix != '[]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build dirctl from source
+        id: setup-dirctl
+        uses: ./.github/actions/build-dirctl
+
+      - name: Upload dirctl artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dirctl
+          path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
+          retention-days: 7
+
+  import-mcp:
+    needs: [setup-matrix, build-dirctl]
     if: ${{ needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
     runs-on: ubuntu-latest
     permissions:
@@ -131,9 +152,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Build dirctl from source
+      - name: Download dirctl
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dirctl
+          path: .bin
+
+      - name: Prepare dirctl
         id: setup-dirctl
-        uses: ./.github/actions/build-dirctl
+        run: |
+          chmod +x .bin/dirctl
+          echo "${GITHUB_WORKSPACE}/.bin" >> "${GITHUB_PATH}"
+          echo "dirctl_path=${GITHUB_WORKSPACE}/.bin/dirctl" >> "${GITHUB_OUTPUT}"
 
       - name: Install Task
         uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1.1.0
@@ -306,7 +336,7 @@ jobs:
           fi
 
   import-agent-skills:
-    needs: setup-matrix
+    needs: [setup-matrix, build-dirctl]
     if: ${{ needs.setup-matrix.outputs.run_agent_skills_import == 'true' && needs.setup-matrix.outputs.agent_skills_matrix != '[]' }}
     runs-on: ubuntu-latest
     permissions:
@@ -356,9 +386,18 @@ jobs:
           echo "Synced $(git -C "$REPO_DIR" rev-parse --short HEAD) from origin/main"
           echo "repo_dir=$REPO_DIR" >> $GITHUB_OUTPUT
 
-      - name: Build dirctl from source
+      - name: Download dirctl
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dirctl
+          path: .bin
+
+      - name: Prepare dirctl
         id: setup-dirctl
-        uses: ./.github/actions/build-dirctl
+        run: |
+          chmod +x .bin/dirctl
+          echo "${GITHUB_WORKSPACE}/.bin" >> "${GITHUB_PATH}"
+          echo "dirctl_path=${GITHUB_WORKSPACE}/.bin/dirctl" >> "${GITHUB_OUTPUT}"
 
       - name: Create Enricher Config
         run: |

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -39,6 +39,10 @@ on:
         description: "Directory server address"
         type: string
         default: "ads.outshift.io:443"
+      debug:
+        description: "Enable dirctl import debug output (dedup and validation details)"
+        type: boolean
+        default: false
   schedule:
     - cron: "0 0 * * *"
 
@@ -61,6 +65,7 @@ jobs:
       sign: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sign || 'true' }}
       force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}
       scanner_enabled: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scanner_enabled || 'false' }}
+      debug: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug || 'false' }}
     env:
       IMPORT_CONFIG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.import_config || '.github/workflows/scripts/import-records.json' }}
     steps:
@@ -167,6 +172,7 @@ jobs:
       SIGN: ${{ needs.setup-matrix.outputs.sign }}
       FORCE: ${{ needs.setup-matrix.outputs.force }}
       SCANNER_ENABLED: ${{ needs.setup-matrix.outputs.scanner_enabled }}
+      DEBUG: ${{ needs.setup-matrix.outputs.debug }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -251,6 +257,10 @@ jobs:
             CMD+=(--filter="updated_since=${{ matrix.entry.updated_since }}")
           fi
 
+          if [[ "${{ env.DEBUG }}" == "true" ]]; then
+            CMD+=(--debug)
+          fi
+
           echo "Running: ${CMD[*]}"
           set +e
           OUTPUT=$("${CMD[@]}" 2>&1)
@@ -330,6 +340,7 @@ jobs:
       SERVER_ADDRESS: ${{ needs.setup-matrix.outputs.server_address }}
       SIGN: ${{ needs.setup-matrix.outputs.sign }}
       FORCE: ${{ needs.setup-matrix.outputs.force }}
+      DEBUG: ${{ needs.setup-matrix.outputs.debug }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -422,6 +433,10 @@ jobs:
              CMD+=("--force")
           fi
 
+          if [[ "${{ env.DEBUG }}" == "true" ]]; then
+            CMD+=(--debug)
+          fi
+
           echo "Running: ${CMD[*]}"
           set +e
           OUTPUT=$("${CMD[@]}" 2>&1)
@@ -500,6 +515,7 @@ jobs:
       SIGN: ${{ needs.setup-matrix.outputs.sign }}
       RUN_MCP_IMPORT: ${{ needs.setup-matrix.outputs.run_mcp_import }}
       RUN_AGENT_SKILLS_IMPORT: ${{ needs.setup-matrix.outputs.run_agent_skills_import }}
+      DEBUG: ${{ needs.setup-matrix.outputs.debug }}
       SETUP_MATRIX_RESULT: ${{ needs.setup-matrix.result }}
       BUILD_DIRCTL_RESULT: ${{ needs.build-dirctl.result }}
       IMPORT_MCP_RESULT: ${{ needs.import-mcp.result }}

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -117,6 +117,7 @@ jobs:
       id-token: write # Required for OIDC signing with Sigstore
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         entry: ${{ fromJson(needs.setup-matrix.outputs.mcp_matrix) }}
     env:
@@ -313,6 +314,7 @@ jobs:
       id-token: write # Required for OIDC signing with Sigstore
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         entry: ${{ fromJson(needs.setup-matrix.outputs.agent_skills_matrix) }}
     env:

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -42,6 +42,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: import-records
+  cancel-in-progress: false
+
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest
@@ -204,6 +208,7 @@ jobs:
 
       - name: Import MCP Records
         id: import
+        timeout-minutes: 300
         env:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_BASE_URL: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
@@ -429,6 +434,7 @@ jobs:
 
       - name: Import Agent Skills
         id: import
+        timeout-minutes: 300
         env:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_BASE_URL: ${{ secrets.AZURE_OPENAI_ENDPOINT }}

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -344,7 +344,7 @@ jobs:
 
       - name: Upload unsigned CIDs after sign failure
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' && steps.sign-records.outputs.failed != '0' }}
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-to-sign-mcp-${{ matrix.entry.index }}
           path: failed-to-sign.txt
@@ -538,7 +538,7 @@ jobs:
 
       - name: Upload unsigned CIDs after sign failure
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' && steps.sign-records.outputs.failed != '0' }}
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: failed-to-sign-agent-skills-${{ matrix.entry.index }}
           path: failed-to-sign.txt

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -133,6 +133,25 @@ jobs:
           path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
           retention-days: 7
 
+      - name: Install Task
+        if: ${{ needs.setup-matrix.outputs.scanner_enabled == 'true' && needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+
+      - name: Install mcp-scanner
+        if: ${{ needs.setup-matrix.outputs.scanner_enabled == 'true' && needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
+        run: |
+          task importer:deps:mcp-scanner
+          mkdir -p .bin
+          install -m 755 "${HOME}/.local/bin/mcp-scanner" .bin/mcp-scanner
+
+      - name: Upload mcp-scanner artifact
+        if: ${{ needs.setup-matrix.outputs.scanner_enabled == 'true' && needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mcp-scanner
+          path: .bin/mcp-scanner
+          retention-days: 7
+
   import-mcp:
     needs: [setup-matrix, build-dirctl]
     if: ${{ needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
@@ -169,14 +188,16 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.bin" >> "${GITHUB_PATH}"
           echo "dirctl_path=${GITHUB_WORKSPACE}/.bin/dirctl" >> "${GITHUB_OUTPUT}"
 
-      - name: Install Task
-        uses: go-task/setup-task@70f2430ad412f838533de8c0515c749ffb2b8bd3 # v1.1.0
-        with:
-          version: 3.49.1
-
-      - name: Install mcp-scanner
+      - name: Download mcp-scanner
         if: ${{ env.SCANNER_ENABLED == 'true' }}
-        run: task importer:deps:mcp-scanner
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mcp-scanner
+          path: .bin
+
+      - name: Prepare mcp-scanner
+        if: ${{ env.SCANNER_ENABLED == 'true' }}
+        run: chmod +x .bin/mcp-scanner
 
       - name: Create Enricher Config
         run: |
@@ -234,7 +255,7 @@ jobs:
           fi
 
           if [[ "${{ env.SCANNER_ENABLED }}" == "true" ]]; then
-             CMD+=("--scanner-enabled")
+             CMD+=("--scanner-enabled" "--scanner-cli-path=${GITHUB_WORKSPACE}/.bin/mcp-scanner")
           fi
 
           if [ -n "${{ matrix.entry.search }}" ]; then

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -379,6 +379,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Download dirctl
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dirctl
+          path: .bin
+
+      - name: Prepare dirctl
+        id: setup-dirctl
+        run: |
+          chmod +x .bin/dirctl
+          echo "${GITHUB_WORKSPACE}/.bin" >> "${GITHUB_PATH}"
+          echo "dirctl_path=${GITHUB_WORKSPACE}/.bin/dirctl" >> "${GITHUB_OUTPUT}"
+
       - name: Cache skill repo
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -407,19 +420,6 @@ jobs:
 
           echo "Synced $(git -C "$REPO_DIR" rev-parse --short HEAD) from origin/main"
           echo "repo_dir=$REPO_DIR" >> $GITHUB_OUTPUT
-
-      - name: Download dirctl
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dirctl
-          path: .bin
-
-      - name: Prepare dirctl
-        id: setup-dirctl
-        run: |
-          chmod +x .bin/dirctl
-          echo "${GITHUB_WORKSPACE}/.bin" >> "${GITHUB_PATH}"
-          echo "dirctl_path=${GITHUB_WORKSPACE}/.bin/dirctl" >> "${GITHUB_OUTPUT}"
 
       - name: Create Enricher Config
         run: |

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -43,6 +43,14 @@ on:
         description: "Enable dirctl import debug output (dedup and validation details)"
         type: boolean
         default: false
+      sign_max_retries:
+        description: "Per-CID signature attempts before deleting unsigned records"
+        type: number
+        default: 3
+      sign_cleanup_on_failure:
+        description: "Delete unsigned records when signing fails after all retries"
+        type: boolean
+        default: true
   schedule:
     - cron: "0 0 * * *"
 
@@ -66,6 +74,8 @@ jobs:
       force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}
       scanner_enabled: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scanner_enabled || 'false' }}
       debug: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug || 'false' }}
+      sign_max_retries: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sign_max_retries || '3' }}
+      sign_cleanup_on_failure: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sign_cleanup_on_failure || 'true' }}
     env:
       IMPORT_CONFIG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.import_config || '.github/workflows/scripts/import-records.json' }}
     steps:
@@ -173,6 +183,8 @@ jobs:
       FORCE: ${{ needs.setup-matrix.outputs.force }}
       SCANNER_ENABLED: ${{ needs.setup-matrix.outputs.scanner_enabled }}
       DEBUG: ${{ needs.setup-matrix.outputs.debug }}
+      SIGN_MAX_RETRIES: ${{ needs.setup-matrix.outputs.sign_max_retries }}
+      SIGN_CLEANUP_ON_FAILURE: ${{ needs.setup-matrix.outputs.sign_cleanup_on_failure }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -314,6 +326,7 @@ jobs:
 
       - name: Sign imported records
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
+        id: sign-records
         uses: ./.github/actions/sign-record
         with:
           cids: ${{ steps.sign-cids.outputs.cids }}
@@ -321,6 +334,21 @@ jobs:
           server_addr: ${{ env.SERVER_ADDRESS }}
           auth_token: ${{ steps.oidc-dir-sign.outputs.token }}
           dirctl_path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
+          max_retries: ${{ env.SIGN_MAX_RETRIES }}
+          cleanup_on_failure: ${{ env.SIGN_CLEANUP_ON_FAILURE }}
+
+      - name: Write failed-to-sign artifact
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' && steps.sign-records.outputs.failed != '0' }}
+        run: |
+          printf '%s\n' "${{ steps.sign-records.outputs.failed_cids }}" > failed-to-sign.txt
+
+      - name: Upload unsigned CIDs after sign failure
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' && steps.sign-records.outputs.failed != '0' }}
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: failed-to-sign-mcp-${{ matrix.entry.index }}
+          path: failed-to-sign.txt
+          if-no-files-found: ignore
 
   import-agent-skills:
     needs: [setup-matrix, build-dirctl]
@@ -341,6 +369,8 @@ jobs:
       SIGN: ${{ needs.setup-matrix.outputs.sign }}
       FORCE: ${{ needs.setup-matrix.outputs.force }}
       DEBUG: ${{ needs.setup-matrix.outputs.debug }}
+      SIGN_MAX_RETRIES: ${{ needs.setup-matrix.outputs.sign_max_retries }}
+      SIGN_CLEANUP_ON_FAILURE: ${{ needs.setup-matrix.outputs.sign_cleanup_on_failure }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -490,6 +520,7 @@ jobs:
 
       - name: Sign imported records
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
+        id: sign-records
         uses: ./.github/actions/sign-record
         with:
           cids: ${{ steps.sign-cids.outputs.cids }}
@@ -497,6 +528,21 @@ jobs:
           server_addr: ${{ env.SERVER_ADDRESS }}
           auth_token: ${{ steps.oidc-dir-sign.outputs.token }}
           dirctl_path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
+          max_retries: ${{ env.SIGN_MAX_RETRIES }}
+          cleanup_on_failure: ${{ env.SIGN_CLEANUP_ON_FAILURE }}
+
+      - name: Write failed-to-sign artifact
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' && steps.sign-records.outputs.failed != '0' }}
+        run: |
+          printf '%s\n' "${{ steps.sign-records.outputs.failed_cids }}" > failed-to-sign.txt
+
+      - name: Upload unsigned CIDs after sign failure
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' && steps.sign-records.outputs.failed != '0' }}
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: failed-to-sign-agent-skills-${{ matrix.entry.index }}
+          path: failed-to-sign.txt
+          if-no-files-found: ignore
 
   import-summary:
     needs:
@@ -516,6 +562,8 @@ jobs:
       RUN_MCP_IMPORT: ${{ needs.setup-matrix.outputs.run_mcp_import }}
       RUN_AGENT_SKILLS_IMPORT: ${{ needs.setup-matrix.outputs.run_agent_skills_import }}
       DEBUG: ${{ needs.setup-matrix.outputs.debug }}
+      SIGN_MAX_RETRIES: ${{ needs.setup-matrix.outputs.sign_max_retries }}
+      SIGN_CLEANUP_ON_FAILURE: ${{ needs.setup-matrix.outputs.sign_cleanup_on_failure }}
       SETUP_MATRIX_RESULT: ${{ needs.setup-matrix.result }}
       BUILD_DIRCTL_RESULT: ${{ needs.build-dirctl.result }}
       IMPORT_MCP_RESULT: ${{ needs.import-mcp.result }}

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -277,70 +277,40 @@ jobs:
 
           echo "cids_file=$CIDS_FILE" >> $GITHUB_OUTPUT
 
-      - name: Fetch Sigstore OIDC token
+      - name: Load imported CIDs for signing
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' }}
-        id: oidc-sigstore
-        uses: ./.github/actions/fetch-oidc-token
-        with:
-          audience: sigstore
+        id: sign-cids
+        run: |
+          CIDS_FILE="${{ steps.import.outputs.cids_file }}"
+          if [ ! -f "$CIDS_FILE" ] || [ ! -s "$CIDS_FILE" ]; then
+            echo "No CIDs to sign"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          {
+            echo 'cids<<EOF'
+            cat "$CIDS_FILE"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Fetch Directory OIDC token for signing
-        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' }}
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
         id: oidc-dir-sign
         uses: ./.github/actions/fetch-oidc-token
         with:
           audience: dir
 
-      - name: Sign Imported Records
-        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' }}
-        env:
-          SIGSTORE_OIDC_TOKEN: ${{ steps.oidc-sigstore.outputs.token }}
-          DIRCTL_PATH: dirctl
-          DIR_AUTH_TOKEN: ${{ steps.oidc-dir-sign.outputs.token }}
-        run: |
-          CIDS_FILE="${{ steps.import.outputs.cids_file }}"
-
-          if [ ! -f "$CIDS_FILE" ]; then
-            echo "No CIDs file found - no records were imported"
-            exit 0
-          fi
-
-          CID_COUNT=$(wc -l < "$CIDS_FILE" | tr -d ' ')
-          if [ "$CID_COUNT" -eq 0 ]; then
-            echo "No CIDs to sign"
-            exit 0
-          fi
-
-          echo "Signing $CID_COUNT records..."
-          SIGNED=0
-          FAILED=0
-
-          while IFS= read -r CID || [ -n "$CID" ]; do
-            [ -z "$CID" ] && continue
-
-            echo "Signing CID: $CID"
-
-            if "${DIRCTL_PATH}" sign "$CID" \
-              --server-addr="${{ env.SERVER_ADDRESS }}" \
-              --auth-mode=oidc \
-              --auth-token="${DIR_AUTH_TOKEN}" \
-              --oidc-token="${SIGSTORE_OIDC_TOKEN}" \
-              --oidc-provider-url="https://token.actions.githubusercontent.com" \
-              --oidc-client-id="https://github.com/${{ github.repository }}/.github/workflows/import-records.yaml@${{ github.ref }}"; then
-              SIGNED=$((SIGNED + 1))
-            else
-              echo "Failed to sign CID: $CID"
-              FAILED=$((FAILED + 1))
-            fi
-          done < "$CIDS_FILE"
-
-          echo "=== Signing Summary ==="
-          echo "Signed: $SIGNED"
-          echo "Failed: $FAILED"
-
-          if [ "$FAILED" -gt 0 ]; then
-            exit 1
-          fi
+      - name: Sign imported records
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
+        uses: ./.github/actions/sign-record
+        with:
+          cids: ${{ steps.sign-cids.outputs.cids }}
+          oidc_client_id: https://github.com/${{ github.repository }}/.github/workflows/import-records.yaml@${{ github.ref }}
+          server_addr: ${{ env.SERVER_ADDRESS }}
+          auth_token: ${{ steps.oidc-dir-sign.outputs.token }}
+          dirctl_path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
 
   import-agent-skills:
     needs: [setup-matrix, build-dirctl]
@@ -478,67 +448,37 @@ jobs:
 
           echo "cids_file=$CIDS_FILE" >> $GITHUB_OUTPUT
 
-      - name: Fetch Sigstore OIDC token
+      - name: Load imported CIDs for signing
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' }}
-        id: oidc-sigstore
-        uses: ./.github/actions/fetch-oidc-token
-        with:
-          audience: sigstore
+        id: sign-cids
+        run: |
+          CIDS_FILE="${{ steps.import.outputs.cids_file }}"
+          if [ ! -f "$CIDS_FILE" ] || [ ! -s "$CIDS_FILE" ]; then
+            echo "No CIDs to sign"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          {
+            echo 'cids<<EOF'
+            cat "$CIDS_FILE"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Fetch Directory OIDC token for signing
-        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' }}
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
         id: oidc-dir-sign
         uses: ./.github/actions/fetch-oidc-token
         with:
           audience: dir
 
-      - name: Sign Imported Records
-        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' }}
-        env:
-          SIGSTORE_OIDC_TOKEN: ${{ steps.oidc-sigstore.outputs.token }}
-          DIRCTL_PATH: dirctl
-          DIR_AUTH_TOKEN: ${{ steps.oidc-dir-sign.outputs.token }}
-        run: |
-          CIDS_FILE="${{ steps.import.outputs.cids_file }}"
-
-          if [ ! -f "$CIDS_FILE" ]; then
-            echo "No CIDs file found - no records were imported"
-            exit 0
-          fi
-
-          CID_COUNT=$(wc -l < "$CIDS_FILE" | tr -d ' ')
-          if [ "$CID_COUNT" -eq 0 ]; then
-            echo "No CIDs to sign"
-            exit 0
-          fi
-
-          echo "Signing $CID_COUNT records..."
-          SIGNED=0
-          FAILED=0
-
-          while IFS= read -r CID || [ -n "$CID" ]; do
-            [ -z "$CID" ] && continue
-
-            echo "Signing CID: $CID"
-
-            if "${DIRCTL_PATH}" sign "$CID" \
-              --server-addr="${{ env.SERVER_ADDRESS }}" \
-              --auth-mode=oidc \
-              --auth-token="${DIR_AUTH_TOKEN}" \
-              --oidc-token="${SIGSTORE_OIDC_TOKEN}" \
-              --oidc-provider-url="https://token.actions.githubusercontent.com" \
-              --oidc-client-id="https://github.com/${{ github.repository }}/.github/workflows/import-records.yaml@${{ github.ref }}"; then
-              SIGNED=$((SIGNED + 1))
-            else
-              echo "Failed to sign CID: $CID"
-              FAILED=$((FAILED + 1))
-            fi
-          done < "$CIDS_FILE"
-
-          echo "=== Signing Summary ==="
-          echo "Signed: $SIGNED"
-          echo "Failed: $FAILED"
-
-          if [ "$FAILED" -gt 0 ]; then
-            exit 1
-          fi
+      - name: Sign imported records
+        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
+        uses: ./.github/actions/sign-record
+        with:
+          cids: ${{ steps.sign-cids.outputs.cids }}
+          oidc_client_id: https://github.com/${{ github.repository }}/.github/workflows/import-records.yaml@${{ github.ref }}
+          server_addr: ${{ env.SERVER_ADDRESS }}
+          auth_token: ${{ steps.oidc-dir-sign.outputs.token }}
+          dirctl_path: ${{ steps.setup-dirctl.outputs.dirctl_path }}

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -482,3 +482,35 @@ jobs:
           server_addr: ${{ env.SERVER_ADDRESS }}
           auth_token: ${{ steps.oidc-dir-sign.outputs.token }}
           dirctl_path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
+
+  import-summary:
+    needs:
+      - setup-matrix
+      - build-dirctl
+      - import-mcp
+      - import-agent-skills
+    if: ${{ always() && !cancelled() && needs.setup-matrix.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    env:
+      SERVER_ADDRESS: ${{ needs.setup-matrix.outputs.server_address }}
+      DRY_RUN: ${{ needs.setup-matrix.outputs.dry_run }}
+      SIGN: ${{ needs.setup-matrix.outputs.sign }}
+      RUN_MCP_IMPORT: ${{ needs.setup-matrix.outputs.run_mcp_import }}
+      RUN_AGENT_SKILLS_IMPORT: ${{ needs.setup-matrix.outputs.run_agent_skills_import }}
+      SETUP_MATRIX_RESULT: ${{ needs.setup-matrix.result }}
+      BUILD_DIRCTL_RESULT: ${{ needs.build-dirctl.result }}
+      IMPORT_MCP_RESULT: ${{ needs.import-mcp.result }}
+      IMPORT_AGENT_SKILLS_RESULT: ${{ needs.import-agent-skills.result }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Write import run summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          chmod +x .github/workflows/scripts/import-records-summary.sh
+          .github/workflows/scripts/import-records-summary.sh

--- a/.github/workflows/scripts/import-records-summary.sh
+++ b/.github/workflows/scripts/import-records-summary.sh
@@ -20,6 +20,7 @@ append_overview() {
     echo "| Server | \`${SERVER_ADDRESS}\` |"
     echo "| Dry run | ${DRY_RUN} |"
     echo "| Sign | ${SIGN} |"
+    echo "| Debug | ${DEBUG} |"
     echo "| MCP import enabled | ${RUN_MCP_IMPORT} |"
     echo "| Agent skills import enabled | ${RUN_AGENT_SKILLS_IMPORT} |"
     echo ""

--- a/.github/workflows/scripts/import-records-summary.sh
+++ b/.github/workflows/scripts/import-records-summary.sh
@@ -21,6 +21,8 @@ append_overview() {
     echo "| Dry run | ${DRY_RUN} |"
     echo "| Sign | ${SIGN} |"
     echo "| Debug | ${DEBUG} |"
+    echo "| Sign max retries | ${SIGN_MAX_RETRIES} |"
+    echo "| Sign cleanup on failure | ${SIGN_CLEANUP_ON_FAILURE} |"
     echo "| MCP import enabled | ${RUN_MCP_IMPORT} |"
     echo "| Agent skills import enabled | ${RUN_AGENT_SKILLS_IMPORT} |"
     echo ""

--- a/.github/workflows/scripts/import-records-summary.sh
+++ b/.github/workflows/scripts/import-records-summary.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+: "${GITHUB_STEP_SUMMARY:?GITHUB_STEP_SUMMARY is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+JOBS_JSON=$(gh run view "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --json jobs)
+
+append_overview() {
+  {
+    echo "## Import Records Run Summary"
+    echo ""
+    echo "| Setting | Value |"
+    echo "|---------|-------|"
+    echo "| Server | \`${SERVER_ADDRESS}\` |"
+    echo "| Dry run | ${DRY_RUN} |"
+    echo "| Sign | ${SIGN} |"
+    echo "| MCP import enabled | ${RUN_MCP_IMPORT} |"
+    echo "| Agent skills import enabled | ${RUN_AGENT_SKILLS_IMPORT} |"
+    echo ""
+    echo "| Job | Result |"
+    echo "|-----|--------|"
+    echo "| setup-matrix | ${SETUP_MATRIX_RESULT} |"
+    echo "| build-dirctl | ${BUILD_DIRCTL_RESULT} |"
+    echo "| import-mcp | ${IMPORT_MCP_RESULT} |"
+    echo "| import-agent-skills | ${IMPORT_AGENT_SKILLS_RESULT} |"
+    echo ""
+    echo "[View workflow run](${RUN_URL})"
+    echo ""
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+append_matrix_table() {
+  local title=$1
+  local filter=$2
+  local conclusion=${3:-}
+
+  local rows
+  if [ -n "$conclusion" ]; then
+    rows=$(echo "$JOBS_JSON" | jq -r --arg filter "$filter" --arg conclusion "$conclusion" '
+      [.jobs[]
+        | select(.name | startswith($filter))
+        | select((.conclusion // .status // "unknown") == $conclusion)
+        | {
+            name: .name,
+            conclusion: (.conclusion // .status // "unknown"),
+            url: .html_url
+          }
+      ]
+      | sort_by(.name)
+      | .[]
+      | "| [\(.name)](\(.url)) | \(.conclusion) |"
+    ')
+  else
+    rows=$(echo "$JOBS_JSON" | jq -r --arg filter "$filter" '
+      [.jobs[]
+        | select(.name | startswith($filter))
+        | {
+            name: .name,
+            conclusion: (.conclusion // .status // "unknown"),
+            url: .html_url
+          }
+      ]
+      | sort_by(.name)
+      | .[]
+      | "| [\(.name)](\(.url)) | \(.conclusion) |"
+    ')
+  fi
+
+  if [ -z "$rows" ]; then
+    return 0
+  fi
+
+  {
+    echo "### ${title}"
+    echo ""
+    echo "| Matrix job | Result |"
+    echo "|------------|--------|"
+    echo "$rows"
+    echo ""
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+append_counts() {
+  local counts
+  counts=$(echo "$JOBS_JSON" | jq -r '
+    [.jobs[] | select(.name | startswith("import-mcp (") or startswith("import-agent-skills ("))]
+    | group_by(.conclusion // .status // "unknown")
+    | map({key: (.[0].conclusion // .[0].status // "unknown"), count: length})
+    | sort_by(.key)
+    | .[]
+    | "\(.key): \(.count)"
+  ')
+
+  if [ -z "$counts" ]; then
+    return 0
+  fi
+
+  {
+    echo "### Matrix job counts"
+    echo ""
+    while IFS= read -r line; do
+      echo "- ${line}"
+    done <<< "$counts"
+    echo ""
+  } >> "$GITHUB_STEP_SUMMARY"
+}
+
+append_overview
+append_counts
+append_matrix_table "Failed matrix jobs" "import-" "failure"
+append_matrix_table "Cancelled matrix jobs" "import-" "cancelled"
+append_matrix_table "Timed out matrix jobs" "import-" "timed_out"
+
+FAILED=$(echo "$JOBS_JSON" | jq '[.jobs[] | select(.name | startswith("import-mcp (") or startswith("import-agent-skills (")) | select((.conclusion // "") | IN("failure", "cancelled", "timed_out"))] | length')
+if [ "$FAILED" -gt 0 ]; then
+  {
+    echo "> **${FAILED} import matrix job(s) failed, were cancelled, or timed out.**"
+    echo ""
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 1
+fi
+
+SUCCESS=$(echo "$JOBS_JSON" | jq '[.jobs[] | select(.name | startswith("import-mcp (") or startswith("import-agent-skills (")) | select((.conclusion // "") == "success")] | length')
+if [ "$SUCCESS" -gt 0 ]; then
+  append_matrix_table "Successful matrix jobs" "import-" "success"
+fi
+
+{
+  echo "All completed import matrix jobs succeeded (${SUCCESS})."
+  echo ""
+} >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scripts/import-records.json
+++ b/.github/workflows/scripts/import-records.json
@@ -1,37 +1,40 @@
 {
   "mcp-registry": [
     {
-      "search": "com.microsoft"
+      "search": "com.microsoft/"
     },
     {
-      "search": "io.github.microsoft"
+      "search": "io.github.microsoft/"
     },
     {
       "search": "io.github.github/"
     },
     {
-      "search": "io.github.google"
+      "search": "io.github.GoogleCloudPlatform/"
     },
     {
-      "search": "io.github.aws"
+      "search": "io.github.googleapis/"
     },
     {
-      "search": "com.cisco"
+      "search": "io.github.aws/"
     },
     {
-      "search": "com.thousandeyes"
+      "search": "com.cisco/"
     },
     {
-      "search": "io.github.redhat"
+      "search": "com.thousandeyes/"
     },
     {
-      "search": "io.github.arm"
+      "search": "io.github.RedHatInsights/"
     },
     {
-      "search": "io.github.pagerduty"
+      "search": "io.github.arm/"
     },
     {
-      "search": "com.postman"
+      "search": "io.github.pagerduty/"
+    },
+    {
+      "search": "com.postman/"
     }
   ],
   "agent-skill": [

--- a/.github/workflows/scripts/mcphost_ci.json.template
+++ b/.github/workflows/scripts/mcphost_ci.json.template
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "dir-mcp-server": {
+      "command": "__DIRCTL_PATH__",
+      "args": [
+        "mcp",
+        "serve"
+      ],
+      "env": {
+        "OASF_API_VALIDATION_SCHEMA_URL": "https://schema.oasf.outshift.com",
+        "DIRECTORY_CLIENT_AUTH_MODE": "insecure"
+      }
+    }
+  },
+  "model": "azure:gpt-4o",
+  "max-steps": 10
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -6,7 +6,7 @@ require (
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260610090943-03acfe1f6b7e.1
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260602080720-2b66557c6456.1
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
-	github.com/agntcy/oasf-sdk/pkg v1.0.5
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/opencontainers/go-digest v1.0.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -6,8 +6,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-202604152011
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/agntcy/oasf-sdk/pkg v1.0.5 h1:Sv8K9tqdfl4gfl30spFh9MYkqnzXcTByCsb2uZsNWE4=
-github.com/agntcy/oasf-sdk/pkg v1.0.5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 h1:wvavxaeUuqyKzGU2JZhHshFrl7l74ADEKBiBfg4rgN8=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260602080720-2b66557c6456.1
-	github.com/agntcy/dir-importer v1.4.1-0.20260610125234-c3d75c103025
+	github.com/agntcy/dir-importer v1.4.1-0.20260612122304-f331bd5b73d6
 	github.com/agntcy/dir-mcp v1.3.1
 	github.com/agntcy/dir-runtime/discovery v1.3.1
 	github.com/agntcy/dir-runtime/server v1.3.1
@@ -30,7 +30,7 @@ require (
 	github.com/agntcy/dir/reconciler v1.4.0
 	github.com/agntcy/dir/server v1.4.0
 	github.com/agntcy/dir/utils v1.4.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260610090927-85c0d92a3374
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8
 	github.com/ipfs/go-cid v0.6.1
 	github.com/libp2p/go-libp2p v0.48.0
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -192,8 +192,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.1-0.20260610125234-c3d75c103025 h1:U0o352kpdyPGLY/Zdkf458PEvhShQ62hCSrV6QQt9Rg=
-github.com/agntcy/dir-importer v1.4.1-0.20260610125234-c3d75c103025/go.mod h1:P3XwfCYSsgf/zslZbhcm5ZbVLmi0b+3AlvkvTfkgp7o=
+github.com/agntcy/dir-importer v1.4.1-0.20260612122304-f331bd5b73d6 h1:t1g+IgNyzuD3V7w1qEumBj0hEv6doAreuszqTB6z6Ss=
+github.com/agntcy/dir-importer v1.4.1-0.20260612122304-f331bd5b73d6/go.mod h1:B2i4gnXpOIwUvCc3IJf6Dmm/HVo1PGg1giEHt95tkag=
 github.com/agntcy/dir-mcp v1.3.1 h1:KoyFof//ylamRsw7xg57W0TCF1u93Y6sFl0JSTUWYUA=
 github.com/agntcy/dir-mcp v1.3.1/go.mod h1:ISREp2R0HUpzrk+Pv1Y3+hynf3oC4pC0D8SKSjjIBNk=
 github.com/agntcy/dir-runtime/discovery v1.3.1 h1:z+NHyGrm0bU0fbFz426OXg3bFwXqipp1F9YDsETxpUE=
@@ -204,8 +204,8 @@ github.com/agntcy/dir-runtime/store v1.3.1 h1:CPIV60I5MAJG5hPK6Vv+MhHiYFmaf7tCxq
 github.com/agntcy/dir-runtime/store v1.3.1/go.mod h1:ywWhrOu30CoZnsfXdY5hh5vBadZqUNGfeH/xIcPVYag=
 github.com/agntcy/dir-runtime/utils v1.3.1 h1:sEXS9TlFyK3d0NIZzaMQqW8cRjm/FgYTC1aWHte8JOo=
 github.com/agntcy/dir-runtime/utils v1.3.1/go.mod h1:ugJUOWpR+kOxVv22snmYSMMNqTh1c6leZ9CJcEZRMpo=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260610090927-85c0d92a3374 h1:UPqzw5ft5ZVkjcHl2hCuCjchKTAnaaSIsLhrJPWzs1c=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260610090927-85c0d92a3374/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 h1:wvavxaeUuqyKzGU2JZhHshFrl7l74ADEKBiBfg4rgN8=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/client/go.mod
+++ b/client/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ThalesIgnite/crypto11 v1.6.0 // indirect
-	github.com/agntcy/oasf-sdk/pkg v1.0.5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -47,8 +47,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ThalesGroup/crypto11 v1.6.1 h1:8A8dZPAJPkQnuE55rRkaFWKuLvZ0fklrtJuOd1r92yU=
 github.com/ThalesGroup/crypto11 v1.6.1/go.mod h1:JcRp7axGx5fDqzAcco/jC1BYMHCvd+hKPwpdoaMNHMQ=
-github.com/agntcy/oasf-sdk/pkg v1.0.5 h1:Sv8K9tqdfl4gfl30spFh9MYkqnzXcTByCsb2uZsNWE4=
-github.com/agntcy/oasf-sdk/pkg v1.0.5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 h1:wvavxaeUuqyKzGU2JZhHshFrl7l74ADEKBiBfg4rgN8=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=

--- a/reconciler/go.mod
+++ b/reconciler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/agntcy/dir/client v1.4.0
 	github.com/agntcy/dir/server v1.4.0
 	github.com/agntcy/dir/utils v1.4.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260605125511-e0bbc735d1b8
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8
 	github.com/csirmazbendeguz/regclient v0.0.0-20260429082137-82ab6d426079
 	github.com/sigstore/sigstore v1.10.8
 	github.com/spf13/viper v1.21.0

--- a/reconciler/go.sum
+++ b/reconciler/go.sum
@@ -51,8 +51,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ThalesGroup/crypto11 v1.6.1 h1:8A8dZPAJPkQnuE55rRkaFWKuLvZ0fklrtJuOd1r92yU=
 github.com/ThalesGroup/crypto11 v1.6.1/go.mod h1:JcRp7axGx5fDqzAcco/jC1BYMHCvd+hKPwpdoaMNHMQ=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260605125511-e0bbc735d1b8 h1:5pHng9P6Rd36bgKUvIne3dSdENlNTugn5xqscbiLmNA=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260605125511-e0bbc735d1b8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 h1:wvavxaeUuqyKzGU2JZhHshFrl7l74ADEKBiBfg4rgN8=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/server/go.mod
+++ b/server/go.mod
@@ -18,7 +18,7 @@ require (
 	buf.build/go/protovalidate v1.2.0
 	github.com/agntcy/dir/api v1.4.0
 	github.com/agntcy/dir/utils v1.4.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260605125511-e0bbc735d1b8
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3

--- a/server/go.sum
+++ b/server/go.sum
@@ -60,8 +60,8 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260605125511-e0bbc735d1b8 h1:5pHng9P6Rd36bgKUvIne3dSdENlNTugn5xqscbiLmNA=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260605125511-e0bbc735d1b8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 h1:wvavxaeUuqyKzGU2JZhHshFrl7l74ADEKBiBfg4rgN8=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.4.1-0.20260610125234-c3d75c103025
+	github.com/agntcy/dir-importer v1.4.1-0.20260612122304-f331bd5b73d6
 	github.com/agntcy/dir/api v1.4.0
 	github.com/agntcy/dir/cli v1.4.0
 	github.com/agntcy/dir/client v1.4.0
@@ -92,7 +92,7 @@ require (
 	github.com/agntcy/dir/reconciler v1.4.0 // indirect
 	github.com/agntcy/dir/server v1.4.0
 	github.com/agntcy/dir/utils v1.4.0 // indirect
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260610090927-85c0d92a3374 // indirect
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -192,8 +192,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.1-0.20260610125234-c3d75c103025 h1:U0o352kpdyPGLY/Zdkf458PEvhShQ62hCSrV6QQt9Rg=
-github.com/agntcy/dir-importer v1.4.1-0.20260610125234-c3d75c103025/go.mod h1:P3XwfCYSsgf/zslZbhcm5ZbVLmi0b+3AlvkvTfkgp7o=
+github.com/agntcy/dir-importer v1.4.1-0.20260612122304-f331bd5b73d6 h1:t1g+IgNyzuD3V7w1qEumBj0hEv6doAreuszqTB6z6Ss=
+github.com/agntcy/dir-importer v1.4.1-0.20260612122304-f331bd5b73d6/go.mod h1:B2i4gnXpOIwUvCc3IJf6Dmm/HVo1PGg1giEHt95tkag=
 github.com/agntcy/dir-mcp v1.3.1 h1:KoyFof//ylamRsw7xg57W0TCF1u93Y6sFl0JSTUWYUA=
 github.com/agntcy/dir-mcp v1.3.1/go.mod h1:ISREp2R0HUpzrk+Pv1Y3+hynf3oC4pC0D8SKSjjIBNk=
 github.com/agntcy/dir-runtime/discovery v1.3.1 h1:z+NHyGrm0bU0fbFz426OXg3bFwXqipp1F9YDsETxpUE=
@@ -204,8 +204,8 @@ github.com/agntcy/dir-runtime/store v1.3.1 h1:CPIV60I5MAJG5hPK6Vv+MhHiYFmaf7tCxq
 github.com/agntcy/dir-runtime/store v1.3.1/go.mod h1:ywWhrOu30CoZnsfXdY5hh5vBadZqUNGfeH/xIcPVYag=
 github.com/agntcy/dir-runtime/utils v1.3.1 h1:sEXS9TlFyK3d0NIZzaMQqW8cRjm/FgYTC1aWHte8JOo=
 github.com/agntcy/dir-runtime/utils v1.3.1/go.mod h1:ugJUOWpR+kOxVv22snmYSMMNqTh1c6leZ9CJcEZRMpo=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260610090927-85c0d92a3374 h1:UPqzw5ft5ZVkjcHl2hCuCjchKTAnaaSIsLhrJPWzs1c=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260610090927-85c0d92a3374/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 h1:wvavxaeUuqyKzGU2JZhHshFrl7l74ADEKBiBfg4rgN8=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
## Summary

Stabilizes and improves the `import-records` GitHub Actions workflow for MCP registry and agent-skill catalog imports.

- **Serial matrix execution** — `max-parallel: 1` on both import jobs to reduce server/API contention
- **Workflow concurrency** — single `import-records` run at a time; in-progress runs are not cancelled
- **Shared build artifacts** — `dirctl` and `mcp-scanner` built once and reused across matrix jobs
- **Import timeouts** — 300-minute cap per import step for clearer failures before the 6h runner limit
- **Agent-skill caching** — shallow clone + cache keyed by repo slug; `dirctl` downloaded before repo sync
- **DRY config** — enricher config rendered from `mcphost_ci.json.template`
- **Signing** — reuse `.github/actions/sign-record` instead of duplicated inline loops
- **Sign retry and cleanup** — per-CID sign retries with fresh Sigstore OIDC tokens; delete unsigned records after failed signing so the next import can re-push (`sign_max_retries`, `sign_cleanup_on_failure` workflow inputs)
- **Run summary** — final `import-summary` job (`if: always()`) reports matrix success/failure/timeout in the Step Summary
- **Optional debug** — workflow_dispatch `debug` input (default false) passes `--debug` to `dirctl import` when enabled
- **MCP search filters** — trailing `/` on registry search prefixes to avoid typosquat substring matches (e.g. `io.github.Armigerous`); split Google and Red Hat into correct namespace prefixes
- **Deps** — bump `oasf-sdk` and `dir-importer` to latest