### PR TITLE
docs(docs/get-started): trim and reorder the Get Started pages for easier onboarding

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,7 @@ jobs:
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '!gui/**'

--- a/HomebrewFormula/README.md
+++ b/HomebrewFormula/README.md
@@ -2,7 +2,7 @@
 
 ## How to add this homebrew tap to your system
 ```bash
-    brew tap agntcy/dir https://github.com/agntcy/dir/
+    brew tap agntcy/dir https://github.com/agntcy/dir
 ```
 
 ## Trust the formulae for getting updates

--- a/cli/README.md
+++ b/cli/README.md
@@ -20,7 +20,8 @@ Full documentation: [https://docs.agntcy.org/dir/dir-cli-reference/](https://doc
 
 ```bash
 # Install (Homebrew)
-brew tap agntcy/dir https://github.com/agntcy/dir/
+brew tap agntcy/dir https://github.com/agntcy/dir
+brew trust agntcy/dir
 brew install dirctl
 
 # Store, publish, search, pull

--- a/docs/content/dir/dir-api-reference.md
+++ b/docs/content/dir/dir-api-reference.md
@@ -19,6 +19,20 @@ canonical schema live on [buf.build/agntcy/dir](https://buf.build/agntcy/dir).
 Use the Buf schema browser for message types, RPC names, and versioned packages. The
 [Architecture](dir-architecture.md) page describes how these APIs map to Directory components.
 
+## Error codes
+
+Server APIs return standard gRPC status codes:
+
+| Error Code | Description |
+|------------|-------------|
+| `codes.InvalidArgument` | Client provided an invalid or malformed argument, such as a missing or invalid record reference or record. |
+| `codes.NotFound` | The requested object does not exist in the local store or across the network. |
+| `codes.FailedPrecondition` | The server environment or configuration is not in the required state (e.g., failed to create a directory or temp file). |
+| `codes.Internal` | An unexpected internal error occurred, such as I/O failures, serialization errors, or other server-side issues. |
+| `codes.Canceled` | The operation was canceled by the client or the context expired. |
+| `codes.Unauthenticated` | The client is not authenticated to perform the operation. |
+| `codes.PermissionDenied` | The client does not have permission to perform the operation. |
+
 ## Clients
 
 - **CLI** — [Directory CLI Reference](dir-cli-reference.md) (`dirctl`)

--- a/docs/content/dir/dir-component-routing.md
+++ b/docs/content/dir/dir-component-routing.md
@@ -22,6 +22,32 @@ Discovery uses:
 Skill matching supports exact and hierarchical prefix matching. Network search results
 reflect cached announcements and may be stale or incomplete until peers replicate records.
 
+ADS uses [libp2p Kad-DHT](https://github.com/libp2p/specs/tree/master/kad-dht) for server and
+content discovery.
+
+## Publication and discovery flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant DHT
+    participant ServerA
+    participant ServerB
+
+    Note over ServerA,ServerB: Publication Phase
+    ServerA->>ServerA: Generate CID, store record, extract labels
+    ServerA->>DHT: Announce CID + labels
+    ServerB->>ServerB: Generate CID, store record, extract labels
+    ServerB->>DHT: Announce CID + labels
+    DHT->>DHT: Update routing tables<br/>(labels→CIDs→servers)
+
+    Note over User,ServerB: Discovery Phase
+    User->>DHT: Query by labels
+    DHT->>User: Return matching CIDs<br/>+ server addresses
+    User->>ServerA: Download record 1
+    User->>ServerB: Download record 2
+```
+
 ## Related documentation
 
 - [Architecture](dir-architecture.md) — full system design and diagram

--- a/docs/content/dir/dir-component-store.md
+++ b/docs/content/dir/dir-component-store.md
@@ -24,11 +24,10 @@ Directory supports multiple OCI-compatible registry backends:
 | `ghcr` | GitHub Container Registry |
 | `dockerhub` | Docker Hub |
 
-The backend is selected and configured via environment variables on the Directory server:
+The backend is configured via environment variables on the Directory server:
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| `DIRECTORY_SERVER_STORE_OCI_TYPE` | Registry type (`zot`, `ghcr`, `dockerhub`) | `zot` |
 | `DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS` | Registry address | `127.0.0.1:5000` |
 | `DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME` | Repository name | `dir` |
 
@@ -46,7 +45,6 @@ Credentials are supplied through additional environment variables:
 **Zot (local development)**
 
 ```bash
-export DIRECTORY_SERVER_STORE_OCI_TYPE=zot
 export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=localhost:5000
 export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=dir
 export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=true
@@ -55,7 +53,6 @@ export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=true
 **GitHub Container Registry (GHCR)**
 
 ```bash
-export DIRECTORY_SERVER_STORE_OCI_TYPE=ghcr
 export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=ghcr.io
 export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=your-org/dir
 export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME=your-github-username
@@ -74,7 +71,6 @@ export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=false
 **Docker Hub**
 
 ```bash
-export DIRECTORY_SERVER_STORE_OCI_TYPE=dockerhub
 export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=docker.io
 export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=your-username/dir
 export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME=your-dockerhub-username

--- a/docs/content/dir/dir-component-store.md
+++ b/docs/content/dir/dir-component-store.md
@@ -85,6 +85,21 @@ export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=false
 See also [Local Deployment](dir-deployment-local.md) and
 [Production Deployment](dir-prod-deployment.md) for deployment-specific configuration.
 
+## Storage model
+
+ADS differs from block storage systems like [IPFS](https://ipfs.tech/) in its approach to
+distributed object storage:
+
+- **Simplified content retrieval** — ADS stores complete records rather than splitting them
+  into blocks, so no special optimizations are needed to reassemble content from multiple
+  sources. Records are retrieved as complete units using standard OCI protocols.
+- **OCI integration** — records are stored and transferred as OCI artifacts, so any
+  OCI distribution-compliant server can participate in the network and peers retrieve records
+  directly from each other using standard OCI protocols.
+
+While ADS uses [zot](https://zotregistry.dev) as its reference OCI server implementation, the
+system works with any server that implements the OCI distribution specification.
+
 ## Related documentation
 
 - [Records](dir-component-records-validation.md) — OASF record model, CIDs, and validation

--- a/docs/content/dir/dir-component-store.md
+++ b/docs/content/dir/dir-component-store.md
@@ -14,15 +14,79 @@ When a client pushes a record, the server:
 Records can be retrieved by CID or, when configured with a verifiable name, by
 Docker-style name references (`name`, `name:version`, `name:version@cid`).
 
-## Backends
+## Backends and configuration
 
-Directory supports OCI-compatible registries including [Zot](https://github.com/project-zot/zot)
-(default for local deployments), GitHub Container Registry, and Docker Hub. The server selects
-the backend via store configuration (see [Local Deployment](dir-deployment-local.md) and
-[Production Deployment](dir-prod-deployment.md)).
+Directory supports multiple OCI-compatible registry backends:
+
+| Registry Type | Description |
+|---------------|-------------|
+| `zot` | [Zot](https://github.com/project-zot/zot) OCI registry (default for local deployments) |
+| `ghcr` | GitHub Container Registry |
+| `dockerhub` | Docker Hub |
+
+The backend is selected and configured via environment variables on the Directory server:
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `DIRECTORY_SERVER_STORE_OCI_TYPE` | Registry type (`zot`, `ghcr`, `dockerhub`) | `zot` |
+| `DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS` | Registry address | `127.0.0.1:5000` |
+| `DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME` | Repository name | `dir` |
+
+Credentials are supplied through additional environment variables:
+
+| Environment Variable | Description |
+|---------------------|-------------|
+| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME` | Username for basic authentication |
+| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_PASSWORD` | Password for basic authentication |
+| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_ACCESS_TOKEN` | Access token for token-based authentication |
+| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE` | Skip TLS verification (default: `true`) |
+
+### Configuration examples
+
+**Zot (local development)**
+
+```bash
+export DIRECTORY_SERVER_STORE_OCI_TYPE=zot
+export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=localhost:5000
+export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=dir
+export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=true
+```
+
+**GitHub Container Registry (GHCR)**
+
+```bash
+export DIRECTORY_SERVER_STORE_OCI_TYPE=ghcr
+export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=ghcr.io
+export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=your-org/dir
+export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME=your-github-username
+export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_PASSWORD=your-github-token
+export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=false
+```
+
+!!! warning
+    GHCR does not support record deletion via the OCI API. Attempting to
+    delete a record when using GHCR will return an error.
+    To manage packages hosted on GHCR, use the GitHub UI, REST API, or
+    GraphQL API instead. See
+    [Deleting and restoring a package](https://docs.github.com/en/packages/learn-github-packages/deleting-and-restoring-a-package)
+    for details.
+
+**Docker Hub**
+
+```bash
+export DIRECTORY_SERVER_STORE_OCI_TYPE=dockerhub
+export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=docker.io
+export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=your-username/dir
+export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME=your-dockerhub-username
+export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_PASSWORD=your-dockerhub-token
+export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=false
+```
+
+See also [Local Deployment](dir-deployment-local.md) and
+[Production Deployment](dir-prod-deployment.md) for deployment-specific configuration.
 
 ## Related documentation
 
 - [Records](dir-component-records-validation.md) — OASF record model, CIDs, and validation
-- [Features and Usage Scenarios — Store](dir-features-scenarios.md#store) — CLI examples and registry configuration
+- [Features and Usage Scenarios — Store](dir-features-scenarios.md#store) — CLI examples for push, pull, and info
 - [CLI Reference — Storage Operations](dir-cli-reference.md#storage-operations) — `push`, `pull`, `delete`, `info`

--- a/docs/content/dir/dir-features-scenarios.md
+++ b/docs/content/dir/dir-features-scenarios.md
@@ -64,77 +64,9 @@ OCI digest into a CIDv1 format using CID multihash encoding. Each record is then
 its CID in the registry, enabling direct lookup and ensuring content integrity through
 cryptographic addressing.
 
-### Supported Registries
-
-The Directory supports multiple OCI-compatible registry backends:
-
-| Registry Type | Description |
-|---------------|-------------|
-| `zot` | [Zot](https://github.com/project-zot/zot) OCI registry (default) |
-| `ghcr` | GitHub Container Registry |
-| `dockerhub` | Docker Hub |
-
-#### Registry Configuration
-
-The registry backend is configured via environment variables on the Directory server:
-
-| Environment Variable | Description | Default |
-|---------------------|-------------|---------|
-| `DIRECTORY_SERVER_STORE_OCI_TYPE` | Registry type (`zot`, `ghcr`, `dockerhub`) | `zot` |
-| `DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS` | Registry address | `127.0.0.1:5000` |
-| `DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME` | Repository name | `dir` |
-
-### Authentication Configuration
-
-Credentials for the registry are configured via environment variables:
-
-| Environment Variable | Description |
-|---------------------|-------------|
-| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME` | Username for basic authentication |
-| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_PASSWORD` | Password for basic authentication |
-| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_ACCESS_TOKEN` | Access token for token-based authentication |
-| `DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE` | Skip TLS verification (default: `true`) |
-
-### Configuration Examples
-
-**Zot (Local Development)**
-
-```bash
-export DIRECTORY_SERVER_STORE_OCI_TYPE=zot
-export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=localhost:5000
-export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=dir
-export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=true
-```
-
-**GitHub Container Registry (GHCR)**
-
-```bash
-export DIRECTORY_SERVER_STORE_OCI_TYPE=ghcr
-export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=ghcr.io
-export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=your-org/dir
-export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME=your-github-username
-export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_PASSWORD=your-github-token
-export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=false
-```
-
-!!! warning
-    GHCR does not support record deletion via the OCI API. Attempting to
-    delete a record when using GHCR will return an error.
-    To manage packages hosted on GHCR, use the GitHub UI, REST API, or
-    GraphQL API instead. See
-    [Deleting and restoring a package](https://docs.github.com/en/packages/learn-github-packages/deleting-and-restoring-a-package)
-    for details.
-
-**Docker Hub**
-
-```bash
-export DIRECTORY_SERVER_STORE_OCI_TYPE=dockerhub
-export DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS=docker.io
-export DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME=your-username/dir
-export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME=your-dockerhub-username
-export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_PASSWORD=your-dockerhub-token
-export DIRECTORY_SERVER_STORE_OCI_AUTH_CONFIG_INSECURE=false
-```
+The server can be backed by Zot (default), GHCR, or Docker Hub. For the supported registry
+backends and the server-side environment variables that configure them, see
+[Store — Backends and configuration](dir-component-store.md#backends-and-configuration).
 
 ### Basic Operations
 
@@ -498,15 +430,8 @@ dirctl search --name "api-*-service" --version "v2.*"
 dirctl search --skill "*machine*learning*"
 ```
 
-**Available Search Flags:**
-
-- `--name <name>` - Search by record name
-- `--version <version>` - Search by record version
-- `--skill-id <id>` - Search by skill ID number
-- `--skill <skill>` - Search by skill name
-- `--locator <type>` - Search by locator type
-- `--domain <domain>` - Search by domain
-- `--module <module>` - Search by module name
+For the full list of search filter flags and output options, see
+[CLI Reference — `dirctl search`](dir-cli-reference.md#dirctl-search-flags).
 
 **Search Logic:**
 
@@ -657,27 +582,3 @@ dirctl export --output-dir=./exports/ --format=a2a --module "integration/a2a"
 
 By default, only the latest semver version is exported; use `--all-versions` to export every
 version. See [CLI Reference — Export Operations](dir-cli-reference.md#export-operations).
-
-## gRPC Error Codes
-
-The following table lists the gRPC error codes returned by the server APIs, along with a
-description of when each code is used:
-
-| Error Code                 | Description                                                  |
-| -------------------------- | ------------------------------------------------------------ |
-| `codes.InvalidArgument`    | When client provides an invalid or malformed argument, such |
-|                            | as a missing or invalid record reference or record.         |
-| `codes.NotFound`           | When the requested object does not exist in the local store |
-|                            | or across the network.                                       |
-| `codes.FailedPrecondition` | When the server environment or configuration is not in the  |
-|                            | required state (e.g., failed to create a directory or temp  |
-|                            | file).                                                       |
-| `codes.Internal`           | When an unexpected internal error occurs, such as I/O       |
-|                            | failures, serialization errors, or other server-side        |
-|                            | issues.                                                      |
-| `codes.Canceled`           | When the operation is canceled by the client or context     |
-|                            | expires.                                                     |
-| `codes.Unauthenticated`    | When the client is not authenticated to perform the         |
-|                            | operation.                                                   |
-| `codes.PermissionDenied`   | When the client does not have permission to perform the     |
-|                            | operation.                                                   |

--- a/docs/content/dir/dir-overview.md
+++ b/docs/content/dir/dir-overview.md
@@ -117,24 +117,17 @@ sequenceDiagram
     participant DHT
     participant ServerA
     participant ServerB
-    participant ServerC
 
-    Note over ServerA,ServerC: Publication Phase
-    ServerA->>ServerA: Generate record CID
-    ServerA->>ServerA: Extract skills from record
-    ServerA->>ServerA: Store record locally
+    Note over ServerA,ServerB: Publication Phase
+    ServerA->>ServerA: Generate CID, store record, extract skills
     ServerA->>DHT: Announce CID + skills
-    ServerB->>ServerB: Generate record CID
-    ServerB->>ServerB: Extract skills from record
-    ServerB->>ServerB: Store record locally
+    ServerB->>ServerB: Generate CID, store record, extract skills
     ServerB->>DHT: Announce CID + skills
     DHT->>DHT: Update routing tables<br/>(skills→CIDs→servers)
 
-    Note over User,ServerC: Discovery Phase
+    Note over User,ServerB: Discovery Phase
     User->>DHT: Query by skills
-    DHT->>DHT: Search routing tables
     DHT->>User: Return matching CIDs<br/>+ server addresses
-    User->>User: Select records
     User->>ServerA: Download record 1
     User->>ServerB: Download record 2
 ```
@@ -144,6 +137,5 @@ sequenceDiagram
 Ready to get started? Choose your path:
 
 - Run a local instance: follow the [Quickstart](dir-quickstart.md) or see [Local Deployment](dir-deployment-local.md) and [Kubernetes Deployment](dir-deployment-kubernetes.md).
-- Configure external user or automation access with OIDC: see [OIDC Authentication for Directory](dir-component-oidc-authentication.md).
 - Connect to the public Directory: use the existing network at `ads.outshift.io` to discover and publish agents. See [Running a Federated Directory Instance](dir-federation-setup.md).
 - Deploy for production: run your own Directory instance on AWS EKS and optionally federate with the network. See [Production Deployment](dir-prod-deployment.md).

--- a/docs/content/dir/dir-overview.md
+++ b/docs/content/dir/dir-overview.md
@@ -47,10 +47,6 @@ complementary skills solve complex problems, and dependency chains for composite
 - **Distributed Architecture**: Built on proven distributed systems principles,
 ADS uses content-addressing for global uniqueness and implements distributed hash tables (DHT)
 for scalable content discovery across decentralized networks.
-- **Runtime Discovery**: Automatically discover and query agent workloads running in container
-runtimes (Docker, Kubernetes). The discovery system watches for labeled containers/pods,
-resolves their metadata (A2A cards, OASF records), and exposes them via gRPC API for
-integration with other Directory components.
 
 ## Naming
 

--- a/docs/content/dir/dir-overview.md
+++ b/docs/content/dir/dir-overview.md
@@ -21,8 +21,10 @@ integration and testing across different versions, environments, and features.
 
 Each directory record must include skills from a defined taxonomy, as specified
 in the [Taxonomy of AI Agent Skills](https://schema.oasf.outshift.com/skill_categories) from the [OASF](https://docs.agntcy.org/oasf/open-agentic-schema-framework/).
-While all record data is modeled using the [OASF](https://docs.agntcy.org/oasf/open-agentic-schema-framework/), only skills are
-leveraged for content routing in the distributed network of directory servers.
+While all record data is modeled using the [OASF](https://docs.agntcy.org/oasf/open-agentic-schema-framework/), content routing
+in the distributed network of directory servers is driven by a subset of record attributes —
+skills, domains, modules, and locators — which are announced as labels and used for network
+discovery.
 The ADS specification is under active development and is published as an
 Internet Draft at [ADS Spec](https://datatracker.ietf.org/doc/draft-mp-agntcy-ads). The source code is
 available in the [ADS Spec sources](https://github.com/agntcy/dir-spec).

--- a/docs/content/dir/dir-overview.md
+++ b/docs/content/dir/dir-overview.md
@@ -25,15 +25,10 @@ While all record data is modeled using the [OASF](https://docs.agntcy.org/oasf/o
 in the distributed network of directory servers is driven by a subset of record attributes —
 skills, domains, modules, and locators — which are announced as labels and used for network
 discovery.
-The ADS specification is under active development and is published as an
-Internet Draft at [ADS Spec](https://datatracker.ietf.org/doc/draft-mp-agntcy-ads). The source code is
-available in the [ADS Spec sources](https://github.com/agntcy/dir-spec).
-Directory gRPC APIs and protobuf definitions are published on
-[buf.build/agntcy/dir](https://buf.build/agntcy/dir).
-The current reference implementation, written in Go, provides server and client
-nodes with gRPC and protocol buffer interfaces. The directory record storage is
-built on [ORAS](https://oras.land) (OCI Registry As Storage), while data
-distribution uses the [zot](https://zotregistry.dev) OCI server implementation.
+
+The ADS specification is under active development as an IETF Internet Draft, with a Go
+reference implementation that exposes gRPC and protocol buffer interfaces. See
+[Specifications and references](#specifications-and-references) for the relevant links.
 
 ## Features
 
@@ -131,6 +126,14 @@ sequenceDiagram
     User->>ServerA: Download record 1
     User->>ServerB: Download record 2
 ```
+
+## Specifications and references
+
+- [ADS Specification](https://datatracker.ietf.org/doc/draft-mp-agntcy-ads) — IETF Internet Draft (under active development)
+- [ADS Spec sources](https://github.com/agntcy/dir-spec) — specification source repository
+- [gRPC API & protobuf](https://buf.build/agntcy/dir) — published schema on buf.build
+- [OASF](https://docs.agntcy.org/oasf/open-agentic-schema-framework/) — Open Agentic Schema Framework (record data model)
+- [CSIT](https://docs.agntcy.org/csit/csit/) — continuous system integration and testing
 
 ## Next Steps
 

--- a/docs/content/dir/dir-overview.md
+++ b/docs/content/dir/dir-overview.md
@@ -48,81 +48,6 @@ complementary skills solve complex problems, and dependency chains for composite
 ADS uses content-addressing for global uniqueness and implements distributed hash tables (DHT)
 for scalable content discovery across decentralized networks.
 
-## Naming
-
-In distributed systems, having a reliable and collision-resistant naming scheme
-is crucial. The agent directory uses cryptographic hashes to generate globally
-unique identifiers for data records.
-ADS leverages [Content Identifiers](https://github.com/multiformats/cid) for
-naming directory records. CIDs provide a self-describing, content-addressed
-naming scheme that ensures data integrity and immutability.
-
-In addition to CID-based addressing, ADS supports verifiable domain-based names that enable human-readable references while maintaining cryptographic verification. See [Features and Usage Scenarios — Name Verification](dir-features-scenarios.md#name-verification) and the [CLI Reference](dir-cli-reference.md#security-verification) for details.
-
-## Content Routing
-
-ADS implements capability-based record discovery through a hierarchical skill
-taxonomy. This architecture enables:
-
-1. Capability Announcement:
-    1. Multi-agent systems can publish their capabilities by encoding them as skill taxonomies.
-    2. Each record contains metadata describing the agent's functional capabilities.
-    3. Skills are structured in a hierarchical format for efficient matching.
-2. Discovery Process: The system performs a two-phase discovery operation:
-    1. Matches queried capabilities against the skill taxonomy to determine records by their identifier.
-    2. Identifies the server nodes storing relevant records.
-3. Distributed Resolution: Local nodes execute targeted retrievals based on:
-    1. Skill matching results: Evaluates capability requirements.
-    2. Server location information: Determines optimal data sources.
-
-ADS uses [libp2p Kad-DH](https://github.com/libp2p/specs/tree/master/kad-dht) for server and content discovery.
-
-## Distributed Object Storage
-
-ADS differs from block storage systems like
-[IPFS](https://ipfs.tech/) in its approach to distributed object storage.
-The differences are described in the following sections.
-
-### Simplified Content Retrieval
-
-1. ADS directly stores complete records rather than splitting them into blocks.
-2. No special optimizations needed for retrieving content from multiple sources.
-3. Records are retrieved as complete units using standard OCI protocols.
-
-### OCI Integration
-
-ADS leverages the OCI distribution specification for content storage and retrieval:
-
-1. Records are stored and transferred using OCI artifacts.
-2. Any OCI distribution-compliant server can participate in the network.
-3. Servers retrieve records directly from each other using standard OCI protocols.
-
-While ADS uses [zot](https://zotregistry.dev) as its reference OCI server implementation, the system works
-with any server that implements the OCI distribution specification.
-
-## Flow Diagrams
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant DHT
-    participant ServerA
-    participant ServerB
-
-    Note over ServerA,ServerB: Publication Phase
-    ServerA->>ServerA: Generate CID, store record, extract skills
-    ServerA->>DHT: Announce CID + skills
-    ServerB->>ServerB: Generate CID, store record, extract skills
-    ServerB->>DHT: Announce CID + skills
-    DHT->>DHT: Update routing tables<br/>(skills→CIDs→servers)
-
-    Note over User,ServerB: Discovery Phase
-    User->>DHT: Query by skills
-    DHT->>User: Return matching CIDs<br/>+ server addresses
-    User->>ServerA: Download record 1
-    User->>ServerB: Download record 2
-```
-
 ## Specifications and references
 
 - [ADS Specification](https://datatracker.ietf.org/doc/draft-mp-agntcy-ads) — IETF Internet Draft (under active development)
@@ -135,6 +60,7 @@ sequenceDiagram
 
 Ready to get started? Choose your path:
 
+- Understand how it works: see the [Architecture](dir-architecture.md) overview and the core components — [Records](dir-component-records-validation.md), [Store](dir-component-store.md), and [Routing](dir-component-routing.md).
 - Run a local instance: follow the [Quickstart](dir-quickstart.md) or see [Local Deployment](dir-deployment-local.md) and [Kubernetes Deployment](dir-deployment-kubernetes.md).
 - Connect to the public Directory: use the existing network at `ads.outshift.io` to discover and publish agents. See [Running a Federated Directory Instance](dir-federation-setup.md).
 - Deploy for production: run your own Directory instance on AWS EKS and optionally federate with the network. See [Production Deployment](dir-prod-deployment.md).

--- a/docs/content/dir/dir-quickstart.md
+++ b/docs/content/dir/dir-quickstart.md
@@ -96,16 +96,23 @@ guides instead of the daemon.
 
 ## Discover records
 
-Search the network by skill, then pull a result:
+The quickstart runs a single local Directory, so the published record lives on this peer.
+List it locally by skill, then pull it:
 
 ```bash
-dirctl routing search --skill "images_computer_vision" --limit 5
+dirctl routing list --skill "images_computer_vision"
 dirctl pull "$CID"
 ```
 
-For local-only listings, use `dirctl routing list`. See
-[Features and Usage Scenarios](dir-features-scenarios.md) for signing, sync, import, export, and other
-workflows.
+To discover records announced by *other* peers across a network or federation, use
+`dirctl routing search`. It queries cached network announcements and deliberately excludes
+local records, so it returns nothing in a single-node setup:
+
+```bash
+dirctl routing search --skill "images_computer_vision" --limit 5
+```
+
+See [Features and Usage Scenarios](dir-features-scenarios.md) for signing, sync, import, export, and other workflows.
 
 ## Authenticate to a remote Directory
 

--- a/docs/content/dir/dir-quickstart.md
+++ b/docs/content/dir/dir-quickstart.md
@@ -8,7 +8,8 @@ only page on the docs site with CLI installation instructions.
 === "Homebrew"
 
     ```bash
-    brew tap agntcy/dir https://github.com/agntcy/dir/
+    brew tap agntcy/dir https://github.com/agntcy/dir
+    brew trust agntcy/dir
     brew install dirctl
     ```
 

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -111,8 +111,8 @@ nav:
   - Documentation:
       - Get Started:
           - Overview: dir/dir-overview.md
-          - Features and Usage Scenarios: dir/dir-features-scenarios.md
           - Quickstart: dir/dir-quickstart.md
+          - Features and Usage Scenarios: dir/dir-features-scenarios.md
       - Concepts:
           - Architecture: dir/dir-architecture.md
           - Records: dir/dir-component-records-validation.md

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -32,7 +32,6 @@ func TestConfig(t *testing.T) {
 				"DIRECTORY_SERVER_LISTEN_ADDRESS":                      "example.com:8889",
 				"DIRECTORY_SERVER_OASF_API_VALIDATION_SCHEMA_URL":      "https://custom.schema.url",
 				"DIRECTORY_SERVER_STORE_PROVIDER":                      "provider",
-				"DIRECTORY_SERVER_STORE_OCI_TYPE":                      "ghcr",
 				"DIRECTORY_SERVER_STORE_OCI_LOCAL_DIR":                 "local-dir",
 				"DIRECTORY_SERVER_STORE_OCI_REGISTRY_ADDRESS":          "example.com:5001",
 				"DIRECTORY_SERVER_STORE_OCI_REPOSITORY_NAME":           "test-dir",


### PR DESCRIPTION
Reworks the Get Started section so its pages stay short and easy to digest. Overview, Quickstart, and Features and Usage Scenarios were carrying reference-depth material that slowed first-time readers; that content now lives in the Concept and Reference pages, and the navigation follows a natural Overview → Quickstart → Features flow.

- Reorders the `mkdocs.yml` nav so Quickstart comes before Features and Usage Scenarios, matching the existing cross-links between the two.
- Slims `dir-overview.md` by moving naming and content-routing details into `dir-component-routing.md`, and simplifies the overview diagram.
- Moves error codes and store backend configuration out of `dir-features-scenarios.md` into `dir-component-store.md` and `dir-api-reference.md`.
- Fixes the Quickstart Homebrew install instructions and clarifies record discovery (`routing list` for local records vs `routing search` for remote peers).
- Removes an unnecessary environment variable from the store backend configuration docs.