### PR TITLE
fix(helm): roll apiserver pods when ConfigMap changes

### DIFF
--- a/install/charts/dir/apiserver/templates/deployment.yaml
+++ b/install/charts/dir/apiserver/templates/deployment.yaml
@@ -21,10 +21,12 @@ spec:
       {{- include "chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Roll pods when server/reconciler ConfigMap data changes (subPath mounts are not updated in-place).
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "chart.selectorLabels" . | nindent 8 }}
     spec:

--- a/install/charts/dir/apiserver/templates/reconciler-deployment.yaml
+++ b/install/charts/dir/apiserver/templates/reconciler-deployment.yaml
@@ -18,6 +18,8 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/name: reconciler
         app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Add checksum/config pod annotations derived from the server ConfigMap so Helm upgrades trigger a rolling restart.