### PR TITLE
chore(docs): updating copyright message

### DIFF
--- a/docs/content/stylesheets/agntcy-docs.css
+++ b/docs/content/stylesheets/agntcy-docs.css
@@ -257,6 +257,14 @@
   background-color: var(--md-footer-bg-color);
 }
 
+.md-copyright--centered,
+.md-copyright--centered .md-copyright__highlight {
+  width: 100%;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--light);
+}
+
 .md-footer__link {
   color: var(--md-default-fg-color);
 }

--- a/docs/mkdocs/mkdocs.yml
+++ b/docs/mkdocs/mkdocs.yml
@@ -25,8 +25,7 @@ extra:
     org: AGNTCY
 
   copyright: >
-    © Copyright AGNTCY Contributors.
-    <a href="#__consent">Change cookie settings</a>
+    © 2026, Agntcy, a Series of LF Projects, LLC. All rights reserved.
   analytics:
     provider: google
     property: G-H5NVFB80VS
@@ -157,7 +156,6 @@ theme:
     - content.code.copy
     - content.tabs.link
     - content.tooltips
-    - navigation.footer
     - navigation.indexes
     - navigation.path
     - navigation.sections

--- a/docs/mkdocs/overrides/partials/copyright.html
+++ b/docs/mkdocs/overrides/partials/copyright.html
@@ -1,3 +1,5 @@
-<div style="text-align: center; font-size: 0.75rem; margin-top: 1rem; color: var(--md-default-fg-color--light);">
-  {{ config.extra.copyright }}
+<div class="md-copyright md-copyright--centered">
+  <div class="md-copyright__highlight">
+    {{ config.extra.copyright }}
+  </div>
 </div>


### PR DESCRIPTION
This PR updates the copyright message in the docs site.

<img width="3240" height="1732" alt="image" src="https://github.com/user-attachments/assets/3034d6f5-169e-48b7-b1eb-1d6b05b2f244" />
