### PR TITLE
ci(license): skip license cache warm-up when cache is already hit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,7 @@ jobs:
         uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Setup license cache
+        id: license-cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
@@ -125,6 +126,7 @@ jobs:
             license-cache-${{ runner.os }}-
 
       - name: License cache
+        if: steps.license-cache.outputs.cache-hit != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
The `license:cache` step in the CI license job was running unconditionally on every PR — even when the `actions/cache` restore was a full hit and all `.licensei.cache` files were already up to date. This meant `licensei cache` was invoked sequentially across all Go modules for no reason, adding unnecessary minutes to the job. A good example of this happening is [this run on PR #1708](https://github.com/agntcy/dir/actions/runs/28238424981/job/83658870541), where no dependencies were changed but the cache warm-up step still ran in full.

The fix adds an `id` to the cache restore step so its `cache-hit` output can be referenced, then gates the warm-up step behind `if: steps.license-cache.outputs.cache-hit != 'true'`. When the cache is cold (e.g. after a `go.sum` change), behavior is unchanged.