### PR TITLE
docs(dir): reorganize concepts and deploy navigation

### DIFF
--- a/docs/content/dir/.index
+++ b/docs/content/dir/.index
@@ -9,7 +9,6 @@ nav:
     - Store: dir-component-store.md
     - Routing: dir-component-routing.md
     - Trust Model: dir-component-trust-model.md
-    - Federation: dir-federation-overview.md
     - Extensions:
       - Runtime Discovery: dir-component-runtime-discovery.md
       - MCP Server: dir-component-mcp-server.md
@@ -19,6 +18,7 @@ nav:
     - Kubernetes Deployment: dir-deployment-kubernetes.md
     - Production Deployment: dir-prod-deployment.md
     - Federation Deployment:
+      - Overview: dir-federation-overview.md
       - Federation on Amazon EKS: dir-federation-aws-eks.md
       - Running a Federated Directory Instance: dir-federation-setup.md
       - Profiles: dir-federation-profiles.md

--- a/docs/content/dir/.index
+++ b/docs/content/dir/.index
@@ -13,6 +13,7 @@ nav:
       - Runtime Discovery: dir-component-runtime-discovery.md
       - MCP Server: dir-component-mcp-server.md
       - Import and Export: dir-component-import.md
+      - OIDC Authentication: dir-component-oidc-authentication.md
   - Deploy:
     - Local Deployment: dir-deployment-local.md
     - Kubernetes Deployment: dir-deployment-kubernetes.md
@@ -23,7 +24,6 @@ nav:
       - Running a Federated Directory Instance: dir-federation-setup.md
       - Profiles: dir-federation-profiles.md
       - Best Practices and Troubleshooting: dir-federation-troubleshooting.md
-    - OIDC Authentication: dir-component-oidc-authentication.md
   - SDKs:
     - SDK Overview: dir-sdk.md
   - Reference:

--- a/docs/content/dir/dir-component-import.md
+++ b/docs/content/dir/dir-component-import.md
@@ -87,4 +87,3 @@ MCP servers into a single configuration file.
 - [Usage Guide — Export](dir-features-scenarios.md#export) — export CLI walkthroughs
 - [CLI Reference — Import Operations](dir-cli-reference.md#import-operations) — `dirctl import` flags
 - [CLI Reference — Export Operations](dir-cli-reference.md#export-operations) — `dirctl export` flags
-- [CLI Import Workflow](https://github.com/agntcy/dir/tree/main/cli#-import-workflow) — full import configuration reference

--- a/docs/content/dir/dir-features-scenarios.md
+++ b/docs/content/dir/dir-features-scenarios.md
@@ -356,8 +356,7 @@ cronjobs:
 ```
 
 For filtering, limits, custom enrichment config, force reimport, and all other options, see
-[CLI Reference — Import Operations](dir-cli-reference.md#import-operations) and the
-[CLI Import Workflow documentation](https://github.com/agntcy/dir/tree/main/cli#-import-workflow).
+[CLI Reference — Import Operations](dir-cli-reference.md#import-operations).
 
 ## Export
 

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
               - Runtime Discovery: dir/dir-component-runtime-discovery.md
               - MCP Server: dir/dir-component-mcp-server.md
               - Import and Export: dir/dir-component-import.md
+              - OIDC Authentication: dir/dir-component-oidc-authentication.md
       - Deploy:
           - Local Deployment: dir/dir-deployment-local.md
           - Kubernetes Deployment: dir/dir-deployment-kubernetes.md
@@ -135,7 +136,6 @@ nav:
               - Running a Federated Directory Instance: dir/dir-federation-setup.md
               - Profiles: dir/dir-federation-profiles.md
               - Best Practices and Troubleshooting: dir/dir-federation-troubleshooting.md
-          - OIDC Authentication: dir/dir-component-oidc-authentication.md
       - SDKs:
           - SDK Overview: dir/dir-sdk.md
       - Reference:

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -121,7 +121,6 @@ nav:
           - Store: dir/dir-component-store.md
           - Routing: dir/dir-component-routing.md
           - Trust Model: dir/dir-component-trust-model.md
-          - Federation: dir/dir-federation-overview.md
           - Extensions:
               - Runtime Discovery: dir/dir-component-runtime-discovery.md
               - MCP Server: dir/dir-component-mcp-server.md
@@ -131,6 +130,7 @@ nav:
           - Kubernetes Deployment: dir/dir-deployment-kubernetes.md
           - Production Deployment: dir/dir-prod-deployment.md
           - Federation Deployment:
+              - Overview: dir/dir-federation-overview.md
               - Federation on Amazon EKS: dir/dir-federation-aws-eks.md
               - Running a Federated Directory Instance: dir/dir-federation-setup.md
               - Profiles: dir/dir-federation-profiles.md


### PR DESCRIPTION
Reorganizes the documentation navigation so pages sit in the section that matches how they're actually used, and removes a dead cross-reference. Federation moves to where its deployment guides live, while the OIDC gateway joins the optional capability extensions.

- Moves `dir-federation-overview.md` from **Concepts** to **Deploy → Federation Deployment → Overview**, since it orients readers to the federation deployment guides rather than explaining a standalone concept.
- Moves `dir-component-oidc-authentication.md` from **Deploy** to **Concepts → Extensions**, alongside Runtime Discovery, MCP Server, and Import and Export, since the optional `oidc-gateway` layer is an add-on capability.
- Removes the broken `cli#-import-workflow` GitHub link from `dir-component-import.md` and `dir-features-scenarios.md`, leaving the CLI Reference as the canonical import-options source.
- Updates both `docs/content/dir/.index` and `docs/mkdocs/mkdocs.yml` to keep the two nav definitions in sync.