### PR TITLE
fix(docs): adds back header shadow

### DIFF
--- a/docs/content/stylesheets/agntcy-docs.css
+++ b/docs/content/stylesheets/agntcy-docs.css
@@ -76,15 +76,15 @@
 [data-md-color-primary="black"] .md-header {
   background-color: var(--md-primary-fg-color) !important;
   border-bottom: none;
-  box-shadow:
-    inset 0 1px 0 var(--md-header-highlight),
-    0 1px 2px rgba(0, 0, 0, 0.04);
+  box-shadow: inset 0 1px 0 var(--md-header-highlight);
 }
 
-.md-header[data-md-state="shadow"] {
+.md-header.md-header--shadow,
+[data-md-color-primary="black"] .md-header.md-header--shadow {
   box-shadow:
     inset 0 1px 0 var(--md-header-highlight),
-    0 1px 3px rgba(0, 0, 0, 0.06);
+    0 0 0.2rem rgba(0, 0, 0, 0.1),
+    0 0.2rem 0.4rem rgba(0, 0, 0, 0.2);
 }
 
 /* Announcement banner */

--- a/docs/content/stylesheets/dir-landing.css
+++ b/docs/content/stylesheets/dir-landing.css
@@ -82,11 +82,6 @@
 }
 
 /* Home page only: MkDocs chrome adjustments for full-bleed hero. */
-body:has(.dir-landing) .md-header,
-body:has(.dir-landing) .md-header[data-md-state="shadow"] {
-  box-shadow: none;
-}
-
 body:has(.dir-landing) .md-tabs__item--active .md-tabs__link {
   border-bottom-color: transparent;
 }


### PR DESCRIPTION
Adds the default soft shadow to the header when content is being scrolled.

BEFORE 
<img width="1435" height="273" alt="image" src="https://github.com/user-attachments/assets/6b095b79-7046-4efc-a303-7e25362bc5cd" />


AFTER
<img width="1434" height="258" alt="image" src="https://github.com/user-attachments/assets/7def61ca-a983-48a4-bc8b-35bdb9ef2975" />
