### PR TITLE
docs(dir): add build-time doc versioning and refresh concept guides

### DIFF
--- a/.github/workflows/demo-dir.yaml
+++ b/.github/workflows/demo-dir.yaml
@@ -9,7 +9,7 @@ on:
       image_version:
         required: true
         type: string
-        default: v1.3.0
+        default: v1.5.0
         description: "dirctl version to use"
       server_addr:
         required: true

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ It is not advised to use artifacts with mismatched versions.
 All container images are distributed via [GitHub Packages](https://github.com/orgs/agntcy/packages?repo_name=dir).
 
 ```bash
-docker pull ghcr.io/agntcy/dir-ctl:v1.3.0
-docker pull ghcr.io/agntcy/dir-apiserver:v1.3.0
+docker pull ghcr.io/agntcy/dir-ctl:v1.5.0
+docker pull ghcr.io/agntcy/dir-apiserver:v1.5.0
 ```
 
 ### Helm charts
@@ -124,7 +124,7 @@ docker pull ghcr.io/agntcy/dir-apiserver:v1.3.0
 All helm charts are distributed as OCI artifacts via [GitHub Packages](https://github.com/agntcy/dir/pkgs/container/dir%2Fhelm-charts%2Fdir).
 
 ```bash
-helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.3.0
+helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.5.0
 ```
 
 ### Binaries
@@ -187,8 +187,8 @@ task server:start
 This will deploy Directory services into an existing Kubernetes cluster.
 
 ```bash
-helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.3.0
-helm upgrade --install dir oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.3.0
+helm pull oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.5.0
+helm upgrade --install dir oci://ghcr.io/agntcy/dir/helm-charts/dir --version v1.5.0
 ```
 
 ## Copyright Notice

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -125,3 +125,7 @@ Publishing the root GitHub Release creates only the server-side module tags:
 - `reconciler/v1.3.0`
 
 It does not re-tag `api`, `client`, or `utils`.
+
+## 6. Update Hardcoded Versions in the README
+
+Bump the pinned release version in the `README.md` distribution examples (the `docker pull` image tags and the `helm` `--version` flags).

--- a/docs/content/dir/.index
+++ b/docs/content/dir/.index
@@ -1,8 +1,8 @@
 nav:
   - Get Started:
     - Overview: dir-overview.md
-    - Features: dir-features-scenarios.md
     - Quickstart: dir-quickstart.md
+    - Usage Guide: dir-features-scenarios.md
   - Concepts:
     - Architecture: dir-architecture.md
     - Records: dir-component-records-validation.md

--- a/docs/content/dir/dir-architecture.md
+++ b/docs/content/dir/dir-architecture.md
@@ -10,7 +10,9 @@ for an overview of the protocol surface.
 
 - **Records**: The fundamental units of information in the ADS, representing individual agents and their capabilities. Each record is uniquely identified and contains metadata describing the agent's skills, attributes, and constraints.
 
-- **Distributed Hash Table (DHT)**: A decentralized storage system that enables efficient lookup and retrieval of directory records. The DHT maps agent skills to record identifiers, allowing for quick discovery of relevant agents based on their capabilities.
+- **Store**: The content-addressable storage layer for records, backed by an OCI registry (such as Zot). Records are stored and retrieved by their content identifier (CID), ensuring integrity and deduplication.
+
+- **Distributed Hash Table (DHT)**: A decentralized storage system that enables efficient lookup and retrieval of directory records. The DHT maps agent attributes—skills, domains, modules, and locators—to record identifiers, allowing for quick discovery of relevant agents based on their capabilities.
 
 - **Content Routing Protocol**: A set of rules and mechanisms for routing requests and responses between agents and directory servers. This protocol ensures that queries for agent capabilities are efficiently directed to the appropriate servers hosting the relevant records.
 
@@ -20,21 +22,7 @@ for an overview of the protocol surface.
 
 - **Runtime Discovery**: Components that watch container runtimes (Docker, Kubernetes) for workloads and provide a gRPC API for querying them. Enables dynamic discovery of agents running in containerized environments, with support for resolving A2A agent cards and OASF records from discovered workloads.
 
-- **Event Streaming**: Real-time notification system that publishes Directory events to message brokers, enabling subscribers to react to record changes, discoveries, and other Directory operations.
-
 - **Security and Trust Mechanisms**: Features that ensure the integrity and authenticity of directory records and nodes, including cryptographic signing, verification of claims, secure communication protocols, and access controls.
-
-### Core vs extensions
-
-Per the [Directory specification](https://github.com/agntcy/dir-spec), **Records**, **Store**, and
-**Routing** are the defining core components. They are documented at depth in
-[Records](dir-component-records-validation.md), [Store](dir-component-store.md), and
-[Routing](dir-component-routing.md).
-
-Optional **extensions** include
-[Runtime Discovery](dir-component-runtime-discovery.md) and the
-[MCP Server](dir-component-mcp-server.md). External access
-via [OIDC](dir-component-oidc-authentication.md) is configured at deployment time.
 
 ## Principles
 

--- a/docs/content/dir/dir-component-records-validation.md
+++ b/docs/content/dir/dir-component-records-validation.md
@@ -21,7 +21,7 @@ Records must include a `name` field with a domain-based identifier that enables 
 - The domain must host a JWKS file at `<scheme>://<domain>/.well-known/jwks.json`.
 - Records signed with a private key associated with a public key present in that JWKS file can be verified as authorized by the domain.
 
-See [Features and Usage Scenarios — Name Verification](dir-features-scenarios.md#name-verification) and the [CLI Reference](dir-cli-reference.md#security-verification) for name verification workflows.
+See [Usage Guide — Name Verification](dir-features-scenarios.md#name-verification) and the [CLI Reference](dir-cli-reference.md#security-verification) for name verification workflows.
 
 ### Example Email Agent
 

--- a/docs/content/dir/dir-component-routing.md
+++ b/docs/content/dir/dir-component-routing.md
@@ -52,6 +52,6 @@ sequenceDiagram
 
 - [Architecture](dir-architecture.md) — full system design and diagram
 - [Records](dir-component-records-validation.md) — skill taxonomy and record structure
-- [Features and Usage Scenarios — Announce / Discover](dir-features-scenarios.md#announce) — CLI walkthroughs
+- [Usage Guide — Announce / Discover](dir-features-scenarios.md#announce) — CLI walkthroughs
 - [CLI Reference — Routing Operations](dir-cli-reference.md#routing-operations) — `routing publish`, `unpublish`, `list`, `search`, `info`
 - [Federation](dir-federation-overview.md) — multi-instance routing across federated directories

--- a/docs/content/dir/dir-component-store.md
+++ b/docs/content/dir/dir-component-store.md
@@ -99,5 +99,5 @@ system works with any server that implements the OCI distribution specification.
 ## Related documentation
 
 - [Records](dir-component-records-validation.md) — OASF record model, CIDs, and validation
-- [Features and Usage Scenarios — Store](dir-features-scenarios.md#store) — CLI examples for push, pull, and info
+- [Usage Guide — Store](dir-features-scenarios.md#store) — CLI examples for push, pull, and info
 - [CLI Reference — Storage Operations](dir-cli-reference.md#storage-operations) — `push`, `pull`, `delete`, `info`

--- a/docs/content/dir/dir-deployment-kubernetes.md
+++ b/docs/content/dir/dir-deployment-kubernetes.md
@@ -74,7 +74,7 @@ The Agent Directory Service can be deployed using Helm or GitOps / Argo CD. Helm
 
         ```bash
         helm install dir oci://ghcr.io/agntcy/dir/helm-charts/dir \
-          --version v1.0.0 \
+          --version {{ dir_version }} \
           --namespace dir-dev-dir \
           --create-namespace \
           -f - <<'EOF'
@@ -83,7 +83,7 @@ The Agent Directory Service can be deployed using Helm or GitOps / Argo CD. Helm
         apiserver:
           image:
             repository: ghcr.io/agntcy/dir-apiserver
-            tag: v1.0.0
+            tag: {{ dir_version }}
             pullPolicy: IfNotPresent
           service:
             type: NodePort
@@ -263,7 +263,7 @@ The Agent Directory Service can be deployed using Helm or GitOps / Argo CD. Helm
     |-----------|-------|---------|
     | **SPIRE CRDs** | `spiffe/spire-crds` | 0.5.0 |
     | **SPIRE** | `spiffe/spire` | 0.27.0 |
-    | **Directory** | `oci://ghcr.io/agntcy/dir/helm-charts/dir` | v1.0.0 |
+    | **Directory** | `oci://ghcr.io/agntcy/dir/helm-charts/dir` | {{ dir_version }} |
 
     For full configuration examples see the [dir-staging applications](https://github.com/agntcy/dir-staging/tree/main/applications).
 

--- a/docs/content/dir/dir-features-scenarios.md
+++ b/docs/content/dir/dir-features-scenarios.md
@@ -1,4 +1,4 @@
-# Features
+# Usage Guide
 
 This document defines a basic overview of main Directory features, components, and usage
 scenarios. All code snippets below are tested against the Directory `v1.0.0` release.

--- a/docs/content/dir/dir-federation-aws-eks.md
+++ b/docs/content/dir/dir-federation-aws-eks.md
@@ -95,14 +95,10 @@ These pins match the current staging deployment references at the time this guid
 
 | Component | Source | Version |
 |-----------|--------|---------|
-| Directory Helm chart | `oci://ghcr.io/agntcy/dir/helm-charts/dir` | `v1.2.0` |
-| Directory apiserver image | `ghcr.io/agntcy/dir-apiserver` | `v1.2.0` |
-| Directory reconciler image | `ghcr.io/agntcy/dir-reconciler` | `v1.2.0` |
+| Directory Helm chart | `oci://ghcr.io/agntcy/dir/helm-charts/dir` | `{{ dir_version }}` |
+| Directory apiserver image | `ghcr.io/agntcy/dir-apiserver` | `{{ dir_version }}` |
+| Directory reconciler image | `ghcr.io/agntcy/dir-reconciler` | `{{ dir_version }}` |
 | SPIRE Helm chart | `spiffe/spire` | `0.28.3` |
-
-!!! note
-
-    Older Directory docs still show `v1.0.0` examples. Prefer the versions above for a fresh deployment.
 
 ## Before You Start
 
@@ -330,7 +326,7 @@ This guide does not try to provision the AWS infrastructure from zero in the mai
     apiserver:
       image:
         repository: ghcr.io/agntcy/dir-apiserver
-        tag: v1.2.0
+        tag: {{ dir_version }}
         pullPolicy: IfNotPresent
 
       spire:
@@ -454,7 +450,7 @@ This guide does not try to provision the AWS infrastructure from zero in the mai
         enabled: true
         image:
           repository: ghcr.io/agntcy/dir-reconciler
-          tag: v1.2.0
+          tag: {{ dir_version }}
           pullPolicy: IfNotPresent
         config:
           database:
@@ -533,7 +529,7 @@ This guide does not try to provision the AWS infrastructure from zero in the mai
 
     ```bash
     helm upgrade --install dir oci://ghcr.io/agntcy/dir/helm-charts/dir \
-      --version v1.2.0 \
+      --version {{ dir_version }} \
       --namespace "${DIR_NAMESPACE}" \
       --create-namespace \
       -f dir-values.yaml \

--- a/docs/mkdocs/hooks.py
+++ b/docs/mkdocs/hooks.py
@@ -1,16 +1,54 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-"""MkDocs hooks: trust store for urllib (HTTPS includes in mkdocs-include-markdown-plugin)."""
+"""MkDocs hooks.
+
+- Trust store for urllib (HTTPS includes in mkdocs-include-markdown-plugin).
+- Inject the Directory release version into pages so docs never drift from the
+  single source of truth (``versions.yaml`` at the repo root). Use the
+  ``{{ dir_version }}`` placeholder in any Markdown page and it is replaced at
+  build time with the current release tag (e.g. ``v1.4.0``).
+"""
+import re
 import ssl
+from pathlib import Path
+
 import certifi
+
+# Repo root is two levels up from docs/mkdocs/hooks.py.
+_VERSIONS_FILE = Path(__file__).resolve().parents[2] / "versions.yaml"
+# Match the same first `version:` entry that Taskfile.vars.yml reads.
+_VERSION_RE = re.compile(r"^\s*version:\s*(\S+)\s*$", re.MULTILINE)
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*dir_version\s*\}\}")
+
+_dir_version: str | None = None
+
+
+def _load_dir_version() -> str:
+    """Read the Directory release version from versions.yaml."""
+    text = _VERSIONS_FILE.read_text(encoding="utf-8")
+    match = _VERSION_RE.search(text)
+    if not match:
+        raise RuntimeError(
+            f"Could not find a 'version:' entry in {_VERSIONS_FILE}"
+        )
+    return match.group(1)
 
 
 def on_startup(**kwargs):
-    """Configure SSL context to use certifi certificates."""
+    """Configure SSL context to use certifi certificates and cache the version."""
     import urllib.request
 
     ssl_context = ssl.create_default_context(cafile=certifi.where())
     https_handler = urllib.request.HTTPSHandler(context=ssl_context)
     opener = urllib.request.build_opener(https_handler)
     urllib.request.install_opener(opener)
+
+    global _dir_version
+    _dir_version = _load_dir_version()
+
+
+def on_page_markdown(markdown: str, **kwargs) -> str:
+    """Replace the ``{{ dir_version }}`` placeholder with the release version."""
+    version = _dir_version or _load_dir_version()
+    return _PLACEHOLDER_RE.sub(version, markdown)

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -114,7 +114,7 @@ nav:
       - Get Started:
           - Overview: dir/dir-overview.md
           - Quickstart: dir/dir-quickstart.md
-          - Features: dir/dir-features-scenarios.md
+          - Usage Guide: dir/dir-features-scenarios.md
       - Concepts:
           - Architecture: dir/dir-architecture.md
           - Records: dir/dir-component-records-validation.md


### PR DESCRIPTION
Documentation pinned the Directory release version in many places, so examples drifted (README still showed `v1.3.0`). This adds a single source of truth for docs versions and cleans up the concept guides — renaming the usage guide and refreshing the architecture overview.

- Added an MkDocs `on_page_markdown` hook that resolves a `{{ dir_version }}` placeholder from `versions.yaml` at build time, so docs never drift from the release version.
- Converted the Kubernetes deployment and AWS EKS federation guides to use `{{ dir_version }}` for `helm --version`, image `tag:`, and chart-version tables, and removed the now-stale "older docs show `v1.0.0`" note.
- Bumped the hardcoded `README.md` distribution examples and the `demo-dir.yaml` workflow default to `v1.5.0`, and added a `RELEASE.md` step reminding maintainers to bump the README versions each release.
- Renamed "Features and Usage Scenarios" to "Usage Guide" across the page title, nav (`mkdocs.yml`, `.index`), and cross-links in the records, routing, and store docs.
- Refreshed `dir-architecture.md`: added the Store component, expanded the DHT attribute description, and dropped the Event Streaming and "Core vs extensions" sections.