### PR TITLE
feat(workflows): add integration-aware DIR agent skill

### DIFF
--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: agntcy-dir
+description: "Use when the user wants to work with the AGNTCY Directory (dirctl): set up dirctl or a local directory daemon; author, validate, or import OASF agent records; push, sign, or publish records; discover, search, browse, suggest, or recommend agents, MCP servers, A2A agents, or agent skills; verify signatures, name ownership, or security scans; synchronize directories; or install/uninstall agents and agentic resources (MCP servers, agent skills, prompts) into coding agents like VS Code Copilot, Claude Code, or Cursor."
+metadata:
+  author: AGNTCY Contributors
+  version: 2.0.0
+---
+
+# AGNTCY Directory (dirctl)
+
+The AGNTCY Directory (DIR) is a distributed, peer-to-peer registry of AI agent
+records described in [OASF](https://schema.oasf.outshift.com). Records are
+content-addressed by CID and carry skills, domains, modules (MCP, A2A, Agent
+Skills), locators, signatures, and security scan results.
+
+This skill turns natural-language requests into `dirctl` workflows. It is a
+**router**: read the matching reference file below _before_ acting on a
+workflow. Read more than one when the request spans workflows (e.g. "import
+and publish" → authoring + publishing).
+
+## Dispatch
+
+| User intent (examples)                                                                                      | Read first                                               |
+| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| "install dirctl", "set up a local directory", "start the daemon", "configure contexts", "connection issues" | [references/setup.md](references/setup.md)               |
+| "create a record", "validate my record", "import MCP servers / A2A cards / skills into DIR"                 | [references/authoring.md](references/authoring.md)       |
+| "push", "publish to the network", "sign my record", "prove name ownership"                                  | [references/publishing.md](references/publishing.md)     |
+| "find/search/suggest agents, MCP servers, skills", "browse the directory", "pull a record"                  | [references/discovery.md](references/discovery.md)       |
+| "is this record signed/safe/verified?", "check scan reports", "verify signature"                            | [references/verification.md](references/verification.md) |
+| "sync with another directory", "mirror records", "autosync from a peer"                                     | [references/sync.md](references/sync.md)                 |
+| "install <record> into my editor/agent", "uninstall", "export as mcp.json / SKILL.md / A2A card"            | [references/install.md](references/install.md)           |
+
+## Vocabulary
+
+- **Record** — one OASF JSON document describing an agent (name, version, skills, domains, locators, modules, annotations).
+- **CID** — content identifier; hash of the record bytes. Same bytes → same CID. Any change → new CID.
+- **Reference** — how commands address records: `<cid>`, `<name>`, `<name>:<version>`, `<name>@<cid>`, `<name>:<version>@<cid>` (the `@<cid>` forms are hash-verified and fail on mismatch).
+- **Skill / Domain** — OASF taxonomy nodes describing what an agent does and where.
+- **Module** — typed payload on a record: `integration/mcp` (MCP server), `integration/a2a` (A2A card), `core/language_model/agentskills` (Agent Skill).
+- **Locator** — pointer to a runnable artifact (`docker-image`, `source_code`, `helm_chart`, …).
+- **Referrer** — OCI artifact attached to a record: signature, public key, security scan report.
+
+## Prerequisites
+
+`dirctl` must be on `PATH` — probe with `dirctl version` (works in every
+shell; POSIX: `command -v dirctl`, PowerShell: `Get-Command dirctl`). If
+missing, follow the install section of
+[references/setup.md](references/setup.md) — never suggest building from
+source.
+
+A reachable Directory server is required for everything except `context`,
+`validate`, `install list`, and `version`. Default is `localhost:8888` (local
+daemon). Server selection order: `--context <name>` flag →
+`DIRECTORY_CLIENT_CONTEXT` → `current_context` in config → `--server-addr` /
+`DIRECTORY_CLIENT_SERVER_ADDRESS` overrides.
+
+## CLI conventions (apply everywhere)
+
+- **Parse, don't scrape**: request `-o json` (or `-o jsonl` for streams) when
+  you need to read results; `-o raw` for CIDs in shell pipelines. Structured
+  formats write data to stdout and messages to stderr, so piping to `jq` is
+  safe. `validate`, `context`, `auth`, `daemon`, `mcp serve`, and `version` do
+  not take `-o`.
+- **Quote every argument** — record names contain `/` and `:`.
+- **Capability probing**: command surface varies by version. Before relying on
+  newer commands (`install`, `init`, NL search), check `dirctl <cmd> --help`;
+  if absent, use the documented fallback in the relevant reference file.
+- **Auth**: never invent auth flags. On an auth error, surface the raw error
+  and ask the user how to authenticate (see setup reference: `auth login`,
+  `--auth-mode`, `--auth-token`).
+- **Destructive ops** (`delete`, `uninstall`, `sync delete`, `--force`):
+  always confirm with the user first.
+- **Never fabricate** CIDs, names, versions, scores, or scan results — every
+  value shown must come from real command output.
+
+## Platforms & shells
+
+`dirctl` ships for **Linux** and **macOS** (amd64 + arm64) and **Windows**
+(amd64 only — no windows-arm64 build; the binary is `dirctl.exe`). Homebrew
+covers macOS/Linux only; on Windows install from GitHub Releases (see setup
+reference). `dirctl` behaves identically everywhere — only the wrapping shell
+syntax and paths differ.
+
+**Emit commands for the shell the host actually runs — never assume bash.**
+Code blocks in this skill are written for POSIX shells (bash/zsh) and run
+as-is on Linux/macOS. On Windows (PowerShell), translate before running:
+
+| bash idiom                          | PowerShell equivalent                                              |
+| ----------------------------------- | ------------------------------------------------------------------ |
+| `CID=$(dirctl … -o raw)` … `"$CID"` | `$CID = dirctl … -o raw` … `$CID`                                  |
+| `for f in ./out/*.json; do … done`  | `Get-ChildItem ./out/*.json \| ForEach-Object { … $_.FullName … }` |
+| `command -v dirctl`                 | `Get-Command dirctl`                                               |
+| `mktemp`                            | `(New-TemporaryFile).FullName`                                     |
+| `chmod +x dirctl`                   | not needed (`.exe`)                                                |
+| `cmd1 && cmd2`                      | run sequentially as separate commands                              |
+
+Path rules: `~` in this skill means the user's home directory —
+`%USERPROFILE%` on Windows (e.g. `~/.agntcy/dir/` →
+`%USERPROFILE%\.agntcy\dir\`). When unsure where the effective client config
+lives, run `dirctl context show` instead of guessing paths.
+
+## Environment adaptivity
+
+Maximize the host's native capabilities; degrade gracefully:
+
+| Capability                   | VS Code Copilot                                 | Claude Code                    | Copilot CLI / other CLIs                 |
+| ---------------------------- | ----------------------------------------------- | ------------------------------ | ---------------------------------------- |
+| Confirm selections & choices | ask-questions tool (question card with options) | AskUserQuestion tool           | Plain-text numbered list; wait for reply |
+| Display result sets          | Markdown table                                  | Markdown table                 | Markdown table (narrow columns)          |
+| File links in summaries      | Clickable relative Markdown links               | Plain paths                    | Plain paths                              |
+| Post-install activation      | Suggest "MCP: List Servers" → restart           | Suggest restarting the session | Suggest restarting the tool              |
+
+Other agentic hosts (Cursor, Windsurf, Zed, Cline, Roo, Gemini CLI, opencode,
+Continue, Codex, …) are not listed per-column — detect capabilities instead of
+matching product names: if an interactive question tool exists, use it;
+otherwise behave like the CLI column. You generally know which host you are
+running in; when you don't, infer it from your available tools, not from
+guesses.
+
+Rules:
+
+- Use an interactive question tool whenever one exists for: picking records to
+  install, choosing install scope/agents, and confirming destructive actions.
+  Only fall back to free-text prompts when no such tool is available.
+- Never promise webviews, side panels, or native dialogs — chat surfaces
+  render Markdown only.
+- Long operations (`init` downloads ~89 MB; imports and syncs can run
+  minutes): warn the user before starting and report progress from command
+  output.
+- When the user's host is itself an install target (e.g. VS Code → `vscode`,
+  Claude Code → `claude-code`, Cursor → `cursor`), default installs to that
+  host's agent ID (see install reference).
+- **Headless / CI runs** (no human available to answer): never block on
+  interactive prompts. Use `--yes` for `init` and `install`, authenticate via
+  `DIRECTORY_CLIENT_AUTH_TOKEN` or `auth login --device` / `--no-browser`, and
+  when a decision genuinely requires a human, fail fast with a clear message
+  instead of waiting.
+
+## MCP-native alternative
+
+`dirctl mcp serve` starts a built-in MCP server exposing DIR and OASF
+operations as tools (push, pull, search, validate, taxonomy browsing). When a
+host is configured with this server, prefer its tools over shelling out to
+equivalent CLI commands. To wire it up, add a stdio server entry that runs
+`dirctl mcp serve` to the host's MCP config, following the merge-never-
+overwrite rules in [references/install.md](references/install.md).
+
+## Pointers
+
+- CLI reference: <https://dir.agntcy.org/latest/dir/dir-cli-reference/>
+- Quickstart: <https://dir.agntcy.org/latest/dir/dir-quickstart/>
+- OASF schema: <https://schema.oasf.outshift.com>
+- Repo: <https://github.com/agntcy/dir>

--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: agntcy-dir
-description: "Use when the user wants to work with the AGNTCY Directory (dirctl): set up dirctl or a local directory daemon; author, validate, or import OASF agent records; push, sign, or publish records; discover, search, browse, suggest, or recommend agents, MCP servers, A2A agents, or agent skills; verify signatures, name ownership, or security scans; synchronize directories; or install/uninstall agents and agentic resources (MCP servers, agent skills, prompts) into coding agents like VS Code Copilot, Claude Code, or Cursor."
+description: Use when the user asks to discover, browse, search, suggest, recommend, or install agents and agentic resources. Author, validate, or import OASF records; push, sign, and publish records; discover, search, browse, suggest, or recommend agents like MCP servers, A2A agents, or agent skills; verify signatures, name ownership, or security scans; synchronize data between servers; or install/uninstall agents and agentic resources into coding agents like VS Code Copilot, Claude Code, or Cursor.
 metadata:
   author: AGNTCY Contributors
-  version: 2.0.0
+  version: 1.0.0
 ---
 
 # AGNTCY Directory (dirctl)
@@ -38,7 +38,7 @@ and publish" → authoring + publishing).
 - **Skill / Domain** — OASF taxonomy nodes describing what an agent does and where.
 - **Module** — typed payload on a record: `integration/mcp` (MCP server), `integration/a2a` (A2A card), `core/language_model/agentskills` (Agent Skill).
 - **Locator** — pointer to a runnable artifact (`docker-image`, `source_code`, `helm_chart`, …).
-- **Referrer** — OCI artifact attached to a record: signature, public key, security scan report.
+- **Referrer** — Artifact attached to a record: signature, public key, security scan report.
 
 ## Prerequisites
 

--- a/.skill/references/authoring.md
+++ b/.skill/references/authoring.md
@@ -1,0 +1,125 @@
+# Authoring: create, validate, and import OASF records
+
+Goal: produce valid OASF record JSON — written by hand or imported from
+existing artifacts (MCP servers, A2A cards, Agent Skills) — ready to push.
+
+## Author a record by hand
+
+Minimal top-level fields: `name`, `schema_version`, `version`, `description`,
+`authors`, `created_at` (RFC 3339), `skills`. Recommended: `domains`,
+`locators`, `modules`. Custom metadata goes in the `annotations` map.
+
+```json
+{
+  "name": "example.com/research-agent",
+  "schema_version": "1.0.0",
+  "version": "v1.0.0",
+  "description": "Answers research questions with cited sources.",
+  "authors": ["Example Corp"],
+  "created_at": "2026-07-14T00:00:00Z",
+  "skills": [{ "id": 10201, "name": "natural_language_processing/text_completion" }],
+  "domains": [{ "name": "technology" }],
+  "locators": [{ "type": "docker-image", "url": "ghcr.io/example/research-agent:v1.0.0" }],
+  "modules": []
+}
+```
+
+Rules:
+
+- Skills/domains are closed taxonomies — resolve valid `id`/`name` pairs from
+  the OASF schema (`https://schema.oasf.outshift.com/<version>/skills`) or the
+  `agntcy_oasf_get_schema_skills` / `..._domains` MCP tools. Do not invent
+  taxonomy entries; ID and name must refer to the same class.
+- Names starting with `https://` / `http://` opt into domain-based name
+  ownership verification (see publishing reference). Plain names skip it.
+- Modules determine installability later: `integration/mcp` → MCP server,
+  `core/language_model/agentskills` → Agent Skill, `integration/a2a` → A2A
+  card.
+- Records are capped at 4 MB (metadata 100 KB) — reference large blobs via
+  locators.
+
+## Validate before pushing
+
+The server rejects invalid records with `InvalidArgument`, so validate first:
+
+```bash
+dirctl validate record.json --url https://schema.oasf.outshift.com
+dirctl pull <cid> | dirctl validate --url https://schema.oasf.outshift.com  # stdin works
+```
+
+`--url` is required (API-based validation). Use the same OASF endpoint the
+target server validates against — schema-version drift between client and
+server is a common source of rejections.
+
+Render validation ERRORs/WARNINGs as a table (severity | path | message) and
+fix ERRORs before pushing.
+
+## Import existing artifacts
+
+`dirctl import` converts external artifacts into OASF records and pushes them.
+
+| `--type` | Source | Required flag |
+| --- | --- | --- |
+| `mcp-registry` | HTTP MCP registry (v0.1 list API) | `--url` |
+| `mcp` | Local JSON (one server or array) | `--file-path` |
+| `a2a` | Local A2A AgentCard JSON | `--file-path` |
+| `agent-skill` | Local directory containing `SKILL.md` | `--file-path` |
+
+Useful flags: `--limit N`, `--filter key=value` (registry: `search`,
+`version`, `updated_since`), `--output-cids <file>`, `--force` (skip
+name+version dedup), `--debug`, `--sign` (+ `--key` / `--oidc-token`).
+
+### Recommended workflow: dry-run → review → push
+
+`--dry-run` writes transformed records to disk instead of pushing — one
+`<cid>.record.json` per record — so the user can review before anything
+reaches the directory:
+
+```bash
+dirctl import --type=mcp-registry \
+  --url=https://registry.modelcontextprotocol.io/v0.1 \
+  --filter search=github --limit 10 \
+  --dry-run --output-dir=./out
+
+# review ./out/*.record.json with the user, then:
+for f in ./out/*.record.json; do dirctl push "$f"; done
+```
+
+PowerShell (Windows) equivalent of the push loop:
+
+```powershell
+Get-ChildItem ./out/*.record.json | ForEach-Object { dirctl push $_.FullName }
+```
+
+Prefer dry-run whenever the user hasn't seen the records yet; import directly
+only when they explicitly ask for it.
+
+### Enrichment
+
+By default import enriches records with OASF skills/domains using an LLM
+(tool-calling against `dirctl mcp serve`; built-in default `azure:gpt-4o`).
+This requires LLM credentials (e.g. `AZURE_OPENAI_API_KEY`). Two alternatives
+via `--config <yaml>`:
+
+```yaml
+# Static taxonomy — no LLM needed:
+enricher:
+  skip_enricher: true
+  skills:
+    - name: natural_language_processing/text_completion
+      id: 10201
+  domains:
+    - name: technology
+      id: 1
+```
+
+If an import fails on enrichment, offer `skip_enricher` with skills/domains
+derived from the artifact description as the no-credentials path.
+
+## Common pitfalls
+
+- Re-importing without `--force` silently skips records that already exist
+  (name+version dedup) — use `--debug` to see why records were skipped.
+- CID covers exact bytes: reformatting a record file changes its CID.
+- `created_at` must be RFC 3339; version tags need not be semver (`latest`,
+  `dev` are fine — resolution picks the newest `created_at`).

--- a/.skill/references/discovery.md
+++ b/.skill/references/discovery.md
@@ -1,0 +1,101 @@
+# Discovery: search, browse, and pull records
+
+Goal: turn a natural-language request into directory matches, presented as a
+table with real trust signals, ready for pull/install.
+
+## Local vs network
+
+| Scope | Command | When |
+| --- | --- | --- |
+| Local index (connected server) | `dirctl search` | Default — "what's available", installs |
+| Peer-to-peer network | `dirctl routing search` | User says network/peers/other directories, or local search found nothing relevant |
+
+## Primary path: natural-language search
+
+Both commands accept a free-text query:
+
+```bash
+dirctl search "MCP server that manages GitHub issues and pull requests" -o json --limit 25
+dirctl routing search "agent for summarizing financial reports" -o json --limit 25
+```
+
+Query construction rules:
+
+- **Keep the query under 512 characters** while preserving enough context to
+  disambiguate: topic, artifact type (MCP server / A2A agent / agent skill),
+  constraints (vendor, language, capability). Strip filler ("can you find
+  me", "please").
+- Pass the user's intent, not flag syntax — no wildcards or `key:value` in
+  the NL query.
+- Trust requirements do not go in the query text; add them as flags on top:
+  `--verified`, `--trusted`, `--safe`, `--scan-severity <lvl>`.
+
+## Fallback: structured skill/domain filters
+
+Trigger: the NL search returns **zero results** (or NL search is unsupported
+by the installed version — probe `dirctl search --help`).
+
+Derive skill/domain terms from the user query and retry **once** with only
+those filters, using generous wildcards:
+
+```bash
+dirctl search --skill "*text_completion*" --domain "*finance*" -o json --limit 25
+dirctl routing search --skill "natural_language_processing" --limit 25
+```
+
+If still empty: report "no matches", show both queries attempted, and suggest
+refinements. Do not loop further.
+
+Full filter surface (for power users and batch operations — all repeatable;
+wildcards `*`, `?`): `--name`, `--version`, `--skill` / `--skill-id`,
+`--domain` / `--domain-id`, `--module` / `--module-id`, `--locator`,
+`--author`, `--schema-version`, `--annotation key=value`, plus trust filters
+and `--limit` / `--offset`. `routing search` additionally has `--min-score`.
+`--format record` returns full records instead of CIDs.
+
+## Render results as a grid
+
+Parse the JSON and render a Markdown table with these columns:
+
+| # | Name | Version | Artifacts | Verified | Trusted | Safe | CID |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+- **#** — 1-based row index (referenced by selection prompts).
+- **Artifacts** — from modules: `MCP` (`integration/mcp`), `Skill`
+  (`core/language_model/agentskills`), `A2A` (`integration/a2a`); else `OASF`.
+- **Verified** — ✓ when name ownership is verified.
+- **Trusted** — ✓ when signature verification passed.
+- **Safe** — ✓ when all security scanners reported `is_safe=true`; blank when
+  unscanned (do not conflate unscanned with unsafe).
+- **CID** — first 12 chars + `…` for display; keep a row→full-CID map
+  internally, and always use the full CID in subsequent commands.
+- Routing results: add a **Score** column (match score) and note the provider
+  peer.
+
+Cap visible rows at 10; if more matched, end with `… N more — refine your
+query`. Never fabricate values — trust columns come only from record/search
+output (verified/trusted/safe fields or `--safe`-filtered queries).
+
+## Pull records
+
+```bash
+dirctl pull <cid>                                   # full record JSON (default -o json)
+dirctl pull "example.com/agent:v1.0.0"              # by name:version
+dirctl pull "example.com/agent@bafyrei..."          # hash-verified (fails on mismatch)
+dirctl pull <cid> --output-file record.json         # to file
+dirctl pull --name "example.com/*" --output-dir ./records --limit 50   # batch (needs ≥1 filter)
+dirctl info <cid-or-name>                           # metadata only
+```
+
+- No version → most recent `created_at` wins (supports non-semver tags like
+  `latest`).
+- Batch pull keeps the latest per name unless `--all-versions`.
+- Referrer flags extend output: `--signature`, `--public-key`,
+  `--scan-report` (see verification reference).
+
+## After discovery
+
+Offer next steps based on the artifacts column: install into the user's agent
+(install reference), verify trust (verification reference), or pull raw JSON.
+Never install without explicit selection confirmed via the host's question
+tool.

--- a/.skill/references/install.md
+++ b/.skill/references/install.md
@@ -1,0 +1,107 @@
+# Install & use: put directory records to work in coding agents
+
+Goal: install a record's artifacts (MCP server entry, Agent Skill) into the
+user's AI coding agents — natively via `dirctl install` when available, via
+`dirctl export` otherwise — and activate them.
+
+## Preferred path: `dirctl install`
+
+Probe first: `dirctl install --help`. If absent, use the export fallback
+below.
+
+What gets installed is decided by the record's **modules**, not flags:
+
+| Module | Artifact installed |
+| --- | --- |
+| `integration/mcp` | MCP server entry (`command`/`args`/`env`) under each agent's MCP config |
+| `core/language_model/agentskills` | Agent Skill (`SKILL.md`) in each agent's skill/rules mechanism |
+| `integration/a2a` | Not installable — command errors; use `dirctl export --format a2a` |
+
+Supported agent IDs: `vscode`, `claude-code`, `claude-desktop`, `cursor`,
+`windsurf`, `cline`, `roo`, `gemini`, `opencode`, `zed`, `continue`, `codex`.
+
+### Flow
+
+```bash
+dirctl install list                                   # 1. detected agents + files install would touch (no changes)
+dirctl install <cid-or-name> --dry-run                # 2. preview plan (per agent/artifact: add/updated/unchanged)
+dirctl install <cid-or-name> --agents vscode --yes    # 3. apply after user confirmation
+dirctl uninstall <cid-or-name> [--agents ...]         #    remove what install added (idempotent)
+```
+
+Rules:
+
+1. Run `install list` and show detected agents as a table (agent | detected |
+   config paths).
+2. Always `--dry-run` first and render the plan as a table (agent | artifact
+   | action | path).
+3. Confirm via the host's question tool: which records, which agents. Default
+   `--agents` to the host the user is chatting in (VS Code Copilot →
+   `vscode`, Claude Code → `claude-code`, and analogously for Cursor,
+   Windsurf, Zed, …); offer "all detected" as an option.
+4. Only then run with `--yes` (the confirmation already happened in the UI —
+   don't double-prompt in the terminal).
+5. Summarize the result: every path added/updated/removed/skipped, as
+   clickable links where the host supports them.
+
+Properties worth relying on: writes are atomic and surgical (only the
+record's own entry/managed block is touched); re-installing a newer version
+of the same-named record replaces the old artifacts cleanly; undetected
+agents are skipped, never created.
+
+## Fallback path: `dirctl export`
+
+For hosts without native install support, older dirctl versions, A2A cards,
+or when the user wants the artifact file itself:
+
+| `--format` | Output | Destination examples |
+| --- | --- | --- |
+| `agent-skill` | `SKILL.md` | `.github/skills/<slug>/SKILL.md` (VS Code), `~/.copilot/skills/<slug>/` (user), `.claude/skills/<slug>/` |
+| `mcp-ghcopilot` | GitHub Copilot MCP JSON | merge into `.vscode/mcp.json` under `servers` |
+| `mcp-claudecode` | Claude Code MCP JSON (`mcpServers`) | merge into `.mcp.json` |
+| `mcp-cursor` | Cursor MCP JSON (`mcpServers`) | merge into `.cursor/mcp.json` |
+| `a2a` | A2A AgentCard JSON | wherever the user's A2A tooling expects it |
+
+```bash
+dirctl export <cid-or-name[:version][@digest]> --format=agent-skill --output-file=.github/skills/<slug>/SKILL.md
+dirctl export <cid> --format=mcp-ghcopilot --output-file="$(mktemp)"   # then merge into .vscode/mcp.json
+dirctl export --name "example.com/*" --format=mcp-ghcopilot --output-dir ./out   # batch: MCP formats merge into one mcp.json
+```
+
+PowerShell (Windows): use `--output-file=(New-TemporaryFile).FullName`
+instead of `"$(mktemp)"`.
+
+Fallback rules:
+
+- `<slug>` = record name lowercased, `/` and non-alphanumerics → `-`, max 64
+  chars. After writing a `SKILL.md`, ensure its `name:` frontmatter equals
+  the folder slug — mismatch silently breaks discovery.
+- **Merge, never overwrite** MCP config files: read the existing JSON, add
+  the new server entry, keep all siblings, write back. Create as
+  `{"servers": {}}` / `{"mcpServers": {}}` only when missing.
+- Raw OASF JSON is `dirctl pull` (with `--output-file`/`--output-dir`), not
+  `export`.
+- Ask the user for scope (workspace vs user profile) via the question tool
+  before writing.
+
+## Activation
+
+After installing MCP servers or skills, the host must reload them:
+
+| Host | Action |
+| --- | --- |
+| VS Code Copilot | Command Palette → "MCP: List Servers" → restart; skills are picked up on next chat turn |
+| Claude Code / Claude Desktop | Restart the session/app |
+| Cursor / Windsurf / others | Reload MCP config or restart |
+
+Always end with the activation hint for the agents actually touched.
+
+## Common failure modes
+
+- "Record has nothing installable" — record carries neither MCP nor Agent
+  Skill module; for A2A-only records route to `export --format a2a`.
+- Requested agent skipped — it wasn't detected on this machine; show
+  `install list` output.
+- Version pinning: pass `name:version` (or `@cid` for hash-verified) to
+  install exactly what the user selected in discovery; bare names resolve to
+  the newest record.

--- a/.skill/references/publishing.md
+++ b/.skill/references/publishing.md
@@ -1,0 +1,91 @@
+# Publishing: push, sign, announce, prove ownership
+
+Goal: get a validated record stored, signed, discoverable, and (optionally)
+name-verified.
+
+## The pipeline
+
+```bash
+dirctl validate record.json --url https://schema.oasf.outshift.com   # 1. validate
+CID=$(dirctl push record.json -o raw)                                # 2. store → CID
+dirctl sign "$CID"                                                   # 3. sign (optional, recommended)
+dirctl routing publish "$CID"                                        # 4. announce to the network (optional)
+```
+
+PowerShell (Windows): capture with `$CID = dirctl push record.json -o raw`,
+then pass `$CID` unquoted to the subsequent commands.
+
+Report the CID back to the user prominently — it is the durable handle for
+every later operation.
+
+## 1–2. Push
+
+- `push` stores the record in the content-addressable store and prints the
+  CID (`-o raw` for scripting).
+- Idempotent: pushing identical bytes returns the same CID, no duplicate.
+  Re-push only when the record actually changed.
+- Validation failures come back as `InvalidArgument` with per-attribute
+  messages — render them as a table and route the user to the authoring
+  reference.
+
+## 3. Sign
+
+```bash
+dirctl sign <cid>                      # keyless OIDC (Sigstore; opens browser)
+dirctl sign <cid> --key cosign.key     # private key
+```
+
+- Signatures are stored as OCI **referrers** attached to the CID — the record
+  itself is unchanged.
+- Signing enables the `--trusted` search filter and `dirctl verify` for
+  consumers.
+- Import flows can sign in bulk: `dirctl import ... --sign [--key ...]`.
+- Non-interactive signing: `--oidc-token` (CI).
+
+## 4. Announce to the network (routing)
+
+Records are local until published to the DHT:
+
+```bash
+dirctl routing publish <cid>      # announce; discoverable by peers
+dirctl routing unpublish <cid>    # withdraw from discovery; stays in local storage
+dirctl routing list               # what this node has published (filter: --skill, --domain, --module, --locator, --cid)
+dirctl routing info               # publication stats: counts, skills/locators distribution
+```
+
+Clarify intent with the user: **push** = store on the connected server;
+**routing publish** = make discoverable across the peer-to-peer network. A
+record can be pushed but unpublished (private to that directory).
+
+## Name ownership verification (optional, for `https://` names)
+
+Proves the signing key is authorized by the domain in the record name.
+
+Requirements:
+
+1. Record `name` uses a protocol prefix: `https://example.com/my-agent`.
+2. The domain hosts a JWKS at `https://example.com/.well-known/jwks.json`.
+3. The record is signed with a private key whose public key is in that JWKS.
+
+Workflow:
+
+```bash
+CID=$(dirctl push record.json -o raw)
+dirctl sign "$CID" --key private.key      # triggers automatic domain verification
+dirctl naming verify "$CID"               # check verification status
+```
+
+Verified names light up the `--verified` search filter. If verification
+fails, check (in order): name has the scheme prefix, JWKS is reachable,
+signing key matches a JWKS entry.
+
+## Maintenance
+
+```bash
+dirctl info <cid-or-name>     # metadata for a stored record
+dirctl delete <cid>           # remove from storage — confirm with the user first
+```
+
+`delete` does not retract network announcements on other peers that already
+synced the record; unpublish before deleting when the intent is "remove from
+the network".

--- a/.skill/references/setup.md
+++ b/.skill/references/setup.md
@@ -65,8 +65,12 @@ dirctl daemon stop                   # graceful shutdown via PID file, waits, cl
 - State lives under `--data-dir` (default `~/.agntcy/dir/`;
   `%USERPROFILE%\.agntcy\dir\` on Windows): `dir.db` (SQLite), `store/`
   (OCI), `routing/` (DHT), `daemon.pid`.
-- `daemon start` blocks. In agent environments, start it in a background
-  terminal/async process and verify with `dirctl daemon status`.
+- **`daemon start` runs in the foreground until stopped** — it never
+  daemonizes itself. In agent environments, dedicate a terminal to it: launch
+  it as a persistent background/async process in its own terminal and leave
+  that terminal alone (run no other commands in it; its output is the daemon
+  log). Run all subsequent commands — starting with `dirctl daemon status` to
+  verify startup — from a different terminal.
 - Manage the lifecycle only through `daemon start`/`stop`/`status` — never
   kill the process by signal directly: semantics differ across platforms and
   `stop` also cleans up the PID file.
@@ -146,8 +150,8 @@ POSIX (bash/zsh):
 ```bash
 command -v dirctl || <install via brew/releases>
 dirctl init --yes            # optional, ~89 MB — ask first
-dirctl daemon start          # background it; blocks otherwise
-dirctl daemon status
+dirctl daemon start          # foreground until stopped — dedicate a terminal
+dirctl daemon status         # from another terminal
 dirctl doctor
 ```
 
@@ -156,7 +160,7 @@ Windows (PowerShell):
 ```powershell
 Get-Command dirctl           # else install from GitHub Releases (.exe)
 dirctl init --yes            # optional, ~89 MB — ask first
-dirctl daemon start          # background it; blocks otherwise
-dirctl daemon status
+dirctl daemon start          # foreground until stopped — dedicate a terminal
+dirctl daemon status         # from another terminal
 dirctl doctor
 ```

--- a/.skill/references/setup.md
+++ b/.skill/references/setup.md
@@ -1,0 +1,162 @@
+# Setup: dirctl, local daemon, contexts, and diagnostics
+
+Goal: get a working `dirctl` with either a **local workspace** (self-contained
+daemon on `localhost:8888`) or a **remote directory** (context + OIDC auth).
+
+## 1. Install dirctl
+
+Check first: `dirctl version` (POSIX: `command -v dirctl`; PowerShell:
+`Get-Command dirctl`).
+
+Supported channels — offer the user the choice where more than one applies
+(question tool if available):
+
+- **Homebrew** (macOS / Linux only — not available on Windows):
+
+  ```bash
+  brew install agntcy/dir/dirctl
+  ```
+
+- **GitHub Releases** (all platforms; the only channel on Windows): download
+  the binary for the user's OS/arch from
+  <https://github.com/agntcy/dir/releases>.
+
+  - Linux / macOS (amd64 + arm64): extract, `chmod +x dirctl`, place it on
+    `PATH`.
+  - Windows (**amd64 only** — there is no windows-arm64 build): save the
+    binary as `dirctl.exe` in a directory on `PATH` (e.g.
+    `%LOCALAPPDATA%\Programs\dirctl\`), adding that directory to the user
+    `PATH` via Settings → Environment Variables if needed. No `chmod`.
+
+Do **not** suggest building from source or repo-local task commands.
+
+## 2. First-run provisioning: `dirctl init`
+
+Run once after install. Provisions the OASF taxonomy extractor (a ~89 MB
+sentence-transformer model + taxonomy) into `~/.agntcy/oasf-sdk/extractor` for
+local, LLM-free record enrichment and free-text search. **Warn the user about
+the download size before running.**
+
+```bash
+dirctl init          # interactive; Enter accepts
+dirctl init --yes    # non-interactive (CI, piped shells) — required without a TTY
+dirctl init --oasf-url http://localhost:8080 --yes   # from a local OASF instance
+dirctl init --remove --yes                           # tear down provisioned assets
+```
+
+Idempotent: re-running re-downloads nothing when assets are present and
+current. If `init` is not available in the installed version, skip it — it is
+not required for core operations.
+
+## 3. Local workspace: the daemon
+
+The daemon is a self-contained local directory server (gRPC apiserver +
+reconciler, embedded SQLite, filesystem OCI store). No PostgreSQL, no
+registry, no external dependencies.
+
+```bash
+dirctl daemon status                 # check (inspects PID file)
+dirctl daemon start                  # foreground; blocks until interrupted (Ctrl+C) or `daemon stop`
+dirctl daemon stop                   # graceful shutdown via PID file, waits, cleans up
+```
+
+- Serves on `localhost:8888` — the default for all other commands, so a local
+  workspace needs no `--server-addr` or context at all.
+- State lives under `--data-dir` (default `~/.agntcy/dir/`;
+  `%USERPROFILE%\.agntcy\dir\` on Windows): `dir.db` (SQLite), `store/`
+  (OCI), `routing/` (DHT), `daemon.pid`.
+- `daemon start` blocks. In agent environments, start it in a background
+  terminal/async process and verify with `dirctl daemon status`.
+- Manage the lifecycle only through `daemon start`/`stop`/`status` — never
+  kill the process by signal directly: semantics differ across platforms and
+  `stop` also cleans up the PID file.
+- Custom config: `--config <yaml>` (relative paths resolve against
+  `--data-dir`); env overrides use the `DIRECTORY_DAEMON_` prefix. Without
+  `--config`, embedded defaults are used — see the sync reference for when a
+  config file is required (e.g. P2P autosync).
+
+## 4. Remote directories: contexts
+
+Contexts live in `~/.config/dirctl/config.yaml` (or
+`$XDG_CONFIG_HOME/dirctl/config.yaml`; on Windows under the user profile —
+when unsure, `dirctl context show` prints the effective configuration rather
+than guessing the path):
+
+```yaml
+current_context: prod
+contexts:
+  prod:
+    server_address: gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://idp.example.com
+    oidc_client_id: dirctl
+```
+
+```bash
+dirctl context list          # sorted; * marks current_context
+dirctl context current       # persisted current context
+dirctl context set <name>    # switch persisted context
+dirctl context show [name]   # effective config, secrets redacted
+dirctl context validate      # catch config mistakes before use
+```
+
+Selection order per invocation: `--context` flag → `DIRECTORY_CLIENT_CONTEXT`
+→ `current_context`. Root flags (`--server-addr`, `--auth-mode`,
+`--oidc-issuer`, `--auth-token`) override the selected context for that call.
+
+Do not store long-lived tokens in `config.yaml` — prefer
+`DIRECTORY_CLIENT_AUTH_TOKEN` or a secret manager.
+
+## 5. Authentication (remote only)
+
+Local daemon needs none (auto-detect falls back to insecure for local
+development).
+
+```bash
+dirctl auth login --oidc-issuer "https://idp.example.com" --oidc-client-id "dirctl"
+dirctl auth status
+dirctl auth logout
+```
+
+- `auth login` uses OIDC PKCE (browser); `--no-browser` and `--device` exist
+  for headless environments.
+- CI / automation: pre-issued token via `--auth-token` or
+  `DIRECTORY_CLIENT_AUTH_TOKEN`.
+- Other modes need an explicit `--auth-mode`: `x509`, `jwt`, `token` (SPIFFE),
+  `tls`, `oidc`, `insecure`, `none`.
+- On auth errors: show the raw error and ask the user which mechanism they
+  use. Never guess flags.
+
+## 6. Verify the environment: `dirctl doctor`
+
+Always finish setup with:
+
+```bash
+dirctl doctor                          # connectivity + configuration checks
+dirctl doctor --timeout 5s             # slower networks
+dirctl doctor --bootstrap-peer <maddr> # validate network bootstrap peers
+```
+
+Present failed checks to the user as a table (check | status | hint).
+
+## Recommended local-workspace sequence
+
+POSIX (bash/zsh):
+
+```bash
+command -v dirctl || <install via brew/releases>
+dirctl init --yes            # optional, ~89 MB — ask first
+dirctl daemon start          # background it; blocks otherwise
+dirctl daemon status
+dirctl doctor
+```
+
+Windows (PowerShell):
+
+```powershell
+Get-Command dirctl           # else install from GitHub Releases (.exe)
+dirctl init --yes            # optional, ~89 MB — ask first
+dirctl daemon start          # background it; blocks otherwise
+dirctl daemon status
+dirctl doctor
+```

--- a/.skill/references/sync.md
+++ b/.skill/references/sync.md
@@ -80,7 +80,7 @@ Apply it:
    (comma-separated).
 3. **Restart the daemon** — config is read at startup only:
    `dirctl daemon stop`, then `dirctl daemon start --config <file>`
-   (background it; see setup reference).
+   (foreground until stopped — dedicate a terminal; see setup reference).
 4. **Confirm**: after the peer next announces (or republishes), synced
    records show up in local `dirctl search`; `dirctl daemon` logs report
    "Autosync ingested record" per CID.

--- a/.skill/references/sync.md
+++ b/.skill/references/sync.md
@@ -1,0 +1,111 @@
+# Synchronization: mirror records between directories
+
+Goal: replicate records from a remote directory into the connected one, and
+manage the lifecycle of those syncs.
+
+## Choosing a mode
+
+| The user provides | Mode | Mechanism |
+| --- | --- | --- |
+| A directory **URL / API endpoint** (e.g. a hosted/SaaS instance) | **API sync** — `dirctl sync create` | Server-to-server replication over the Directory API / OCI store |
+| Only a **libp2p peer ID** (`12D3KooW…`) | **P2P autosync** — daemon config patch | Records pulled over libp2p RPCs on DHT announcements (no OCI transport) |
+| Wants to discover records on peers without copying them | `dirctl routing search` | DHT query |
+| Wants own records discoverable | `dirctl routing publish` | DHT announce |
+
+## API sync (SaaS / known endpoint)
+
+Use when the remote directory is a publicly accessible instance with a known
+API endpoint — e.g. a hosted/SaaS directory or any reachable
+`host:port` gRPC address. The **connected server** performs the replication;
+the CLI only manages sync lifecycle.
+
+```bash
+dirctl sync create <remote-directory-url>   # start syncing from a remote; returns a sync ID
+dirctl sync list -o json                    # all syncs with IDs and states
+dirctl sync status <sync-id>                # progress / health of one sync
+dirctl sync delete <sync-id>                # stop and remove a sync — confirm with user first
+```
+
+Workflow:
+
+1. `sync create` and capture the returned sync ID.
+2. Poll `sync status <id>` until it reports an active/completed state — sync
+   is asynchronous; initial replication of a large directory takes time. Warn
+   the user and offer to check back rather than busy-polling.
+3. Confirm arrival with a quick `dirctl search` for a known record from the
+   remote.
+
+Render `sync list` as a table:
+
+| Sync ID | Remote | Status |
+| --- | --- | --- |
+
+## P2P autosync (peer ID only)
+
+Use when the user can only name a **peer** (libp2p peer ID), not an API
+endpoint. There is no CLI command for this: it is enabled by patching the
+**daemon configuration**. Once active, records the allow-listed peer
+announces on the DHT are pulled over **libp2p RPCs** — not the OCI transport
+— and ingested locally with full parity to a normal push (record + referrers:
+signatures, scan reports; content store + search index).
+
+Target config shape (deny-by-default; off unless explicitly enabled):
+
+```yaml
+server:
+  routing:
+    # DHT connectivity is required to hear announcements — bootstrap against
+    # the peer itself or a shared bootstrap node (multiaddr incl. peer ID):
+    bootstrap_peers:
+      - "/dns4/remote-dir.example.com/tcp/8999/p2p/<peer-id>"
+    autosync:
+      enabled: true
+      peerlist:                       # allow-list of trusted source peers
+        - peer: "12D3KooW...peerID1"
+```
+
+Apply it:
+
+1. **Locate or create the daemon config file.** The daemon reads a config
+   file only when started with `--config <file>`; otherwise it runs on
+   embedded defaults (autosync off). A `--config` file is read as the
+   **complete** configuration — start from the full reference daemon config
+   (see `dirctl daemon start --help`), not a fragment containing only the
+   autosync block.
+2. **Patch, don't replace**: merge the `server.routing.autosync` (and
+   `bootstrap_peers`) settings into the existing file, preserving everything
+   else. `peerlist` is YAML-only — it is a list of objects and cannot be set
+   via a `DIRECTORY_DAEMON_*` env var; `bootstrap_peers` may alternatively
+   come from `DIRECTORY_DAEMON_SERVER_ROUTING_BOOTSTRAP_PEERS`
+   (comma-separated).
+3. **Restart the daemon** — config is read at startup only:
+   `dirctl daemon stop`, then `dirctl daemon start --config <file>`
+   (background it; see setup reference).
+4. **Confirm**: after the peer next announces (or republishes), synced
+   records show up in local `dirctl search`; `dirctl daemon` logs report
+   "Autosync ingested record" per CID.
+
+P2P autosync notes:
+
+- Allow-list matching uses libp2p's **authenticated** peer ID — never a
+  self-reported field. An invalid peer ID in `peerlist` fails at daemon
+  startup rather than being silently skipped — surface that error verbatim.
+- Pulled records are CID-checked and OASF-validated before ingestion;
+  mismatches are rejected, not stored.
+- A bare peer ID is not dialable by itself: the DHT needs a route. If the
+  user has no multiaddr for the peer and no shared bootstrap node, ask for
+  one — don't guess addresses.
+- Autosync is continuous and event-driven (announcement-triggered), unlike
+  API sync's explicit lifecycle; to stop it, set `enabled: false` (or remove
+  the peer from `peerlist`) and restart the daemon.
+
+## Notes (both modes)
+
+- Synced records land in local storage and become searchable locally; their
+  CIDs are unchanged (content-addressed).
+- Deleting a sync (or disabling autosync) stops future replication; it does
+  not delete already-synced records.
+- Auth: the connected server performs the sync — remote credentials are a
+  server-side concern. If `sync create` fails with auth errors, surface the
+  raw error; do not invent flags.
+

--- a/.skill/references/verification.md
+++ b/.skill/references/verification.md
@@ -1,0 +1,84 @@
+# Verification: signatures, name ownership, and security scans
+
+Goal: answer "can I trust this record?" with concrete, verifiable signals —
+never a synthesized score.
+
+## The three trust signals
+
+| Signal | Meaning | Command / filter |
+| --- | --- | --- |
+| **Trusted** | Signature verification passed | `dirctl verify <cid>`; search `--trusted` |
+| **Verified** | Signing key authorized by the domain in the record name (JWKS) | `dirctl naming verify <ref>`; search `--verified` |
+| **Safe** | All security scanners reported `is_safe=true` | `dirctl pull <cid> --scan-report`; search `--safe`, `--scan-severity` |
+
+Report them separately; they answer different questions (integrity, identity,
+content safety).
+
+## Verify a signature
+
+```bash
+dirctl verify <cid>                                   # fetch signature from the directory and verify
+dirctl verify <cid> --key public.pem                  # against a specific key (path, URL, or KMS URI)
+dirctl verify <cid> --oidc-issuer "https://accounts.google.com" --oidc-subject "ci@example.com"   # keyless identity match (regexp supported)
+dirctl verify <cid> --from-server                     # use the server's cached verification result
+```
+
+`--ignore-tlog` skips transparency-log verification — only when the user
+explicitly asks.
+
+## Verify name ownership
+
+```bash
+dirctl naming verify <cid>
+dirctl naming verify "https://example.com/agent:v1.0.0"
+```
+
+Checks the signing key against `https://<domain>/.well-known/jwks.json`. Only
+meaningful for records whose name has an `http(s)://` prefix; plain names are
+reported as not applicable, not as failures.
+
+## Security scan reports
+
+The directory reconciler runs scanners automatically and attaches results as
+referrers: **mcp-scanner** (MCP server source) and **skill-scanner** (agent
+skill bundles).
+
+```bash
+dirctl pull <cid> --scan-report -o json
+```
+
+The `scanReports` array contains per-scanner entries: `scanner_type`,
+`scanner_version`, `scanned_at`, `is_safe`, `max_severity`
+(`SEVERITY_NONE|INFO|MEDIUM|HIGH|CRITICAL`), and `findings` (rule ID,
+severity, message, location, remediation).
+
+Render findings as a table:
+
+| Scanner | Severity | Rule | Message | Remediation |
+| --- | --- | --- | --- | --- |
+
+Summarize with `is_safe` + `max_severity` per scanner. A record with **no**
+reports is *unscanned* — say so explicitly rather than implying safety.
+
+## Filtering by trust at search time
+
+```bash
+dirctl search --safe                          # all scanners is_safe=true (unscanned records excluded)
+dirctl search --scan-severity HIGH            # highest finding ≥ HIGH
+dirctl search --trusted --verified            # signed + name-verified
+dirctl search "code review agent" --safe      # combine with NL query
+```
+
+## Pre-install trust check (recommended flow)
+
+Before installing a record the user picked:
+
+```bash
+dirctl verify <cid> --from-server
+dirctl naming verify <cid>
+dirctl pull <cid> --scan-report -o json
+```
+
+Present the three signals as a one-row table. If any signal is negative or
+missing, tell the user and let them decide — do not block, do not
+editorialize beyond the data.

--- a/server/skill/SKILL.md
+++ b/server/skill/SKILL.md
@@ -1,103 +1,253 @@
 ---
 name: agntcy-dir
-description: Use this skill to interact with an AGNTCY Directory (DIR) instance. DIR is a distributed peer-to-peer registry of AI agent records described in OASF. Use it to publish (push), discover (search), retrieve (pull), sign, and verify agent records.
+description: Use when the user asks to discover, browse, search, suggest, recommend, or install agent skills, MCP servers, or other artifacts from the AGNTCY directory (dirctl). Turns a natural-language query into `dirctl search` calls, renders matches as a table (grid) in chat, confirms selection via a popup-style question card, then installs the chosen artifacts into the local VS Code Copilot environment via `dirctl export`.
 metadata:
   author: AGNTCY Contributors
   version: 1.0.0
 ---
 
-# AGNTCY Directory (DIR)
+# agntcy-dir: Discover & Install from the AGNTCY Directory
 
-DIR is a distributed registry for AI agent records. Records describe agents using
-the [Open Agentic Schema Framework (OASF)](https://github.com/agntcy/oasf) and
-are content-addressed by CID.
+End-to-end flow backed by the `dirctl` binary:
 
-This skill explains how to talk to a running DIR node. You can use the MCP server,
-the `dirctl` CLI, the language SDKs, or the raw gRPC API — pick whichever channel
-your environment supports.
+1. **Discover** — translate a natural-language query into `dirctl search`
+   flags and render matches as a Markdown table (grid).
+2. **Confirm** — popup the matches via the `ask-questions` tool so the
+   user picks which record(s) to install.
+3. **Install** — pull each picked record with `dirctl export` in the
+   format Copilot consumes (`agent-skill` or `mcp-ghcopilot`) and drop
+   it into the local Copilot environment.
 
-## Vocabulary
+## When to Use
 
-- **Record** — an OASF JSON document describing one agent (name, version, skills, locators, modules, signatures).
-- **CID** — Content Identifier; the SHA-based hash that uniquely names a record. Pushing the same record twice yields the same CID.
-- **Skill / Domain** — OASF taxonomy nodes describing what an agent does (e.g. `natural_language_processing/text_completion`) and where it operates.
-- **Module** — typed extension on a record (e.g. `core/language_model/agentskills`, `integration/mcp`, `integration/a2a`).
-- **Locator** — pointer to a runnable artifact for the agent (`container_image`, `source_code`, `helm_chart`, `package`, `binary`, `url`).
+- "Find an MCP server for <topic>"
+- "Search the directory for skills about <topic>"
+- "Suggest agent skills I should install"
+- "Install <name> from the directory"
+- "Browse / recommend dirctl records"
 
-## Channels
+## Prerequisites
 
-| Operation | MCP tool | CLI | Go SDK |
-|---|---|---|---|
-| Push a record | `agntcy_dir_push_record` | `dirctl push <file>` | `client.Push` |
-| Pull by CID | `agntcy_dir_pull_record` | `dirctl pull <cid>` | `client.Pull` |
-| Search local | `agntcy_dir_search_local` | `dirctl search` | `client.Search` |
-| Validate against OASF | `agntcy_oasf_validate_record` | `dirctl validate <file>` | — |
-| List OASF versions | `agntcy_oasf_list_versions` | — | — |
-| Sign a record | — | `dirctl sign --key=<cosign.key> <cid>` | `client.Sign` |
-| Verify a signature | `agntcy_dir_verify_record` | `dirctl verify <cid>` | `client.Verify` |
-| Verify name ownership | `agntcy_dir_verify_name` | `dirctl naming verify <cid>` | — |
-| Import MCP / A2A / SKILL.md | `agntcy_oasf_import_record` | `dirctl import --type=<mcp\|a2a\|agent-skill>` | — |
+- `dirctl` on `PATH` (`command -v dirctl`). If missing, stop and tell
+  the user to install it via one of:
+  - **Homebrew** (macOS / Linux):
+    `brew install agntcy/dir/dirctl`
+    (formula source: <https://github.com/agntcy/dir/tree/main/HomebrewFormula>)
+  - **GitHub Releases** — download the archive for the user's
+    OS/arch from <https://github.com/agntcy/dir/releases>, extract,
+    and place `dirctl` on `PATH`.
+    Do **not** suggest building from source or running repo-local task
+    commands.
+- A reachable directory server (default `0.0.0.0:8888`). Pass
+  `--server-addr` or set a `dirctl` context if needed.
+- Do not invent auth flags. If a call fails with an auth error, surface
+  the raw error and ask how to authenticate — global flags include
+  `--auth-mode`, `--auth-token`, OIDC, SPIFFE, TLS (see
+  `dirctl <cmd> --help`).
 
-## Workflow: publish an agent record
+## UI Primitives (chat surface)
 
-1. Author or generate an OASF record JSON. Required top-level fields for the
-   1.0.0 schema: `name`, `schema_version`, `version`, `description`, `authors`,
-   `created_at` (RFC3339), `skills`. Optional: `domains`, `locators`, `modules`,
-   `annotations`.
-2. Validate against the OASF schema before pushing — the server rejects
-   malformed records with `InvalidArgument`.
-3. Push. The server returns the CID. Pushes are idempotent: pushing the same
-   bytes a second time returns the same CID without creating a duplicate.
-4. Optionally sign the record with cosign — produces a signature *referrer*
-   linked to the CID. Anyone can later verify signature and name ownership.
+| Primitive               | Render as                                          | How to invoke                                                          |
+| ----------------------- | -------------------------------------------------- | ---------------------------------------------------------------------- |
+| Question card ("popup") | Inline card with options + optional freeform input | Call the `ask-questions` tool with `header`, `question`, and `options` |
+| Grid                    | Markdown table in the chat reply                   | Emit a standard `\| col \| col \|` table                               |
+
+Webviews, side panels, and native VS Code dialogs are not available
+from a skill. Do not promise them.
+
+---
+
+## Procedure
+
+### Step 1 — Translate the NL query into `dirctl search` flags
+
+Relevant `dirctl search` flags (all multi-valued, support `*` and `?`):
+
+| Flag           | Use for                                           |
+| -------------- | ------------------------------------------------- |
+| `--name`       | Record name, often `vendor/name` (`cisco.com/*`)  |
+| `--version`    | Semver; supports `>=`, `<`, wildcards             |
+| `--skill`      | Skill name (e.g. `natural_language_processing`)   |
+| `--skill-id`   | Numeric skill taxonomy id                         |
+| `--domain`     | Domain (`*education*`, `*finance*`, …)            |
+| `--module`     | Module path (`core/llm/model`, `integration/mcp`) |
+| `--author`     | Author glob                                       |
+| `--annotation` | `key:value` (e.g. `team:platform`)                |
+| `--locator`    | Locator type (e.g. `docker-image`)                |
+| `--created-at` | Date glob / comparison                            |
+| `--verified`   | Verified name ownership only                      |
+| `--trusted`    | Signature verification passed only                |
+| `--limit`      | Cap results (default 100)                         |
+
+Translation rules:
+
+- Quote every value (`--name "web*"`).
+- Use wildcards generously — names are namespaced.
+- If the user mentions **MCP** → add `--module "integration/mcp"`; fall
+  back to `--name "*mcp*"` if empty.
+- If the user mentions **agent skill** → add `--locator "agent-skill"`
+  or `--module "*skill*"`; fall back to keyword search on `--skill` /
+  `--name`.
+- Always request structured output: `--format record --output json`.
+
+Run the command and capture stdout. Example:
 
 ```bash
-dirctl validate agent.json
-CID=$(dirctl push agent.json --output=raw)
-dirctl sign --key=cosign.key "$CID"
+dirctl search \
+  --skill "*nlp*" \
+  --verified \
+  --limit 25 \
+  --format record \
+  --output json
 ```
 
-## Workflow: discover and pull a record
+If the result is empty, retry **once** with a broader query (drop
+`--verified`, widen wildcards) before reporting "no matches".
 
-1. Search by structured filters (names, versions, skills, locators, authors, …).
-   Filters use wildcards: `*` (any), `?` (one char), `[abc]` (set).
-2. The search returns CIDs. Pull each CID to get the full record JSON.
+### Step 2 — Render the grid
+
+Parse the JSON output and render a Markdown table with **exactly** these
+columns, in this order:
+
+| #   | Name | Version | Rating | Artifacts | Verified | CID |
+| --- | ---- | ------- | ------ | --------- | -------- | --- |
+
+Column definitions:
+
+- **#** — 1-based row index, referenced by the popup.
+- **Name** — `record.name`.
+- **Version** — `record.version`.
+- **Rating** — synthesized "fake rating" out of 5 stars, computed from:
+  - `+2` if `verified == true`
+  - `+1` if `trusted == true` (signed)
+  - `+1` if `match_score >= 0.7` (else `+0.5` if `>= 0.4`)
+  - `+1` if the record has ≥3 skills/modules
+  - Cap at 5, round to nearest 0.5, render as `★★★★☆ (4.0)`.
+    Always label this as a heuristic, not an official score.
+- **Artifacts** — tags inferred from modules/locators:
+  `MCP` (module contains `mcp`), `Agent Skill` (locator `agent-skill`
+  or module contains `skill`), `A2A` (has `a2a` capability), else `OASF`.
+- **Verified** — ✓ if `verified`, ✓✓ if also `trusted`, blank otherwise.
+- **CID** — first 12 chars + `…`. Keep the full CID in an internal map
+  for Step 4.
+
+Cap visible rows at 10. If there are more, add a final row
+`… N more — refine your query` and stop.
+
+### Step 3 — Confirm via popup
+
+Call the `ask-questions` tool with **two** questions:
+
+1. `header: "selection"`, `multiSelect: true`, `question:` "Which
+   records would you like to install?". One option per visible row,
+   label `#<n> <name>@<version> — <artifacts>`.
+2. `header: "scope"`, `question:` "Where should they be installed?",
+   options:
+   - `Workspace (.github/skills, .vscode/mcp.json)` — recommended
+   - `User profile (~/.copilot/skills, user mcp.json)`
+
+Do not write any files before both answers arrive.
+
+### Step 4 — Install via `dirctl export`
+
+Pick the export format from the **Artifacts** column:
+
+| Artifact tag in grid | `dirctl export --format` | Destination (workspace scope)                                         |
+| -------------------- | ------------------------ | --------------------------------------------------------------------- |
+| Agent Skill          | `agent-skill`            | `.github/skills/<slug>/SKILL.md`                                      |
+| MCP                  | `mcp-ghcopilot`          | merge into `.vscode/mcp.json` under `servers.<slug>`                  |
+| A2A                  | `a2a`                    | `.copilot/a2a/<slug>.json` (informational; Copilot has no native A2A) |
+| OASF (fallback)      | `oasf`                   | `.copilot/oasf/<slug>.json`                                           |
+
+`<slug>` = record name, lowercased, with `/` and non-alphanumerics
+replaced by `-`, truncated to 64 chars.
+
+Commands:
 
 ```bash
-dirctl search --skill-name "*text_completion*" --limit 20
-dirctl pull <cid>
+# Agent skill → write directly
+mkdir -p .github/skills/<slug>
+dirctl export <cid> \
+  --format=agent-skill \
+  --output-file=.github/skills/<slug>/SKILL.md
+
+# MCP → export to a temp file, then merge into mcp.json
+tmp=$(mktemp)
+dirctl export <cid> --format=mcp-ghcopilot --output-file="$tmp"
+# then deep-merge $tmp into .vscode/mcp.json (create if missing)
 ```
 
-For natural-language searches via an LLM, prefer the `search_records` MCP prompt,
-which translates a free-text query into structured filters automatically.
+User-scope destinations (when "User profile" was chosen):
 
-## OASF essentials
+| Artifact    | Path                                                                             |
+| ----------- | -------------------------------------------------------------------------------- |
+| Agent Skill | `~/.copilot/skills/<slug>/SKILL.md`                                              |
+| MCP         | merge into the user-level `mcp.json` (created/edited via VS Code Settings → MCP) |
 
-- Schema versions in active use: `0.7.0`, `0.8.0`, `1.0.0`. Pick the latest your
-  tooling supports; `1.0.0` is the current default.
-- Module enum is closed in 1.0.0 — only these `name`s validate:
-  `language_model`, `prompt`, `core/language_model/agentskills`, `evaluation`,
-  `observability`, `a2a`, `acp`, `agentspec`, `mcp`. Custom payloads belong in
-  the top-level `annotations` map.
-- Skills and domains are taxonomies; resolve `id` ↔ `name` with the
-  `agntcy_oasf_get_schema_skills` and `agntcy_oasf_get_schema_domains` MCP tools
-  (or fetch the schema JSON directly).
+Rules:
 
-## Common pitfalls
+- Always pass the full **CID** (or `name[:version]`) to `dirctl export`,
+  not the truncated CID shown in the grid. Use the internal map from
+  Step 2.
+- Run exports **sequentially** to keep output readable.
+- If one export fails, continue with the rest and record the failure in
+  the summary table.
+- After writing a `SKILL.md`, verify its `name:` frontmatter equals the
+  folder slug. If `dirctl` emits a mismatched name, rewrite the `name:`
+  field — mismatch is the most common silent discovery failure.
+- For MCP merges: read existing `.vscode/mcp.json`, add the new entry
+  under `servers` without removing siblings, write back with stable key
+  order. Create the file with `{"servers": {…}}` if it doesn't exist.
 
-- A record's CID covers its bytes — any change (whitespace, key order) yields a
-  new CID. Re-push only when the record actually changes.
-- Names beginning with `http://` or `https://` opt into domain-based name
-  ownership verification (`/.well-known/jwks.json` on the host). Plain names
-  skip that path.
-- Search defaults to local-only. To find records on remote peers, use routing
-  search (`dirctl routing search …` / `client.SearchRouting`).
-- The server caps records at 4 MB and metadata at 100 KB. Keep large blobs in
-  external storage and reference them via locators.
+### Step 5 — Report
 
-## Pointers
+Emit a final Markdown table:
 
-- OASF schema: <https://schema.oasf.outshift.com/1.0.0>
-- DIR repo & CLI reference: <https://github.com/agntcy/dir>
-- DIR MCP server: <https://github.com/agntcy/dir-mcp>
-- Quickstart docs: <https://docs.agntcy.org/dir/dir-quickstart/>
+| #   | Name | Format | Path | Status |
+| --- | ---- | ------ | ---- | ------ |
+
+Status is one of: `created`, `merged`, `skipped (already present)`,
+`failed: <reason>`. Make every `Path` cell a clickable Markdown link.
+
+If any MCP servers were installed, remind the user to reload them via
+**Command Palette → "MCP: List Servers" → restart**.
+
+---
+
+## Worked Example
+
+User: _"find me MCP servers for github issues"_
+
+1. Translate → `dirctl search --module "integration/mcp" --name "*github*" --limit 25 --format record --output json`.
+2. Render top 10 matches as the 7-column grid (Artifacts column = `MCP`).
+3. Popup → user picks rows #1 and #3, scope = Workspace.
+4. For each: `dirctl export <cid> --format=mcp-ghcopilot --output-file=/tmp/x.json`, then merge into `.vscode/mcp.json`.
+5. Final summary table + reload hint.
+
+---
+
+## Quality Bar
+
+- Never fabricate CIDs, names, versions, or ratings — every value must
+  come from real `dirctl search` output (rating is computed from those
+  values, not invented).
+- Never run `dirctl export` without a confirmed CID from the popup.
+- Always honor the user's scope answer.
+- Quote every shell argument; record names contain `/` and `:`.
+- A skill's `name:` field MUST equal the folder slug.
+
+## Anti-patterns
+
+- Hard-coding example records into the grid instead of parsing real
+  search output.
+- Asking the user to type a CID when an `ask-questions` popup is
+  available.
+- Overwriting `.vscode/mcp.json` instead of merging.
+- Presenting the rating as authoritative — always label it a heuristic.
+- Promising webviews or native VS Code dialogs the chat cannot render.
+
+## References
+
+- `dirctl search --help`, `dirctl export --help`
+- [Agent Skills docs](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
+- [VS Code MCP servers](https://code.visualstudio.com/docs/copilot/chat/mcp-servers)

--- a/server/skill/SKILL.md
+++ b/server/skill/SKILL.md
@@ -1,253 +1,67 @@
 ---
 name: agntcy-dir
-description: Use when the user asks to discover, browse, search, suggest, recommend, or install agent skills, MCP servers, or other artifacts from the AGNTCY directory (dirctl). Turns a natural-language query into `dirctl search` calls, renders matches as a table (grid) in chat, confirms selection via a popup-style question card, then installs the chosen artifacts into the local VS Code Copilot environment via `dirctl export`.
+description: "Use this skill to interact with an AGNTCY Directory (DIR) instance. This is a bootstrap: it installs the complete agntcy-dir skill (setup, authoring, publishing, discovery, verification, sync, install workflows) from the AGNTCY Directory GitHub repository, then defers to it."
 metadata:
   author: AGNTCY Contributors
-  version: 1.0.0
 ---
 
-# agntcy-dir: Discover & Install from the AGNTCY Directory
+# AGNTCY Directory — skill bootstrap
 
-End-to-end flow backed by the `dirctl` binary:
+This file intentionally does **one** thing: install the full `agntcy-dir`
+skill from the AGNTCY Directory repository and hand over to it. Do not act on
+Directory requests from this bootstrap alone — install the full skill first,
+then follow its instructions.
 
-1. **Discover** — translate a natural-language query into `dirctl search`
-   flags and render matches as a Markdown table (grid).
-2. **Confirm** — popup the matches via the `ask-questions` tool so the
-   user picks which record(s) to install.
-3. **Install** — pull each picked record with `dirctl export` in the
-   format Copilot consumes (`agent-skill` or `mcp-ghcopilot`) and drop
-   it into the local Copilot environment.
+The complete skill lives in the repository's
+[`.skill/` folder](https://github.com/agntcy/dir/tree/main/.skill): a router
+`SKILL.md` plus seven reference files.
 
-## When to Use
+## Install
 
-- "Find an MCP server for <topic>"
-- "Search the directory for skills about <topic>"
-- "Suggest agent skills I should install"
-- "Install <name> from the directory"
-- "Browse / recommend dirctl records"
+Copy the folder into the host's skills directory, named exactly `agntcy-dir`
+(the folder name must match the skill's frontmatter `name`):
 
-## Prerequisites
+| Host                        | Destination                                                    |
+| --------------------------- | -------------------------------------------------------------- |
+| GitHub Copilot (user-wide)  | `~/.copilot/skills/agntcy-dir/`                                |
+| VS Code Copilot (workspace) | `.github/skills/agntcy-dir/`                                   |
+| Claude Code                 | `.claude/skills/agntcy-dir/` or `~/.claude/skills/agntcy-dir/` |
+| Other hosts                 | that host's skills directory, same folder name                 |
 
-- `dirctl` on `PATH` (`command -v dirctl`). If missing, stop and tell
-  the user to install it via one of:
-  - **Homebrew** (macOS / Linux):
-    `brew install agntcy/dir/dirctl`
-    (formula source: <https://github.com/agntcy/dir/tree/main/HomebrewFormula>)
-  - **GitHub Releases** — download the archive for the user's
-    OS/arch from <https://github.com/agntcy/dir/releases>, extract,
-    and place `dirctl` on `PATH`.
-    Do **not** suggest building from source or running repo-local task
-    commands.
-- A reachable directory server (default `0.0.0.0:8888`). Pass
-  `--server-addr` or set a `dirctl` context if needed.
-- Do not invent auth flags. If a call fails with an auth error, surface
-  the raw error and ask how to authenticate — global flags include
-  `--auth-mode`, `--auth-token`, OIDC, SPIFFE, TLS (see
-  `dirctl <cmd> --help`).
-
-## UI Primitives (chat surface)
-
-| Primitive               | Render as                                          | How to invoke                                                          |
-| ----------------------- | -------------------------------------------------- | ---------------------------------------------------------------------- |
-| Question card ("popup") | Inline card with options + optional freeform input | Call the `ask-questions` tool with `header`, `question`, and `options` |
-| Grid                    | Markdown table in the chat reply                   | Emit a standard `\| col \| col \|` table                               |
-
-Webviews, side panels, and native VS Code dialogs are not available
-from a skill. Do not promise them.
-
----
-
-## Procedure
-
-### Step 1 — Translate the NL query into `dirctl search` flags
-
-Relevant `dirctl search` flags (all multi-valued, support `*` and `?`):
-
-| Flag           | Use for                                           |
-| -------------- | ------------------------------------------------- |
-| `--name`       | Record name, often `vendor/name` (`cisco.com/*`)  |
-| `--version`    | Semver; supports `>=`, `<`, wildcards             |
-| `--skill`      | Skill name (e.g. `natural_language_processing`)   |
-| `--skill-id`   | Numeric skill taxonomy id                         |
-| `--domain`     | Domain (`*education*`, `*finance*`, …)            |
-| `--module`     | Module path (`core/llm/model`, `integration/mcp`) |
-| `--author`     | Author glob                                       |
-| `--annotation` | `key:value` (e.g. `team:platform`)                |
-| `--locator`    | Locator type (e.g. `docker-image`)                |
-| `--created-at` | Date glob / comparison                            |
-| `--verified`   | Verified name ownership only                      |
-| `--trusted`    | Signature verification passed only                |
-| `--limit`      | Cap results (default 100)                         |
-
-Translation rules:
-
-- Quote every value (`--name "web*"`).
-- Use wildcards generously — names are namespaced.
-- If the user mentions **MCP** → add `--module "integration/mcp"`; fall
-  back to `--name "*mcp*"` if empty.
-- If the user mentions **agent skill** → add `--locator "agent-skill"`
-  or `--module "*skill*"`; fall back to keyword search on `--skill` /
-  `--name`.
-- Always request structured output: `--format record --output json`.
-
-Run the command and capture stdout. Example:
+Fetch from GitHub (raw content, `main` branch):
 
 ```bash
-dirctl search \
-  --skill "*nlp*" \
-  --verified \
-  --limit 25 \
-  --format record \
-  --output json
+BASE=https://raw.githubusercontent.com/agntcy/dir/main/.skill
+DEST=~/.copilot/skills/agntcy-dir        # adjust to the host (table above)
+mkdir -p "$DEST/references"
+curl -fsSL "$BASE/SKILL.md" -o "$DEST/SKILL.md"
+for f in authoring discovery install publishing setup sync verification; do
+  curl -fsSL "$BASE/references/$f.md" -o "$DEST/references/$f.md"
+done
 ```
 
-If the result is empty, retry **once** with a broader query (drop
-`--verified`, widen wildcards) before reporting "no matches".
+PowerShell (Windows):
 
-### Step 2 — Render the grid
-
-Parse the JSON output and render a Markdown table with **exactly** these
-columns, in this order:
-
-| #   | Name | Version | Rating | Artifacts | Verified | CID |
-| --- | ---- | ------- | ------ | --------- | -------- | --- |
-
-Column definitions:
-
-- **#** — 1-based row index, referenced by the popup.
-- **Name** — `record.name`.
-- **Version** — `record.version`.
-- **Rating** — synthesized "fake rating" out of 5 stars, computed from:
-  - `+2` if `verified == true`
-  - `+1` if `trusted == true` (signed)
-  - `+1` if `match_score >= 0.7` (else `+0.5` if `>= 0.4`)
-  - `+1` if the record has ≥3 skills/modules
-  - Cap at 5, round to nearest 0.5, render as `★★★★☆ (4.0)`.
-    Always label this as a heuristic, not an official score.
-- **Artifacts** — tags inferred from modules/locators:
-  `MCP` (module contains `mcp`), `Agent Skill` (locator `agent-skill`
-  or module contains `skill`), `A2A` (has `a2a` capability), else `OASF`.
-- **Verified** — ✓ if `verified`, ✓✓ if also `trusted`, blank otherwise.
-- **CID** — first 12 chars + `…`. Keep the full CID in an internal map
-  for Step 4.
-
-Cap visible rows at 10. If there are more, add a final row
-`… N more — refine your query` and stop.
-
-### Step 3 — Confirm via popup
-
-Call the `ask-questions` tool with **two** questions:
-
-1. `header: "selection"`, `multiSelect: true`, `question:` "Which
-   records would you like to install?". One option per visible row,
-   label `#<n> <name>@<version> — <artifacts>`.
-2. `header: "scope"`, `question:` "Where should they be installed?",
-   options:
-   - `Workspace (.github/skills, .vscode/mcp.json)` — recommended
-   - `User profile (~/.copilot/skills, user mcp.json)`
-
-Do not write any files before both answers arrive.
-
-### Step 4 — Install via `dirctl export`
-
-Pick the export format from the **Artifacts** column:
-
-| Artifact tag in grid | `dirctl export --format` | Destination (workspace scope)                                         |
-| -------------------- | ------------------------ | --------------------------------------------------------------------- |
-| Agent Skill          | `agent-skill`            | `.github/skills/<slug>/SKILL.md`                                      |
-| MCP                  | `mcp-ghcopilot`          | merge into `.vscode/mcp.json` under `servers.<slug>`                  |
-| A2A                  | `a2a`                    | `.copilot/a2a/<slug>.json` (informational; Copilot has no native A2A) |
-| OASF (fallback)      | `oasf`                   | `.copilot/oasf/<slug>.json`                                           |
-
-`<slug>` = record name, lowercased, with `/` and non-alphanumerics
-replaced by `-`, truncated to 64 chars.
-
-Commands:
-
-```bash
-# Agent skill → write directly
-mkdir -p .github/skills/<slug>
-dirctl export <cid> \
-  --format=agent-skill \
-  --output-file=.github/skills/<slug>/SKILL.md
-
-# MCP → export to a temp file, then merge into mcp.json
-tmp=$(mktemp)
-dirctl export <cid> --format=mcp-ghcopilot --output-file="$tmp"
-# then deep-merge $tmp into .vscode/mcp.json (create if missing)
+```powershell
+$BASE = 'https://raw.githubusercontent.com/agntcy/dir/main/.skill'
+$DEST = "$HOME\.copilot\skills\agntcy-dir"   # adjust to the host (table above)
+New-Item -ItemType Directory -Force -Path "$DEST\references" | Out-Null
+Invoke-WebRequest "$BASE/SKILL.md" -OutFile "$DEST\SKILL.md"
+foreach ($f in 'authoring','discovery','install','publishing','setup','sync','verification') {
+  Invoke-WebRequest "$BASE/references/$f.md" -OutFile "$DEST\references\$f.md"
+}
 ```
-
-User-scope destinations (when "User profile" was chosen):
-
-| Artifact    | Path                                                                             |
-| ----------- | -------------------------------------------------------------------------------- |
-| Agent Skill | `~/.copilot/skills/<slug>/SKILL.md`                                              |
-| MCP         | merge into the user-level `mcp.json` (created/edited via VS Code Settings → MCP) |
 
 Rules:
 
-- Always pass the full **CID** (or `name[:version]`) to `dirctl export`,
-  not the truncated CID shown in the grid. Use the internal map from
-  Step 2.
-- Run exports **sequentially** to keep output readable.
-- If one export fails, continue with the rest and record the failure in
-  the summary table.
-- After writing a `SKILL.md`, verify its `name:` frontmatter equals the
-  folder slug. If `dirctl` emits a mismatched name, rewrite the `name:`
-  field — mismatch is the most common silent discovery failure.
-- For MCP merges: read existing `.vscode/mcp.json`, add the new entry
-  under `servers` without removing siblings, write back with stable key
-  order. Create the file with `{"servers": {…}}` if it doesn't exist.
+- Ask the user for the install scope (workspace vs user profile) when the
+  host supports both.
+- If `agntcy-dir` is already installed, confirm before overwriting it.
+- Verify the install: the destination must contain `SKILL.md` and all seven
+  `references/*.md` files; report the written paths.
 
-### Step 5 — Report
+## After installing
 
-Emit a final Markdown table:
-
-| #   | Name | Format | Path | Status |
-| --- | ---- | ------ | ---- | ------ |
-
-Status is one of: `created`, `merged`, `skipped (already present)`,
-`failed: <reason>`. Make every `Path` cell a clickable Markdown link.
-
-If any MCP servers were installed, remind the user to reload them via
-**Command Palette → "MCP: List Servers" → restart**.
-
----
-
-## Worked Example
-
-User: _"find me MCP servers for github issues"_
-
-1. Translate → `dirctl search --module "integration/mcp" --name "*github*" --limit 25 --format record --output json`.
-2. Render top 10 matches as the 7-column grid (Artifacts column = `MCP`).
-3. Popup → user picks rows #1 and #3, scope = Workspace.
-4. For each: `dirctl export <cid> --format=mcp-ghcopilot --output-file=/tmp/x.json`, then merge into `.vscode/mcp.json`.
-5. Final summary table + reload hint.
-
----
-
-## Quality Bar
-
-- Never fabricate CIDs, names, versions, or ratings — every value must
-  come from real `dirctl search` output (rating is computed from those
-  values, not invented).
-- Never run `dirctl export` without a confirmed CID from the popup.
-- Always honor the user's scope answer.
-- Quote every shell argument; record names contain `/` and `:`.
-- A skill's `name:` field MUST equal the folder slug.
-
-## Anti-patterns
-
-- Hard-coding example records into the grid instead of parsing real
-  search output.
-- Asking the user to type a CID when an `ask-questions` popup is
-  available.
-- Overwriting `.vscode/mcp.json` instead of merging.
-- Presenting the rating as authoritative — always label it a heuristic.
-- Promising webviews or native VS Code dialogs the chat cannot render.
-
-## References
-
-- `dirctl search --help`, `dirctl export --help`
-- [Agent Skills docs](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
-- [VS Code MCP servers](https://code.visualstudio.com/docs/copilot/chat/mcp-servers)
+Reload skills if the host requires it (e.g. start a new chat turn or restart
+the session), then handle the user's Directory request by following the
+installed skill — not this bootstrap.


### PR DESCRIPTION
This PR adds integration-aware DIR agent skill to enable agentic development usage across environments like IDEs and consoles. 