### PR TITLE
feat(dir): extract skill bundles on batch export

### DIFF
--- a/api/exportfmt/exportfmt_test.go
+++ b/api/exportfmt/exportfmt_test.go
@@ -9,6 +9,8 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	oasfv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1alpha1"
@@ -369,6 +371,39 @@ func TestSkillBundleFormatter_FileExtension(t *testing.T) {
 	f, err := exportfmt.GetFormatter("agent-skill-bundle")
 	require.NoError(t, err)
 	assert.Equal(t, ".gzip", f.FileExtension())
+}
+
+func TestExtractSkillBundleArchive(t *testing.T) {
+	t.Run("extracts gzip tar archive", func(t *testing.T) {
+		dir := t.TempDir()
+		archive, err := base64.StdEncoding.DecodeString(skillBundleArchiveBase64(t))
+		require.NoError(t, err)
+
+		require.NoError(t, exportfmt.ExtractSkillBundleArchive(archive, dir))
+
+		data, err := os.ReadFile(filepath.Join(dir, "SKILL.md"))
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "name: code-review")
+	})
+
+	t.Run("rejects path traversal", func(t *testing.T) {
+		dir := t.TempDir()
+
+		var buf bytes.Buffer
+
+		gzipWriter := gzip.NewWriter(&buf)
+		tarWriter := tar.NewWriter(gzipWriter)
+		header := &tar.Header{Name: "../escape.txt", Mode: 0o600, Size: 4, Typeflag: tar.TypeReg}
+		require.NoError(t, tarWriter.WriteHeader(header))
+		_, err := tarWriter.Write([]byte("evil"))
+		require.NoError(t, err)
+		require.NoError(t, tarWriter.Close())
+		require.NoError(t, gzipWriter.Close())
+
+		err = exportfmt.ExtractSkillBundleArchive(buf.Bytes(), dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-local")
+	})
 }
 
 func TestMCPGHCopilotFormatter_Format(t *testing.T) {

--- a/api/exportfmt/skill_bundle_extract.go
+++ b/api/exportfmt/skill_bundle_extract.go
@@ -1,0 +1,136 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package exportfmt
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// ExtractSkillBundleArchive unpacks a gzip-compressed tar skill bundle into destDir.
+func ExtractSkillBundleArchive(archive []byte, destDir string) error {
+	if len(archive) == 0 {
+		return fmt.Errorf("skill bundle archive is empty")
+	}
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil { //nolint:mnd
+		return fmt.Errorf("create destination directory: %w", err)
+	}
+
+	root, err := os.OpenRoot(destDir)
+	if err != nil {
+		return fmt.Errorf("open destination directory: %w", err)
+	}
+	defer root.Close()
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return fmt.Errorf("invalid gzip archive: %w", err)
+	}
+	defer gzipReader.Close()
+
+	tarReader := tar.NewReader(gzipReader)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return fmt.Errorf("read tar entry: %w", err)
+		}
+
+		if err := extractTarEntry(tarReader, header, root); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func extractTarEntry(tarReader *tar.Reader, header *tar.Header, root *os.Root) error {
+	rel, err := localTarEntryPath(header.Name)
+	if err != nil {
+		return fmt.Errorf("invalid tar entry %q: %w", header.Name, err)
+	}
+
+	switch header.Typeflag {
+	case tar.TypeDir:
+		if err := root.MkdirAll(rel, dirPerm(header)); err != nil {
+			return fmt.Errorf("create directory %q: %w", header.Name, err)
+		}
+
+		return nil
+	case tar.TypeReg:
+		if parent := filepath.Dir(rel); parent != "." {
+			if err := root.MkdirAll(parent, 0o755); err != nil { //nolint:mnd
+				return fmt.Errorf("create parent directory for %q: %w", header.Name, err)
+			}
+		}
+
+		file, err := root.OpenFile(rel, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, filePerm(header))
+		if err != nil {
+			return fmt.Errorf("create file %q: %w", header.Name, err)
+		}
+
+		reader := io.Reader(tarReader)
+		if header.Size >= 0 {
+			reader = io.LimitReader(tarReader, header.Size)
+		}
+
+		if _, err := io.Copy(file, reader); err != nil {
+			_ = file.Close()
+
+			return fmt.Errorf("write file %q: %w", header.Name, err)
+		}
+
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("close file %q: %w", header.Name, err)
+		}
+
+		return nil
+	default:
+		return nil
+	}
+}
+
+func localTarEntryPath(name string) (string, error) {
+	rel := filepath.FromSlash(name)
+	if rel == "" {
+		return "", fmt.Errorf("empty tar path")
+	}
+
+	if !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("non-local tar path")
+	}
+
+	return rel, nil
+}
+
+func dirPerm(hdr *tar.Header) os.FileMode {
+	return tarEntryPerm(hdr.Mode, 0o755) //nolint:mnd
+}
+
+func filePerm(hdr *tar.Header) os.FileMode {
+	return tarEntryPerm(hdr.Mode, 0o600) //nolint:mnd
+}
+
+func tarEntryPerm(mode int64, defaultPerm os.FileMode) os.FileMode {
+	if mode == 0 {
+		return defaultPerm
+	}
+
+	perm := mode & 0o777          //nolint:mnd
+	if perm < 0 || perm > 0o777 { //nolint:mnd
+		return defaultPerm
+	}
+
+	return os.FileMode(uint32(perm))
+}

--- a/cli/cmd/export/batch.go
+++ b/cli/cmd/export/batch.go
@@ -122,7 +122,31 @@ func (f *skillBundleBatchExporter) FormatBatch(records []*corev1.Record, outputD
 		return 0, fmt.Errorf("failed to get agent-skill-bundle formatter: %w", err)
 	}
 
-	return defaultBatchExport(formatter, records, outputDir, allVersions)
+	toExport := records
+	if !allVersions {
+		toExport = recordutil.LatestByName(records)
+	}
+
+	exported := 0
+	seen := make(map[string]int)
+
+	for i, record := range toExport {
+		base := recordutil.BatchFileName(record, i, seen, allVersions)
+
+		archive, err := formatter.Format(record)
+		if err != nil {
+			return exported, fmt.Errorf("failed to format skill bundle %q: %w", base, err)
+		}
+
+		skillDir := filepath.Join(outputDir, base)
+		if err := exportfmt.ExtractSkillBundleArchive(archive, skillDir); err != nil {
+			return exported, fmt.Errorf("failed to extract skill bundle %q: %w", base, err)
+		}
+
+		exported++
+	}
+
+	return exported, nil
 }
 
 // --- mcp batch ---

--- a/cli/cmd/export/batch_test.go
+++ b/cli/cmd/export/batch_test.go
@@ -4,6 +4,10 @@
 package export
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -292,12 +296,26 @@ func TestDefaultBatchExport(t *testing.T) {
 }
 
 func TestSkillBatchFormatter(t *testing.T) {
-	bf := getBatchFormatter("agent-skill")
-	require.NotNil(t, bf, "agent-skill should have a batch formatter")
+	testSkillDirectoryBatchFormatter(t, "agent-skill", newSkillTestRecord)
+}
+
+func TestSkillBundleBatchFormatter(t *testing.T) {
+	testSkillDirectoryBatchFormatter(t, "agent-skill-bundle", newSkillBundleTestRecord)
+}
+
+func testSkillDirectoryBatchFormatter(
+	t *testing.T,
+	formatName string,
+	newRecord func(t *testing.T) *corev1.Record,
+) {
+	t.Helper()
+
+	bf := getBatchFormatter(formatName)
+	require.NotNil(t, bf, "%s should have a batch formatter", formatName)
 
 	t.Run("uses name only by default", func(t *testing.T) {
 		dir := t.TempDir()
-		records := []*corev1.Record{newSkillTestRecord(t)}
+		records := []*corev1.Record{newRecord(t)}
 
 		n, err := bf.FormatBatch(records, dir, false)
 		require.NoError(t, err)
@@ -311,7 +329,7 @@ func TestSkillBatchFormatter(t *testing.T) {
 
 	t.Run("all-versions includes version in directory name", func(t *testing.T) {
 		dir := t.TempDir()
-		records := []*corev1.Record{newSkillTestRecord(t)}
+		records := []*corev1.Record{newRecord(t)}
 
 		n, err := bf.FormatBatch(records, dir, true)
 		require.NoError(t, err)
@@ -359,6 +377,39 @@ func TestMCPGHCopilotBatchFormatter(t *testing.T) {
 		require.NoError(t, json.Unmarshal(data, &parsed))
 		assert.Empty(t, parsed["servers"])
 	})
+}
+
+func newSkillBundleTestRecord(t *testing.T) *corev1.Record {
+	t.Helper()
+
+	skillInput, err := structpb.NewStruct(map[string]any{
+		"skillMarkdown": testSkillMarkdown,
+		"skillArchive":  skillBundleArchiveBase64(t),
+	})
+	require.NoError(t, err)
+
+	recordStruct, err := translator.SkillBundleToRecord(skillInput)
+	require.NoError(t, err)
+
+	return &corev1.Record{Data: recordStruct}
+}
+
+func skillBundleArchiveBase64(t *testing.T) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	content := []byte(testSkillMarkdown)
+	hdr := &tar.Header{Name: "SKILL.md", Mode: 0o600, Size: int64(len(content))}
+	require.NoError(t, tw.WriteHeader(hdr))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	return base64.StdEncoding.EncodeToString(buf.Bytes())
 }
 
 func TestRecordGetName(t *testing.T) {

--- a/cli/cmd/export/export.go
+++ b/cli/cmd/export/export.go
@@ -46,6 +46,7 @@ Batch export from search results:
 
   dirctl export --output-dir=./exports/ --format=a2a --name "web*"
   dirctl export --output-dir=./exports/ --format=agent-skill --skill "code*"
+  dirctl export --output-dir=./exports/ --format=agent-skill-bundle --skill "code*"
   dirctl export --output-dir=./exports/ --format=mcp-ghcopilot --module "integration/mcp"
 `,
 	Args: cobra.MaximumNArgs(1),


### PR DESCRIPTION
When batch exporting (using the `--output-dir` flag), automatically extract the Agent Skill bundles into the directory from .gzip files.