### PR TITLE
feat(cli): dirctl install

### DIFF
--- a/cli/cmd/install/apply.go
+++ b/cli/cmd/install/apply.go
@@ -11,13 +11,13 @@ import (
 
 // runInstall applies the record's artifacts to the selected agents, one outcome
 // per touched artifact. Errors on one agent never abort the rest.
-func runInstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
+func runInstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, dryRun bool) []agentcfg.Outcome {
 	var outcomes []agentcfg.Outcome
 
 	seenSkill := map[string]bool{}
 
 	for _, agent := range agents {
-		if set.MCP && agent.MCP != nil {
+		if agent.MCP != nil {
 			for _, srv := range arts.mcpServers {
 				entry := styleEntry(srv.entry, agent.MCP.EntryStyle)
 				o, _ := agentcfg.InstallMCP(agent.MCP, env, entry, srv.name, dryRun)
@@ -26,7 +26,7 @@ func runInstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, set a
 			}
 		}
 
-		if set.Skill && agent.Skill != nil && arts.skill != "" {
+		if agent.Skill != nil && arts.skill != "" {
 			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
 				continue
 			}
@@ -41,13 +41,13 @@ func runInstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, set a
 }
 
 // runUninstall removes the record's artifacts from the selected agents.
-func runUninstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
+func runUninstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, dryRun bool) []agentcfg.Outcome {
 	var outcomes []agentcfg.Outcome
 
 	seenSkill := map[string]bool{}
 
 	for _, agent := range agents {
-		if set.MCP && agent.MCP != nil {
+		if agent.MCP != nil {
 			for _, srv := range arts.mcpServers {
 				o, _ := agentcfg.RemoveMCP(agent.MCP, env, srv.name, dryRun)
 				o.Agent = agent.Name
@@ -55,7 +55,7 @@ func runUninstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, set
 			}
 		}
 
-		if set.Skill && agent.Skill != nil && arts.skill != "" {
+		if agent.Skill != nil && arts.skill != "" {
 			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
 				continue
 			}

--- a/cli/cmd/install/apply.go
+++ b/cli/cmd/install/apply.go
@@ -1,0 +1,100 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"maps"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+)
+
+// runInstall applies the record's artifacts to the selected agents, one outcome
+// per touched artifact. Errors on one agent never abort the rest.
+func runInstall(env agentcfg.Env, arts artifacts, sels []agentcfg.Selection, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
+	var outcomes []agentcfg.Outcome
+
+	seenSkill := map[string]bool{}
+
+	for _, sel := range sels {
+		if set.MCP && sel.Agent.MCP != nil {
+			for _, srv := range arts.mcpServers {
+				entry := styleEntry(srv.entry, sel.Agent.MCP.EntryStyle)
+				o, _ := agentcfg.InstallMCP(sel.Agent.MCP, env, entry, srv.name, dryRun)
+				o.Agent = sel.Agent.Name
+				outcomes = append(outcomes, o)
+			}
+		}
+
+		if set.Skill && sel.Agent.Skill != nil && arts.skill != "" {
+			if dedupeSkill(seenSkill, sel.Agent.Skill, env, arts.slug) {
+				continue
+			}
+
+			o, _ := agentcfg.InstallSkill(sel.Agent.Skill, env, arts.slug, arts.skill, dryRun)
+			o.Agent = sel.Agent.Name
+			outcomes = append(outcomes, o)
+		}
+	}
+
+	return outcomes
+}
+
+// runUninstall removes the record's artifacts from the selected agents.
+func runUninstall(env agentcfg.Env, arts artifacts, sels []agentcfg.Selection, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
+	var outcomes []agentcfg.Outcome
+
+	seenSkill := map[string]bool{}
+
+	for _, sel := range sels {
+		if set.MCP && sel.Agent.MCP != nil {
+			for _, srv := range arts.mcpServers {
+				o, _ := agentcfg.RemoveMCP(sel.Agent.MCP, env, srv.name, dryRun)
+				o.Agent = sel.Agent.Name
+				outcomes = append(outcomes, o)
+			}
+		}
+
+		if set.Skill && sel.Agent.Skill != nil && arts.skill != "" {
+			if dedupeSkill(seenSkill, sel.Agent.Skill, env, arts.slug) {
+				continue
+			}
+
+			o, _ := agentcfg.RemoveSkill(sel.Agent.Skill, env, arts.slug, dryRun)
+			o.Agent = sel.Agent.Name
+			outcomes = append(outcomes, o)
+		}
+	}
+
+	return outcomes
+}
+
+// styleEntry clones base and applies agent-specific entry shaping (Zed adds a
+// "source" field to its context_servers value).
+func styleEntry(base map[string]any, style agentcfg.EntryStyle) map[string]any {
+	entry := make(map[string]any, len(base)+1)
+	maps.Copy(entry, base)
+
+	if style == agentcfg.ZedContextServer {
+		entry["source"] = "custom"
+	}
+
+	return entry
+}
+
+// dedupeSkill reports whether a skill target's resolved path was already acted on
+// this run (e.g. Claude Code and Claude Desktop share one skills folder).
+func dedupeSkill(seen map[string]bool, target *agentcfg.SkillTarget, env agentcfg.Env, slug string) bool {
+	path, _, err := agentcfg.ResolveSkillTargetPath(target, env, slug)
+	if err != nil || path == "" {
+		return false
+	}
+
+	if seen[path] {
+		return true
+	}
+
+	seen[path] = true
+
+	return false
+}

--- a/cli/cmd/install/apply.go
+++ b/cli/cmd/install/apply.go
@@ -11,28 +11,28 @@ import (
 
 // runInstall applies the record's artifacts to the selected agents, one outcome
 // per touched artifact. Errors on one agent never abort the rest.
-func runInstall(env agentcfg.Env, arts artifacts, sels []agentcfg.Selection, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
+func runInstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
 	var outcomes []agentcfg.Outcome
 
 	seenSkill := map[string]bool{}
 
-	for _, sel := range sels {
-		if set.MCP && sel.Agent.MCP != nil {
+	for _, agent := range agents {
+		if set.MCP && agent.MCP != nil {
 			for _, srv := range arts.mcpServers {
-				entry := styleEntry(srv.entry, sel.Agent.MCP.EntryStyle)
-				o, _ := agentcfg.InstallMCP(sel.Agent.MCP, env, entry, srv.name, dryRun)
-				o.Agent = sel.Agent.Name
+				entry := styleEntry(srv.entry, agent.MCP.EntryStyle)
+				o, _ := agentcfg.InstallMCP(agent.MCP, env, entry, srv.name, dryRun)
+				o.Agent = agent.Name
 				outcomes = append(outcomes, o)
 			}
 		}
 
-		if set.Skill && sel.Agent.Skill != nil && arts.skill != "" {
-			if dedupeSkill(seenSkill, sel.Agent.Skill, env, arts.slug) {
+		if set.Skill && agent.Skill != nil && arts.skill != "" {
+			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
 				continue
 			}
 
-			o, _ := agentcfg.InstallSkill(sel.Agent.Skill, env, arts.slug, arts.skill, dryRun)
-			o.Agent = sel.Agent.Name
+			o, _ := agentcfg.InstallSkill(agent.Skill, env, arts.slug, arts.skill, dryRun)
+			o.Agent = agent.Name
 			outcomes = append(outcomes, o)
 		}
 	}
@@ -41,27 +41,27 @@ func runInstall(env agentcfg.Env, arts artifacts, sels []agentcfg.Selection, set
 }
 
 // runUninstall removes the record's artifacts from the selected agents.
-func runUninstall(env agentcfg.Env, arts artifacts, sels []agentcfg.Selection, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
+func runUninstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, set agentcfg.ArtifactSet, dryRun bool) []agentcfg.Outcome {
 	var outcomes []agentcfg.Outcome
 
 	seenSkill := map[string]bool{}
 
-	for _, sel := range sels {
-		if set.MCP && sel.Agent.MCP != nil {
+	for _, agent := range agents {
+		if set.MCP && agent.MCP != nil {
 			for _, srv := range arts.mcpServers {
-				o, _ := agentcfg.RemoveMCP(sel.Agent.MCP, env, srv.name, dryRun)
-				o.Agent = sel.Agent.Name
+				o, _ := agentcfg.RemoveMCP(agent.MCP, env, srv.name, dryRun)
+				o.Agent = agent.Name
 				outcomes = append(outcomes, o)
 			}
 		}
 
-		if set.Skill && sel.Agent.Skill != nil && arts.skill != "" {
-			if dedupeSkill(seenSkill, sel.Agent.Skill, env, arts.slug) {
+		if set.Skill && agent.Skill != nil && arts.skill != "" {
+			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
 				continue
 			}
 
-			o, _ := agentcfg.RemoveSkill(sel.Agent.Skill, env, arts.slug, dryRun)
-			o.Agent = sel.Agent.Name
+			o, _ := agentcfg.RemoveSkill(agent.Skill, env, arts.slug, dryRun)
+			o.Agent = agent.Name
 			outcomes = append(outcomes, o)
 		}
 	}

--- a/cli/cmd/install/apply_test.go
+++ b/cli/cmd/install/apply_test.go
@@ -38,10 +38,10 @@ func TestRunInstallWritesMCPEntryIdempotently(t *testing.T) {
 		}},
 	}
 	agent := agentcfg.Agent{Name: "Claude Code", MCP: target}
-	sels := []agentcfg.Selection{{Agent: agent, Forced: true}}
+	agents := []agentcfg.Agent{agent}
 	set := agentcfg.ArtifactSet{MCP: true}
 
-	first := runInstall(env, arts, sels, set, false)
+	first := runInstall(env, arts, agents, set, false)
 	require.Len(t, first, 1)
 	require.Equal(t, agentcfg.ActionAdded, first[0].Action)
 
@@ -53,7 +53,7 @@ func TestRunInstallWritesMCPEntryIdempotently(t *testing.T) {
 	_, present := codec.GetNested(m, "mcpServers", "code-review")
 	require.True(t, present)
 
-	second := runInstall(env, arts, sels, set, false)
+	second := runInstall(env, arts, agents, set, false)
 	require.Len(t, second, 1)
 	require.Equal(t, agentcfg.ActionUnchanged, second[0].Action)
 }
@@ -78,10 +78,10 @@ func TestRunInstallWritesSkill(t *testing.T) {
 		skill: "---\nname: code-review\ndescription: x\n---\n\nbody\n",
 	}
 	agent := agentcfg.Agent{Name: "Claude Code", Skill: target}
-	sels := []agentcfg.Selection{{Agent: agent, Forced: true}}
+	agents := []agentcfg.Agent{agent}
 	set := agentcfg.ArtifactSet{Skill: true}
 
-	outcomes := runInstall(env, arts, sels, set, false)
+	outcomes := runInstall(env, arts, agents, set, false)
 	require.Len(t, outcomes, 1)
 	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
 
@@ -115,13 +115,13 @@ func TestRunInstallDedupesSharedSkillPath(t *testing.T) {
 		slug:  "code-review",
 		skill: "---\nname: code-review\ndescription: x\n---\n\nbody\n",
 	}
-	sels := []agentcfg.Selection{
-		{Agent: agentcfg.Agent{Name: "Claude Code", Skill: claudeCode}, Forced: true},
-		{Agent: agentcfg.Agent{Name: "Claude Desktop", Skill: claudeDesktop}, Forced: true},
+	agents := []agentcfg.Agent{
+		{Name: "Claude Code", Skill: claudeCode},
+		{Name: "Claude Desktop", Skill: claudeDesktop},
 	}
 	set := agentcfg.ArtifactSet{Skill: true}
 
-	outcomes := runInstall(env, arts, sels, set, false)
+	outcomes := runInstall(env, arts, agents, set, false)
 
 	// Both agents resolve to the same skills path, so dedupeSkill collapses the
 	// shared target to a single skill outcome.

--- a/cli/cmd/install/apply_test.go
+++ b/cli/cmd/install/apply_test.go
@@ -1,0 +1,130 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/internal/agentcfg/codec"
+	"github.com/stretchr/testify/require"
+)
+
+const claudeCodeID = "claude-code"
+
+func TestRunInstallWritesMCPEntryIdempotently(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	// Claude Code MCP target: ~/.claude.json, key mcpServers.
+	var target *agentcfg.MCPTarget
+
+	for _, a := range agentcfg.Registry() {
+		if a.ID == claudeCodeID {
+			target = a.MCP
+		}
+	}
+
+	require.NotNil(t, target)
+
+	arts := artifacts{
+		slug: "code-review",
+		mcpServers: []mcpServer{{
+			name:  "code-review",
+			entry: map[string]any{"command": "npx", "args": []any{"x"}, "env": map[string]any{}},
+		}},
+	}
+	agent := agentcfg.Agent{Name: "Claude Code", MCP: target}
+	sels := []agentcfg.Selection{{Agent: agent, Forced: true}}
+	set := agentcfg.ArtifactSet{MCP: true}
+
+	first := runInstall(env, arts, sels, set, false)
+	require.Len(t, first, 1)
+	require.Equal(t, agentcfg.ActionAdded, first[0].Action)
+
+	raw, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	require.NoError(t, err)
+	m, err := codec.Decode(codec.JSON, raw)
+	require.NoError(t, err)
+
+	_, present := codec.GetNested(m, "mcpServers", "code-review")
+	require.True(t, present)
+
+	second := runInstall(env, arts, sels, set, false)
+	require.Len(t, second, 1)
+	require.Equal(t, agentcfg.ActionUnchanged, second[0].Action)
+}
+
+func TestRunInstallWritesSkill(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	// Claude Code skill target: SkillFolder under ~/.claude/skills/<slug>/SKILL.md.
+	var target *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		if a.ID == claudeCodeID {
+			target = a.Skill
+		}
+	}
+
+	require.NotNil(t, target)
+
+	arts := artifacts{
+		slug:  "code-review",
+		skill: "---\nname: code-review\ndescription: x\n---\n\nbody\n",
+	}
+	agent := agentcfg.Agent{Name: "Claude Code", Skill: target}
+	sels := []agentcfg.Selection{{Agent: agent, Forced: true}}
+	set := agentcfg.ArtifactSet{Skill: true}
+
+	outcomes := runInstall(env, arts, sels, set, false)
+	require.Len(t, outcomes, 1)
+	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
+
+	skillFile := filepath.Join(home, ".claude", "skills", "code-review", "SKILL.md")
+	raw, err := os.ReadFile(skillFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+}
+
+func TestRunInstallDedupesSharedSkillPath(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	// Claude Code and Claude Desktop share the same skills folder
+	// (claude-desktop's Skill.Path resolves to claude-code's path via SharedWith).
+	var claudeCode, claudeDesktop *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		switch a.ID {
+		case claudeCodeID:
+			claudeCode = a.Skill
+		case "claude-desktop":
+			claudeDesktop = a.Skill
+		}
+	}
+
+	require.NotNil(t, claudeCode)
+	require.NotNil(t, claudeDesktop)
+
+	arts := artifacts{
+		slug:  "code-review",
+		skill: "---\nname: code-review\ndescription: x\n---\n\nbody\n",
+	}
+	sels := []agentcfg.Selection{
+		{Agent: agentcfg.Agent{Name: "Claude Code", Skill: claudeCode}, Forced: true},
+		{Agent: agentcfg.Agent{Name: "Claude Desktop", Skill: claudeDesktop}, Forced: true},
+	}
+	set := agentcfg.ArtifactSet{Skill: true}
+
+	outcomes := runInstall(env, arts, sels, set, false)
+
+	// Both agents resolve to the same skills path, so dedupeSkill collapses the
+	// shared target to a single skill outcome.
+	require.Len(t, outcomes, 1)
+	require.Equal(t, "skill", outcomes[0].Artifact)
+}

--- a/cli/cmd/install/apply_test.go
+++ b/cli/cmd/install/apply_test.go
@@ -39,9 +39,8 @@ func TestRunInstallWritesMCPEntryIdempotently(t *testing.T) {
 	}
 	agent := agentcfg.Agent{Name: "Claude Code", MCP: target}
 	agents := []agentcfg.Agent{agent}
-	set := agentcfg.ArtifactSet{MCP: true}
 
-	first := runInstall(env, arts, agents, set, false)
+	first := runInstall(env, arts, agents, false)
 	require.Len(t, first, 1)
 	require.Equal(t, agentcfg.ActionAdded, first[0].Action)
 
@@ -53,7 +52,7 @@ func TestRunInstallWritesMCPEntryIdempotently(t *testing.T) {
 	_, present := codec.GetNested(m, "mcpServers", "code-review")
 	require.True(t, present)
 
-	second := runInstall(env, arts, agents, set, false)
+	second := runInstall(env, arts, agents, false)
 	require.Len(t, second, 1)
 	require.Equal(t, agentcfg.ActionUnchanged, second[0].Action)
 }
@@ -79,9 +78,8 @@ func TestRunInstallWritesSkill(t *testing.T) {
 	}
 	agent := agentcfg.Agent{Name: "Claude Code", Skill: target}
 	agents := []agentcfg.Agent{agent}
-	set := agentcfg.ArtifactSet{Skill: true}
 
-	outcomes := runInstall(env, arts, agents, set, false)
+	outcomes := runInstall(env, arts, agents, false)
 	require.Len(t, outcomes, 1)
 	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
 
@@ -119,9 +117,8 @@ func TestRunInstallDedupesSharedSkillPath(t *testing.T) {
 		{Name: "Claude Code", Skill: claudeCode},
 		{Name: "Claude Desktop", Skill: claudeDesktop},
 	}
-	set := agentcfg.ArtifactSet{Skill: true}
 
-	outcomes := runInstall(env, arts, agents, set, false)
+	outcomes := runInstall(env, arts, agents, false)
 
 	// Both agents resolve to the same skills path, so dedupeSkill collapses the
 	// shared target to a single skill outcome.

--- a/cli/cmd/install/apply_test.go
+++ b/cli/cmd/install/apply_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/agntcy/dir/cli/internal/agentcfg/codec"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -87,6 +88,99 @@ func TestRunInstallWritesSkill(t *testing.T) {
 	raw, err := os.ReadFile(skillFile)
 	require.NoError(t, err)
 	require.NotEmpty(t, raw)
+}
+
+func TestStyleEntryZedContextServerAddSource(t *testing.T) {
+	base := map[string]any{"command": "dirctl", "args": []any{"mcp", "serve"}}
+	got := styleEntry(base, agentcfg.ZedContextServer)
+
+	assert.Equal(t, "custom", got["source"])
+	assert.Equal(t, "dirctl", got["command"])
+
+	// Must not mutate the original.
+	_, hadSource := base["source"]
+	assert.False(t, hadSource, "styleEntry must not mutate the input map")
+}
+
+func TestStyleEntryCommandArgsEnvUnchanged(t *testing.T) {
+	base := map[string]any{"command": "dirctl", "args": []any{"mcp", "serve"}}
+	got := styleEntry(base, agentcfg.CommandArgsEnv)
+
+	_, hasSource := got["source"]
+	assert.False(t, hasSource, "CommandArgsEnv must not add a source field")
+	assert.Equal(t, "dirctl", got["command"])
+}
+
+func TestRunUninstallRemovesMCPEntryAndPreservesSibling(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	var mcpTarget *agentcfg.MCPTarget
+
+	for _, a := range agentcfg.Registry() {
+		if a.ID == claudeCodeID {
+			mcpTarget = a.MCP
+		}
+	}
+
+	require.NotNil(t, mcpTarget)
+
+	// First install both our server and a sibling.
+	path, err := mcpTarget.ConfigPath(env)
+	require.NoError(t, err)
+
+	initialJSON := []byte(`{"mcpServers":{"agntcy-dir-mcp":{"command":"dirctl"},"sibling":{"command":"node"}}}`)
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, initialJSON, 0o600))
+
+	arts := artifacts{
+		slug: "agntcy-dir",
+		mcpServers: []mcpServer{{
+			name:  "agntcy-dir-mcp",
+			entry: map[string]any{"command": "dirctl"},
+		}},
+	}
+	agent := agentcfg.Agent{Name: "Claude Code", MCP: mcpTarget}
+	outcomes := runUninstall(env, arts, []agentcfg.Agent{agent}, false)
+	require.Len(t, outcomes, 1)
+	require.Equal(t, agentcfg.ActionRemoved, outcomes[0].Action)
+
+	// Sibling must survive.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	require.Contains(t, string(raw), "sibling")
+	require.NotContains(t, string(raw), "agntcy-dir-mcp")
+}
+
+func TestRunUninstallRemovesSkill(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	var skillTarget *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		if a.ID == claudeCodeID {
+			skillTarget = a.Skill
+		}
+	}
+
+	require.NotNil(t, skillTarget)
+
+	arts := artifacts{
+		slug:  "code-review",
+		skill: "---\nname: code-review\ndescription: x\n---\n\nbody\n",
+	}
+	agent := agentcfg.Agent{Name: "Claude Code", Skill: skillTarget}
+
+	// Install first.
+	runInstall(env, arts, []agentcfg.Agent{agent}, false)
+
+	// Uninstall.
+	outcomes := runUninstall(env, arts, []agentcfg.Agent{agent}, false)
+	require.Len(t, outcomes, 1)
+	require.Equal(t, agentcfg.ActionRemoved, outcomes[0].Action)
 }
 
 func TestRunInstallDedupesSharedSkillPath(t *testing.T) {

--- a/cli/cmd/install/derive.go
+++ b/cli/cmd/install/derive.go
@@ -5,6 +5,7 @@ package install
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
@@ -59,10 +60,19 @@ func deriveArtifacts(record *corev1.Record) (artifacts, error) {
 			return artifacts{}, fmt.Errorf("translate MCP module: %w", err)
 		}
 
-		for name, srv := range cfg.Servers {
+		// Sort server names so the derived order (and thus plan/summary output) is
+		// deterministic across runs; map iteration order is otherwise random.
+		names := make([]string, 0, len(cfg.Servers))
+		for name := range cfg.Servers {
+			names = append(names, name)
+		}
+
+		sort.Strings(names)
+
+		for _, name := range names {
 			arts.mcpServers = append(arts.mcpServers, mcpServer{
 				name:  name,
-				entry: mcpEntry(srv),
+				entry: mcpEntry(cfg.Servers[name]),
 			})
 		}
 	}

--- a/cli/cmd/install/derive.go
+++ b/cli/cmd/install/derive.go
@@ -1,0 +1,142 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/api/exportfmt"
+	recordutil "github.com/agntcy/oasf-sdk/pkg/record"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// mcpServer is one MCP server entry to place: the key it is stored under and the
+// {command, args, env} value (any-typed for round-trip idempotency).
+type mcpServer struct {
+	name  string
+	entry map[string]any
+}
+
+// artifacts is the set of installable artifacts derived from a record's modules.
+type artifacts struct {
+	slug       string // sanitized record name; skill folder/file + block marker id
+	skill      string // canonical SKILL.md content, empty if the record has no skill
+	mcpServers []mcpServer
+}
+
+// deriveArtifacts inspects the record's OASF modules and builds the installable
+// artifact set. A record with only integration/a2a, or with no installable
+// module, returns an error.
+func deriveArtifacts(record *corev1.Record) (artifacts, error) {
+	data := record.GetData()
+	if data == nil {
+		return artifacts{}, fmt.Errorf("record contains no data")
+	}
+
+	arts := artifacts{slug: sanitizeSlug(record.GetName())}
+
+	if ok, _ := recordutil.GetModule(data, translator.AgentSkillsModuleName); ok {
+		f, err := exportfmt.GetFormatter(exportfmt.FormatAgentSkill)
+		if err != nil {
+			return artifacts{}, fmt.Errorf("get agent-skill formatter: %w", err)
+		}
+
+		out, err := f.Format(record)
+		if err != nil {
+			return artifacts{}, fmt.Errorf("render skill: %w", err)
+		}
+
+		arts.skill = string(out)
+	}
+
+	if ok, _ := recordutil.GetModule(data, translator.MCPModuleName); ok {
+		cfg, err := translator.RecordToGHCopilot(data)
+		if err != nil {
+			return artifacts{}, fmt.Errorf("translate MCP module: %w", err)
+		}
+
+		for name, srv := range cfg.Servers {
+			arts.mcpServers = append(arts.mcpServers, mcpServer{
+				name:  name,
+				entry: mcpEntry(srv),
+			})
+		}
+	}
+
+	if arts.skill == "" && len(arts.mcpServers) == 0 {
+		if ok, _ := recordutil.GetModule(data, translator.A2AModuleName); ok {
+			return artifacts{}, fmt.Errorf(
+				"record carries an A2A AgentCard (%s), which cannot be installed into agent configs; use `dirctl export` instead",
+				translator.A2AModuleName)
+		}
+
+		return artifacts{}, fmt.Errorf(
+			"record has no installable module (found: %s); installable modules are %s and %s",
+			strings.Join(moduleNames(data), ", "),
+			translator.AgentSkillsModuleName, translator.MCPModuleName)
+	}
+
+	if arts.slug == "" {
+		return artifacts{}, fmt.Errorf("record has no name; cannot derive an install identity")
+	}
+
+	return arts, nil
+}
+
+// mcpEntry converts a translator MCP server into a config entry using any-typed
+// collections so InstallMCP's DeepEqual idempotency holds after a JSON/YAML/TOML
+// round-trip.
+func mcpEntry(srv translator.MCPServer) map[string]any {
+	args := make([]any, 0, len(srv.Args))
+	for _, a := range srv.Args {
+		args = append(args, a)
+	}
+
+	env := map[string]any{}
+	for k, v := range srv.Env {
+		env[k] = v
+	}
+
+	return map[string]any{
+		"command": srv.Command,
+		"args":    args,
+		"env":     env,
+	}
+}
+
+// moduleNames lists the module names present in the record data, for error text.
+func moduleNames(data *structpb.Struct) []string {
+	mods, ok := data.GetFields()["modules"]
+	if !ok {
+		return []string{"none"}
+	}
+
+	var names []string
+
+	for _, m := range mods.GetListValue().GetValues() {
+		if n := m.GetStructValue().GetFields()["name"]; n != nil {
+			names = append(names, n.GetStringValue())
+		}
+	}
+
+	if len(names) == 0 {
+		return []string{"none"}
+	}
+
+	return names
+}
+
+// sanitizeSlug turns a record name into a filesystem/marker-safe slug.
+func sanitizeSlug(name string) string {
+	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
+
+	// Trim leading/trailing "." as well as "-" so a name of "." or ".." (and
+	// "../../etc" after the separator replacement above) cannot escape a parent
+	// directory when the slug is used as a filesystem path component. Embedded
+	// dots (e.g. "io.example") are preserved as a single filename component.
+	return strings.Trim(r.Replace(name), "-.")
+}

--- a/cli/cmd/install/derive_test.go
+++ b/cli/cmd/install/derive_test.go
@@ -1,0 +1,79 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func loadRecord(t *testing.T, name string) *corev1.Record {
+	t.Helper()
+
+	raw, err := os.ReadFile("testdata/" + name)
+	require.NoError(t, err)
+
+	var data structpb.Struct
+	require.NoError(t, protojson.Unmarshal(raw, &data))
+
+	return &corev1.Record{Data: &data}
+}
+
+func TestDeriveSkillOnly(t *testing.T) {
+	arts, err := deriveArtifacts(loadRecord(t, "skill.json"))
+	require.NoError(t, err)
+	require.Equal(t, "code-review", arts.slug)
+	require.NotEmpty(t, arts.skill)
+	require.Empty(t, arts.mcpServers)
+}
+
+func TestDeriveMCPOnly(t *testing.T) {
+	arts, err := deriveArtifacts(loadRecord(t, "mcp.json"))
+	require.NoError(t, err)
+	require.Equal(t, "io.example-code-review-server", arts.slug)
+	require.Empty(t, arts.skill)
+	require.Len(t, arts.mcpServers, 1)
+	require.NotEmpty(t, arts.mcpServers[0].name)
+	_, isAnySlice := arts.mcpServers[0].entry["args"].([]any)
+	require.True(t, isAnySlice, "args must be []any")
+
+	_, isAnyMap := arts.mcpServers[0].entry["env"].(map[string]any)
+	require.True(t, isAnyMap, "env must be map[string]any")
+}
+
+func TestDeriveMulti(t *testing.T) {
+	arts, err := deriveArtifacts(loadRecord(t, "multi.json"))
+	require.NoError(t, err)
+	require.NotEmpty(t, arts.skill)
+	require.NotEmpty(t, arts.mcpServers)
+}
+
+func TestDeriveA2AErrors(t *testing.T) {
+	_, err := deriveArtifacts(loadRecord(t, "a2a.json"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dirctl export")
+}
+
+func TestDeriveBareErrors(t *testing.T) {
+	_, err := deriveArtifacts(loadRecord(t, "bare.json"))
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "no installable")
+}
+
+func TestSanitizeSlug(t *testing.T) {
+	require.Equal(t, "io.example-code-review-server", sanitizeSlug("io.example/code-review-server"))
+	require.Equal(t, "my-agent", sanitizeSlug("my agent"))
+
+	// Path-traversal hardening: leading/trailing dots are trimmed so a slug
+	// cannot be "." or ".." or escape a parent directory when used as a path.
+	require.Empty(t, sanitizeSlug(".."))
+	require.Empty(t, sanitizeSlug("."))
+	require.Equal(t, "etc", sanitizeSlug("../../etc"))
+}

--- a/cli/cmd/install/derive_test.go
+++ b/cli/cmd/install/derive_test.go
@@ -67,6 +67,42 @@ func TestDeriveBareErrors(t *testing.T) {
 	require.Contains(t, strings.ToLower(err.Error()), "no installable")
 }
 
+// --- moduleNames tests ---
+
+func TestModuleNamesNoModulesField(t *testing.T) {
+	// A struct with no "modules" key returns ["none"].
+	data, err := structpb.NewStruct(map[string]any{"name": "foo"})
+	require.NoError(t, err)
+
+	got := moduleNames(data)
+	require.Equal(t, []string{"none"}, got)
+}
+
+func TestModuleNamesWithModules(t *testing.T) {
+	// Build a structpb.Struct that has a modules list with named entries.
+	data, err := structpb.NewStruct(map[string]any{
+		"modules": []any{
+			map[string]any{"name": "skills"},
+			map[string]any{"name": "mcp"},
+		},
+	})
+	require.NoError(t, err)
+
+	got := moduleNames(data)
+	require.Equal(t, []string{"skills", "mcp"}, got)
+}
+
+func TestModuleNamesEmptyModulesList(t *testing.T) {
+	// modules list exists but is empty → ["none"].
+	data, err := structpb.NewStruct(map[string]any{
+		"modules": []any{},
+	})
+	require.NoError(t, err)
+
+	got := moduleNames(data)
+	require.Equal(t, []string{"none"}, got)
+}
+
 func TestSanitizeSlug(t *testing.T) {
 	require.Equal(t, "io.example-code-review-server", sanitizeSlug("io.example/code-review-server"))
 	require.Equal(t, "my-agent", sanitizeSlug("my agent"))

--- a/cli/cmd/install/flags.go
+++ b/cli/cmd/install/flags.go
@@ -1,0 +1,47 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"fmt"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/spf13/cobra"
+)
+
+// addSelectionFlags registers the shared install/uninstall flags plus one
+// per-agent selection flag, returning a map of agent ID -> flag value pointer.
+func addSelectionFlags(cmd *cobra.Command, opts *options) map[string]*bool {
+	flags := cmd.PersistentFlags()
+
+	flags.BoolVar(&opts.mcpOnly, "mcp", false, "Act only on the MCP server entry")
+	flags.BoolVar(&opts.skillOnly, "skill", false, "Act only on the skill/rules")
+	flags.BoolVar(&opts.all, "all", false, "Act on all detected agents")
+	flags.BoolVar(&opts.force, "force", false, "Create config paths even if the agent isn't detected")
+	flags.BoolVar(&opts.dryRun, "dry-run", false, "Preview changes without writing")
+	flags.BoolVarP(&opts.yes, "yes", "y", false, "Skip the confirmation prompt")
+
+	agentFlags := map[string]*bool{}
+
+	for _, agent := range agentcfg.Registry() {
+		value := new(bool)
+		agentFlags[agent.ID] = value
+		flags.BoolVar(value, agent.Flag, false, fmt.Sprintf("Target %s", agent.Name))
+	}
+
+	return agentFlags
+}
+
+// chosenFrom collects the agent IDs whose per-agent flag was set.
+func chosenFrom(agentFlags map[string]*bool) map[string]bool {
+	chosen := map[string]bool{}
+
+	for id, value := range agentFlags {
+		if *value {
+			chosen[id] = true
+		}
+	}
+
+	return chosen
+}

--- a/cli/cmd/install/flags.go
+++ b/cli/cmd/install/flags.go
@@ -20,8 +20,6 @@ const allAgents = "all"
 func addSelectionFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.PersistentFlags()
 
-	flags.BoolVar(&opts.mcpOnly, "mcp", false, "Act only on the MCP server entry")
-	flags.BoolVar(&opts.skillOnly, "skill", false, "Act only on the skill/rules")
 	flags.StringSliceVar(&opts.agents, "agents", []string{allAgents},
 		fmt.Sprintf("Agents to target: %q (default, all detected) or a comma-separated list of agent IDs (%s)",
 			allAgents, strings.Join(agentIDs(), ", ")))

--- a/cli/cmd/install/flags.go
+++ b/cli/cmd/install/flags.go
@@ -5,43 +5,72 @@ package install
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/spf13/cobra"
 )
 
-// addSelectionFlags registers the shared install/uninstall flags plus one
-// per-agent selection flag, returning a map of agent ID -> flag value pointer.
-func addSelectionFlags(cmd *cobra.Command, opts *options) map[string]*bool {
+// allAgents is the --agents sentinel selecting every detected agent.
+const allAgents = "all"
+
+// addSelectionFlags registers the shared install/uninstall flags: which agents to
+// target (--agents), which artifacts (--mcp/--skill), and the dry-run/confirm
+// flags.
+func addSelectionFlags(cmd *cobra.Command, opts *options) {
 	flags := cmd.PersistentFlags()
 
 	flags.BoolVar(&opts.mcpOnly, "mcp", false, "Act only on the MCP server entry")
 	flags.BoolVar(&opts.skillOnly, "skill", false, "Act only on the skill/rules")
-	flags.BoolVar(&opts.all, "all", false, "Act on all detected agents")
-	flags.BoolVar(&opts.force, "force", false, "Create config paths even if the agent isn't detected")
+	flags.StringSliceVar(&opts.agents, "agents", []string{allAgents},
+		fmt.Sprintf("Agents to target: %q (default, all detected) or a comma-separated list of agent IDs (%s)",
+			allAgents, strings.Join(agentIDs(), ", ")))
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Preview changes without writing")
 	flags.BoolVarP(&opts.yes, "yes", "y", false, "Skip the confirmation prompt")
-
-	agentFlags := map[string]*bool{}
-
-	for _, agent := range agentcfg.Registry() {
-		value := new(bool)
-		agentFlags[agent.ID] = value
-		flags.BoolVar(value, agent.Flag, false, fmt.Sprintf("Target %s", agent.Name))
-	}
-
-	return agentFlags
 }
 
-// chosenFrom collects the agent IDs whose per-agent flag was set.
-func chosenFrom(agentFlags map[string]*bool) map[string]bool {
-	chosen := map[string]bool{}
+// agentIDs returns the known agent IDs from the registry, for flag help and
+// validation.
+func agentIDs() []string {
+	agents := agentcfg.Registry()
+	ids := make([]string, 0, len(agents))
 
-	for id, value := range agentFlags {
-		if *value {
+	for _, a := range agents {
+		ids = append(ids, a.ID)
+	}
+
+	return ids
+}
+
+// resolveChosen validates the --agents values and returns the chosen agent-ID
+// set. An empty result means "all detected agents". It errors on an unknown ID
+// or on combining "all" with specific IDs.
+func resolveChosen(agents []string) (map[string]bool, error) {
+	valid := map[string]bool{}
+	for _, id := range agentIDs() {
+		valid[id] = true
+	}
+
+	chosen := map[string]bool{}
+	allMode := false
+
+	for _, raw := range agents {
+		id := strings.TrimSpace(raw)
+
+		switch {
+		case id == allAgents:
+			allMode = true
+		case valid[id]:
 			chosen[id] = true
+		default:
+			return nil, fmt.Errorf("unknown agent %q; valid values: %s, %s",
+				id, allAgents, strings.Join(agentIDs(), ", "))
 		}
 	}
 
-	return chosen
+	if allMode && len(chosen) > 0 {
+		return nil, fmt.Errorf("--agents: %q cannot be combined with specific agent IDs", allAgents)
+	}
+
+	return chosen, nil
 }

--- a/cli/cmd/install/flags_test.go
+++ b/cli/cmd/install/flags_test.go
@@ -1,0 +1,34 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveChosenAllMeansEmpty(t *testing.T) {
+	chosen, err := resolveChosen([]string{"all"})
+	require.NoError(t, err)
+	require.Empty(t, chosen, `"all" resolves to an empty set (all detected)`)
+}
+
+func TestResolveChosenExplicitList(t *testing.T) {
+	chosen, err := resolveChosen([]string{"claude-code", "cursor"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]bool{"claude-code": true, "cursor": true}, chosen)
+}
+
+func TestResolveChosenUnknownAgentErrors(t *testing.T) {
+	_, err := resolveChosen([]string{"cusror"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown agent")
+}
+
+func TestResolveChosenAllCombinedWithSpecificErrors(t *testing.T) {
+	_, err := resolveChosen([]string{"all", "cursor"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot be combined")
+}

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -1,0 +1,139 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/presenter"
+	ctxUtils "github.com/agntcy/dir/cli/util/context"
+	"github.com/agntcy/dir/cli/util/reference"
+	"github.com/spf13/cobra"
+)
+
+// opts and agentFlags are shared by the parent `install`, `run`, and `uninstall`
+// via persistent flags on the parent. Only one of those executes per invocation,
+// so a single shared set is correct.
+var (
+	opts       options
+	agentFlags map[string]*bool
+)
+
+// Command is the `dirctl install` parent. With a positional CID/name it runs an
+// install (equivalent to `install run`); with no argument it prints help.
+var Command = &cobra.Command{
+	Use:   "install <cid-or-name[:version][@digest]>",
+	Short: "Install a record's artifacts into detected AI coding agents",
+	Long: `Pull a record from the active Directory and install its artifacts — an MCP
+server entry and/or an Agent Skill, derived from the record's OASF modules —
+directly into the configuration of detected AI coding agents.
+
+  dirctl install <cid-or-name>            detect agents, preview, confirm, install
+  dirctl install run <cid-or-name>        same as above
+  dirctl install uninstall <cid-or-name>  remove what install added
+  dirctl install list                     show detected agents and target paths
+
+Examples:
+  dirctl install my-agent:1.0.0
+  dirctl install bafyrei... --dry-run
+  dirctl install my-agent --mcp --claude-code --cursor
+  dirctl install uninstall my-agent --all
+`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return cmd.Help()
+		}
+
+		return runInstallCmd(cmd, args[0])
+	},
+}
+
+func init() {
+	agentFlags = addSelectionFlags(Command, &opts)
+
+	Command.AddCommand(runCmd)
+	Command.AddCommand(uninstallCmd)
+	Command.AddCommand(ListCommand)
+}
+
+// pullAndDerive resolves the ref, pulls the record, and derives its artifacts.
+func pullAndDerive(cmd *cobra.Command, input string) (artifacts, error) {
+	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
+	if !ok {
+		return artifacts{}, errors.New("failed to get client from context")
+	}
+
+	cid, err := reference.ResolveToCID(cmd.Context(), c, input)
+	if err != nil {
+		return artifacts{}, fmt.Errorf("resolve reference: %w", err)
+	}
+
+	record, err := c.Pull(cmd.Context(), &corev1.RecordRef{Cid: cid})
+	if err != nil {
+		return artifacts{}, fmt.Errorf("failed to pull record: %w", err)
+	}
+
+	return deriveArtifacts(record)
+}
+
+// runInstallCmd is the shared body for the parent's bare-positional form and the
+// `run` subcommand: pull + derive, dry-run plan, confirm, apply, summary.
+func runInstallCmd(cmd *cobra.Command, input string) error {
+	arts, err := pullAndDerive(cmd, input)
+	if err != nil {
+		return err
+	}
+
+	env := agentcfg.ResolveEnv()
+	set := agentcfg.ResolveArtifacts(opts.mcpOnly, opts.skillOnly)
+	chosen := chosenFrom(agentFlags)
+	sels := agentcfg.ResolveSelection(agentcfg.Registry(), env, chosen, opts.all, opts.force)
+
+	plan := runInstall(env, arts, sels, set, true)
+	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
+
+	if len(plan) == 0 {
+		return nil
+	}
+
+	if !opts.yes && !opts.dryRun {
+		ok, err := confirm(cmd, "\nProceed with these changes?")
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			presenter.Printf(cmd, "Aborted. No changes made.\n")
+
+			return nil
+		}
+	}
+
+	outcomes := runInstall(env, arts, sels, set, opts.dryRun)
+	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
+
+	return nil
+}
+
+// confirm prompts for a yes/no answer on the command's input stream.
+func confirm(cmd *cobra.Command, prompt string) (bool, error) {
+	presenter.Printf(cmd, "%s [y/N]: ", prompt)
+
+	reader := bufio.NewReader(cmd.InOrStdin())
+
+	line, err := reader.ReadString('\n')
+	if err != nil && line == "" {
+		return false, fmt.Errorf("read confirmation: %w", err)
+	}
+
+	answer := strings.ToLower(strings.TrimSpace(line))
+
+	return answer == "y" || answer == "yes", nil
+}

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -39,7 +39,7 @@ directly into the configuration of detected AI coding agents.
 Examples:
   dirctl install cisco.com/agent:v1.0.0
   dirctl install bafyrei... --dry-run
-  dirctl install cisco.com/agent --mcp --agents claude-code,cursor
+  dirctl install cisco.com/agent --agents claude-code,cursor
   dirctl install uninstall cisco.com/agent
 `,
 	Args: cobra.MaximumNArgs(1),
@@ -107,14 +107,13 @@ func runInstallCmd(cmd *cobra.Command, input string) error {
 	}
 
 	env := agentcfg.ResolveEnv()
-	set := agentcfg.ResolveArtifacts(opts.mcpOnly, opts.skillOnly)
 
 	selected, err := selectAgents(cmd, env)
 	if err != nil {
 		return err
 	}
 
-	plan := runInstall(env, arts, selected, set, true)
+	plan := runInstall(env, arts, selected, true)
 	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 
 	if len(plan) == 0 {
@@ -134,7 +133,7 @@ func runInstallCmd(cmd *cobra.Command, input string) error {
 		}
 	}
 
-	outcomes := runInstall(env, arts, selected, set, opts.dryRun)
+	outcomes := runInstall(env, arts, selected, opts.dryRun)
 	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 
 	return nil

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -17,13 +17,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// opts and agentFlags are shared by the parent `install`, `run`, and `uninstall`
-// via persistent flags on the parent. Only one of those executes per invocation,
-// so a single shared set is correct.
-var (
-	opts       options
-	agentFlags map[string]*bool
-)
+// opts is shared by the parent `install`, `run`, and `uninstall` via persistent
+// flags on the parent. Only one of those executes per invocation, so a single
+// shared set is correct.
+var opts options
 
 // Command is the `dirctl install` parent. With a positional CID/name it runs an
 // install (equivalent to `install run`); with no argument it prints help.
@@ -40,10 +37,10 @@ directly into the configuration of detected AI coding agents.
   dirctl install list                     show detected agents and target paths
 
 Examples:
-  dirctl install my-agent:1.0.0
+  dirctl install cisco.com/agent:v1.0.0
   dirctl install bafyrei... --dry-run
-  dirctl install my-agent --mcp --claude-code --cursor
-  dirctl install uninstall my-agent --all
+  dirctl install cisco.com/agent --mcp --agents claude-code,cursor
+  dirctl install uninstall cisco.com/agent
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -56,11 +53,29 @@ Examples:
 }
 
 func init() {
-	agentFlags = addSelectionFlags(Command, &opts)
+	addSelectionFlags(Command, &opts)
 
 	Command.AddCommand(runCmd)
 	Command.AddCommand(uninstallCmd)
 	Command.AddCommand(ListCommand)
+}
+
+// selectAgents validates the --agents flag and resolves it to the detected
+// agents to act on, printing a note for any explicitly-requested agent that is
+// not detected (never installed for undetected agents).
+func selectAgents(cmd *cobra.Command, env agentcfg.Env) ([]agentcfg.Agent, error) {
+	chosen, err := resolveChosen(opts.agents)
+	if err != nil {
+		return nil, err
+	}
+
+	selected, skipped := agentcfg.ResolveSelection(agentcfg.Registry(), env, chosen)
+
+	for _, id := range skipped {
+		presenter.Printf(cmd, "Skipping %s: not detected.\n", id)
+	}
+
+	return selected, nil
 }
 
 // pullAndDerive resolves the ref, pulls the record, and derives its artifacts.
@@ -93,10 +108,13 @@ func runInstallCmd(cmd *cobra.Command, input string) error {
 
 	env := agentcfg.ResolveEnv()
 	set := agentcfg.ResolveArtifacts(opts.mcpOnly, opts.skillOnly)
-	chosen := chosenFrom(agentFlags)
-	sels := agentcfg.ResolveSelection(agentcfg.Registry(), env, chosen, opts.all, opts.force)
 
-	plan := runInstall(env, arts, sels, set, true)
+	selected, err := selectAgents(cmd, env)
+	if err != nil {
+		return err
+	}
+
+	plan := runInstall(env, arts, selected, set, true)
 	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 
 	if len(plan) == 0 {
@@ -116,7 +134,7 @@ func runInstallCmd(cmd *cobra.Command, input string) error {
 		}
 	}
 
-	outcomes := runInstall(env, arts, sels, set, opts.dryRun)
+	outcomes := runInstall(env, arts, selected, set, opts.dryRun)
 	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 
 	return nil

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -1,0 +1,31 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListRunsWithoutClient(t *testing.T) {
+	var out bytes.Buffer
+	ListCommand.SetOut(&out)
+	ListCommand.SetErr(&out)
+
+	require.NoError(t, ListCommand.RunE(ListCommand, nil))
+	require.Contains(t, out.String(), "Claude Code")
+}
+
+func TestParentHasSubcommands(t *testing.T) {
+	names := map[string]bool{}
+	for _, c := range Command.Commands() {
+		names[c.Name()] = true
+	}
+
+	require.True(t, names["run"])
+	require.True(t, names["uninstall"])
+	require.True(t, names["list"])
+}

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -29,3 +29,13 @@ func TestParentHasSubcommands(t *testing.T) {
 	require.True(t, names["uninstall"])
 	require.True(t, names["list"])
 }
+
+func TestTopLevelUninstallShorthand(t *testing.T) {
+	// The top-level `dirctl uninstall` shorthand takes one positional and carries
+	// its own selection flags (it has no `install` parent to inherit them from).
+	require.Equal(t, "uninstall", UninstallCommand.Name())
+	require.NotNil(t, UninstallCommand.RunE)
+	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("agents"))
+	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("dry-run"))
+	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("yes"))
+}

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -5,8 +5,13 @@ package install
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +43,128 @@ func TestTopLevelUninstallShorthand(t *testing.T) {
 	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("agents"))
 	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("dry-run"))
 	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("yes"))
+}
+
+// --- confirm tests ---
+
+func runConfirm(t *testing.T, input string) (bool, error) {
+	t.Helper()
+
+	var out bytes.Buffer
+
+	cmd := Command
+	cmd.SetIn(strings.NewReader(input))
+	cmd.SetOut(&out)
+
+	return confirm(cmd, "Proceed?")
+}
+
+func TestConfirmYesLowercase(t *testing.T) {
+	ok, err := runConfirm(t, "y\n")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestConfirmYesFull(t *testing.T) {
+	ok, err := runConfirm(t, "yes\n")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestConfirmYesUppercase(t *testing.T) {
+	ok, err := runConfirm(t, "Y\n")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestConfirmNo(t *testing.T) {
+	ok, err := runConfirm(t, "n\n")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestConfirmEmptyInput(t *testing.T) {
+	ok, err := runConfirm(t, "\n")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestConfirmEOFWithEmptyLine(t *testing.T) {
+	// Empty reader → EOF immediately with no line content.
+	var out bytes.Buffer
+
+	cmd := Command
+	cmd.SetIn(strings.NewReader(""))
+	cmd.SetOut(&out)
+
+	_, err := confirm(cmd, "Proceed?")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read confirmation")
+}
+
+// --- selectAgents tests ---
+
+func TestSelectAgentsAllDetected(t *testing.T) {
+	home := t.TempDir()
+	// Create the marker directory that makes claude-code detectable.
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".claude"), 0o755))
+
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	// Reset opts after test.
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	opts.agents = []string{"all"}
+
+	var out bytes.Buffer
+
+	Command.SetOut(&out)
+
+	selected, err := selectAgents(Command, env)
+	require.NoError(t, err)
+
+	ids := make([]string, 0, len(selected))
+	for _, a := range selected {
+		ids = append(ids, a.ID)
+	}
+
+	assert.Contains(t, ids, "claude-code")
+}
+
+func TestSelectAgentsExplicitNotDetectedPrintsSkipping(t *testing.T) {
+	home := t.TempDir()
+	// Do NOT create the marker dir → agent is not detected.
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	opts.agents = []string{"cursor"}
+
+	var out bytes.Buffer
+
+	Command.SetOut(&out)
+
+	selected, err := selectAgents(Command, env)
+	require.NoError(t, err)
+	assert.Empty(t, selected)
+	assert.Contains(t, out.String(), "Skipping")
+	assert.Contains(t, out.String(), "not detected")
+}
+
+// --- Command.RunE with no args prints help ---
+
+func TestCommandRunENoArgsReturnsNil(t *testing.T) {
+	var out bytes.Buffer
+
+	Command.SetOut(&out)
+	Command.SetErr(&out)
+
+	err := Command.RunE(Command, nil)
+	require.NoError(t, err)
+	// Help output should mention usage.
+	assert.NotEmpty(t, out.String())
 }

--- a/cli/cmd/install/list.go
+++ b/cli/cmd/install/list.go
@@ -1,0 +1,49 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/presenter"
+	"github.com/spf13/cobra"
+)
+
+// ListCommand is exported so root.go can skip client setup for it (list makes no
+// Directory calls).
+var ListCommand = &cobra.Command{
+	Use:   "list",
+	Short: "Show detected agents and the files install would touch",
+	Long: `List every supported AI coding agent, whether it is detected on this machine,
+and the config files that install would touch. Makes no changes and does not
+contact the Directory.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		env := agentcfg.ResolveEnv()
+
+		for _, agent := range agentcfg.Registry() {
+			status := "not detected"
+			if agent.Detect(env) {
+				status = "detected"
+			}
+
+			presenter.Printf(cmd, "%s [%s]\n", agent.Name, status)
+
+			if agent.MCP != nil {
+				path, err := agent.MCP.ConfigPath(env)
+				if err != nil {
+					presenter.Printf(cmd, "  MCP   (path error: %v)\n", err)
+				} else {
+					presenter.Printf(cmd, "  MCP   %s\n", path)
+				}
+			}
+
+			if agent.Skill != nil {
+				// The real slug is the record name, known only at install time; show
+				// the generic target with a placeholder.
+				presenter.Printf(cmd, "  Skill %s\n", agentcfg.ResolveSkillPath(agent.Skill, env, "<record>"))
+			}
+		}
+
+		return nil
+	},
+}

--- a/cli/cmd/install/options.go
+++ b/cli/cmd/install/options.go
@@ -7,8 +7,7 @@ package install
 type options struct {
 	mcpOnly   bool
 	skillOnly bool
-	all       bool
-	force     bool
+	agents    []string
 	dryRun    bool
 	yes       bool
 }

--- a/cli/cmd/install/options.go
+++ b/cli/cmd/install/options.go
@@ -5,9 +5,7 @@ package install
 
 // options holds the shared flags for the install subcommands.
 type options struct {
-	mcpOnly   bool
-	skillOnly bool
-	agents    []string
-	dryRun    bool
-	yes       bool
+	agents []string
+	dryRun bool
+	yes    bool
 }

--- a/cli/cmd/install/options.go
+++ b/cli/cmd/install/options.go
@@ -1,0 +1,14 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+// options holds the shared flags for the install subcommands.
+type options struct {
+	mcpOnly   bool
+	skillOnly bool
+	all       bool
+	force     bool
+	dryRun    bool
+	yes       bool
+}

--- a/cli/cmd/install/run.go
+++ b/cli/cmd/install/run.go
@@ -1,0 +1,15 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import "github.com/spf13/cobra"
+
+var runCmd = &cobra.Command{
+	Use:   "run <cid-or-name[:version][@digest]>",
+	Short: "Install a record's artifacts into detected (or selected) agents",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInstallCmd(cmd, args[0])
+	},
+}

--- a/cli/cmd/install/testdata/a2a.json
+++ b/cli/cmd/install/testdata/a2a.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "1.0.0",
+  "name": "test-a2a-agent",
+  "version": "1.0.0",
+  "description": "A test A2A agent",
+  "modules": [
+    {
+      "name": "integration/a2a",
+      "data": {
+        "card_data": {
+          "name": "test-a2a-agent",
+          "description": "A test A2A agent",
+          "version": "1.0.0",
+          "protocolVersions": ["0.2.6"],
+          "supportedInterfaces": [
+            {
+              "url": "https://example.com/a2a",
+              "protocolBinding": "HTTP+JSON"
+            }
+          ],
+          "capabilities": {},
+          "defaultInputModes": ["text"],
+          "defaultOutputModes": ["text"],
+          "skills": [
+            {
+              "id": "test-skill",
+              "name": "Test Skill",
+              "description": "A skill for testing"
+            }
+          ]
+        },
+        "card_schema_version": "v1.0.0"
+      }
+    }
+  ]
+}

--- a/cli/cmd/install/testdata/bare.json
+++ b/cli/cmd/install/testdata/bare.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "1.0.0",
+  "name": "bare",
+  "version": "1.0.0",
+  "description": "A record with no modules",
+  "modules": []
+}

--- a/cli/cmd/install/testdata/mcp.json
+++ b/cli/cmd/install/testdata/mcp.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "1.0.0",
+  "name": "io.example/code-review-server",
+  "version": "1.0.0",
+  "description": "MCP server for code review",
+  "modules": [
+    {
+      "name": "integration/mcp",
+      "data": {
+        "name": "io.example/code-review-server",
+        "connections": [
+          {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["@example/code-review-server@1.0.0"],
+            "env_vars": [
+              {
+                "name": "API_KEY",
+                "description": "API key for authentication"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/cli/cmd/install/testdata/multi.json
+++ b/cli/cmd/install/testdata/multi.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.0.0",
+  "name": "multi-agent",
+  "version": "1.0.0",
+  "description": "An agent with both skill and MCP modules",
+  "modules": [
+    {
+      "name": "core/language_model/agentskills",
+      "id": 10302,
+      "data": {
+        "skill_file": "SKILL.md",
+        "skill_manifest": {
+          "name": "code-review",
+          "description": "Review code for bugs and style.",
+          "license": "Apache-2.0",
+          "version": "1.0.0"
+        }
+      }
+    },
+    {
+      "name": "integration/mcp",
+      "data": {
+        "name": "io.example/code-review-server",
+        "connections": [
+          {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["@example/code-review-server@1.0.0"],
+            "env_vars": [
+              {
+                "name": "API_KEY",
+                "description": "API key for authentication"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/cli/cmd/install/testdata/skill.json
+++ b/cli/cmd/install/testdata/skill.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": "1.0.0",
+  "name": "code-review",
+  "version": "1.0.0",
+  "description": "Review code for bugs and style.",
+  "modules": [
+    {
+      "name": "core/language_model/agentskills",
+      "id": 10302,
+      "data": {
+        "skill_file": "SKILL.md",
+        "skill_manifest": {
+          "name": "code-review",
+          "description": "Review code for bugs and style.",
+          "license": "Apache-2.0",
+          "version": "1.0.0"
+        }
+      }
+    }
+  ]
+}

--- a/cli/cmd/install/uninstall.go
+++ b/cli/cmd/install/uninstall.go
@@ -20,14 +20,13 @@ var uninstallCmd = &cobra.Command{
 		}
 
 		env := agentcfg.ResolveEnv()
-		set := agentcfg.ResolveArtifacts(opts.mcpOnly, opts.skillOnly)
 
 		selected, err := selectAgents(cmd, env)
 		if err != nil {
 			return err
 		}
 
-		plan := runUninstall(env, arts, selected, set, true)
+		plan := runUninstall(env, arts, selected, true)
 		presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 
 		if len(plan) == 0 {
@@ -47,7 +46,7 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		outcomes := runUninstall(env, arts, selected, set, opts.dryRun)
+		outcomes := runUninstall(env, arts, selected, opts.dryRun)
 		presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 
 		return nil

--- a/cli/cmd/install/uninstall.go
+++ b/cli/cmd/install/uninstall.go
@@ -11,7 +11,7 @@ import (
 
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall <cid-or-name[:version][@digest]>",
-	Short: "Remove a record's artifacts from detected (or selected) agents",
+	Short: "Remove a record's artifacts from detected agents",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		arts, err := pullAndDerive(cmd, args[0])
@@ -21,10 +21,13 @@ var uninstallCmd = &cobra.Command{
 
 		env := agentcfg.ResolveEnv()
 		set := agentcfg.ResolveArtifacts(opts.mcpOnly, opts.skillOnly)
-		chosen := chosenFrom(agentFlags)
-		sels := agentcfg.ResolveSelection(agentcfg.Registry(), env, chosen, opts.all, opts.force)
 
-		plan := runUninstall(env, arts, sels, set, true)
+		selected, err := selectAgents(cmd, env)
+		if err != nil {
+			return err
+		}
+
+		plan := runUninstall(env, arts, selected, set, true)
 		presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 
 		if len(plan) == 0 {
@@ -44,7 +47,7 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		outcomes := runUninstall(env, arts, sels, set, opts.dryRun)
+		outcomes := runUninstall(env, arts, selected, set, opts.dryRun)
 		presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 
 		return nil

--- a/cli/cmd/install/uninstall.go
+++ b/cli/cmd/install/uninstall.go
@@ -1,0 +1,52 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/presenter"
+	"github.com/spf13/cobra"
+)
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall <cid-or-name[:version][@digest]>",
+	Short: "Remove a record's artifacts from detected (or selected) agents",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		arts, err := pullAndDerive(cmd, args[0])
+		if err != nil {
+			return err
+		}
+
+		env := agentcfg.ResolveEnv()
+		set := agentcfg.ResolveArtifacts(opts.mcpOnly, opts.skillOnly)
+		chosen := chosenFrom(agentFlags)
+		sels := agentcfg.ResolveSelection(agentcfg.Registry(), env, chosen, opts.all, opts.force)
+
+		plan := runUninstall(env, arts, sels, set, true)
+		presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
+
+		if len(plan) == 0 {
+			return nil
+		}
+
+		if !opts.yes && !opts.dryRun {
+			ok, err := confirm(cmd, "\nRemove these artifacts?")
+			if err != nil {
+				return err
+			}
+
+			if !ok {
+				presenter.Printf(cmd, "Aborted. No changes made.\n")
+
+				return nil
+			}
+		}
+
+		outcomes := runUninstall(env, arts, sels, set, opts.dryRun)
+		presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
+
+		return nil
+	},
+}

--- a/cli/cmd/install/uninstall.go
+++ b/cli/cmd/install/uninstall.go
@@ -9,46 +9,71 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// uninstallCmd is the `dirctl install uninstall` subcommand. It inherits the
+// selection flags from the `install` parent's persistent flags.
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall <cid-or-name[:version][@digest]>",
 	Short: "Remove a record's artifacts from detected agents",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		arts, err := pullAndDerive(cmd, args[0])
+		return runUninstallCmd(cmd, args[0])
+	},
+}
+
+// UninstallCommand is the top-level `dirctl uninstall`, a shorthand for
+// `dirctl install uninstall`. It carries its own copy of the selection flags
+// since it has no `install` parent to inherit them from.
+var UninstallCommand = &cobra.Command{
+	Use:   "uninstall <cid-or-name[:version][@digest]>",
+	Short: "Remove a record's artifacts from detected agents (shorthand for 'install uninstall')",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUninstallCmd(cmd, args[0])
+	},
+}
+
+func init() {
+	addSelectionFlags(UninstallCommand, &opts)
+}
+
+// runUninstallCmd is the shared body for both `install uninstall` and the
+// top-level `uninstall` shorthand: pull + derive, dry-run plan, confirm, remove,
+// summary.
+func runUninstallCmd(cmd *cobra.Command, input string) error {
+	arts, err := pullAndDerive(cmd, input)
+	if err != nil {
+		return err
+	}
+
+	env := agentcfg.ResolveEnv()
+
+	selected, err := selectAgents(cmd, env)
+	if err != nil {
+		return err
+	}
+
+	plan := runUninstall(env, arts, selected, true)
+	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
+
+	if len(plan) == 0 {
+		return nil
+	}
+
+	if !opts.yes && !opts.dryRun {
+		ok, err := confirm(cmd, "\nRemove these artifacts?")
 		if err != nil {
 			return err
 		}
 
-		env := agentcfg.ResolveEnv()
+		if !ok {
+			presenter.Printf(cmd, "Aborted. No changes made.\n")
 
-		selected, err := selectAgents(cmd, env)
-		if err != nil {
-			return err
-		}
-
-		plan := runUninstall(env, arts, selected, true)
-		presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
-
-		if len(plan) == 0 {
 			return nil
 		}
+	}
 
-		if !opts.yes && !opts.dryRun {
-			ok, err := confirm(cmd, "\nRemove these artifacts?")
-			if err != nil {
-				return err
-			}
+	outcomes := runUninstall(env, arts, selected, opts.dryRun)
+	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 
-			if !ok {
-				presenter.Printf(cmd, "Aborted. No changes made.\n")
-
-				return nil
-			}
-		}
-
-		outcomes := runUninstall(env, arts, selected, opts.dryRun)
-		presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
-
-		return nil
-	},
+	return nil
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/agntcy/dir/cli/cmd/export"
 	importcmd "github.com/agntcy/dir/cli/cmd/import"
 	"github.com/agntcy/dir/cli/cmd/info"
+	"github.com/agntcy/dir/cli/cmd/install"
 	"github.com/agntcy/dir/cli/cmd/mcp"
 	"github.com/agntcy/dir/cli/cmd/naming"
 	"github.com/agntcy/dir/cli/cmd/network"
@@ -114,6 +115,9 @@ func init() {
 	validate.Command.PersistentPreRunE = skipClientSetup
 	version.Command.PersistentPreRunE = skipClientSetup
 	mcp.Command.PersistentPreRunE = skipClientSetup
+	// `install list` makes no Directory calls, so it must not require a client;
+	// `install`/`install run`/`install uninstall` use the client from context.
+	install.ListCommand.PersistentPreRunE = skipClientSetup
 
 	RootCmd.AddCommand(
 		// auth commands
@@ -147,6 +151,8 @@ func init() {
 		events.Command, // Contains: listen
 		// mcp commands
 		mcp.Command, // Contains: serve
+		// install commands
+		install.Command, // Contains: run, uninstall, list
 		// daemon commands
 		daemon.Command, // Contains: start, stop, status
 	)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -152,7 +152,8 @@ func init() {
 		// mcp commands
 		mcp.Command, // Contains: serve
 		// install commands
-		install.Command, // Contains: run, uninstall, list
+		install.Command,          // Contains: run, uninstall, list
+		install.UninstallCommand, // top-level `uninstall` shorthand for `install uninstall`
 		// daemon commands
 		daemon.Command, // Contains: start, stop, status
 	)

--- a/cli/internal/agentcfg/codec/codec.go
+++ b/cli/internal/agentcfg/codec/codec.go
@@ -1,0 +1,200 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package codec decodes and encodes structured config files (JSON, YAML, TOML)
+// through a generic map so that dirctl can upsert or remove only its own entry
+// while leaving all sibling content intact.
+package codec
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	toml "github.com/pelletier/go-toml/v2"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// Format identifies a supported config file encoding.
+type Format int
+
+const (
+	// JSON is the encoding/json format.
+	JSON Format = iota
+	// YAML is the gopkg-compatible YAML format.
+	YAML
+	// TOML is the github.com/pelletier/go-toml/v2 format.
+	TOML
+)
+
+// String returns the lowercase format name.
+func (f Format) String() string {
+	switch f {
+	case JSON:
+		return "json"
+	case YAML:
+		return "yaml"
+	case TOML:
+		return "toml"
+	default:
+		return "unknown"
+	}
+}
+
+// Decode parses data into a generic string-keyed map. Empty input yields an
+// empty (non-nil) map so callers can upsert into a fresh config.
+func Decode(format Format, data []byte) (map[string]any, error) {
+	m := map[string]any{}
+
+	if len(bytes.TrimSpace(data)) == 0 {
+		return m, nil
+	}
+
+	switch format {
+	case JSON:
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.UseNumber() // keep numbers stable instead of coercing ints to float64
+
+		if err := dec.Decode(&m); err != nil {
+			return nil, fmt.Errorf("decode json: %w", err)
+		}
+	case YAML:
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("decode yaml: %w", err)
+		}
+	case TOML:
+		if err := toml.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("decode toml: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported format %d", format)
+	}
+
+	return m, nil
+}
+
+// Encode marshals a generic map back to bytes in the given format.
+func Encode(format Format, m map[string]any) ([]byte, error) {
+	switch format {
+	case JSON:
+		out, err := json.MarshalIndent(m, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("encode json: %w", err)
+		}
+
+		return append(out, '\n'), nil
+	case YAML:
+		out, err := yaml.Marshal(m)
+		if err != nil {
+			return nil, fmt.Errorf("encode yaml: %w", err)
+		}
+
+		return out, nil
+	case TOML:
+		out, err := toml.Marshal(m)
+		if err != nil {
+			return nil, fmt.Errorf("encode toml: %w", err)
+		}
+
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported format %d", format)
+	}
+}
+
+// GetNested walks path through nested maps and returns the value at the leaf.
+func GetNested(m map[string]any, path ...string) (any, bool) {
+	if len(path) == 0 {
+		return nil, false
+	}
+
+	current := m
+	for i, key := range path {
+		value, ok := current[key]
+		if !ok {
+			return nil, false
+		}
+
+		if i == len(path)-1 {
+			return value, true
+		}
+
+		next, ok := asStringMap(value)
+		if !ok {
+			return nil, false
+		}
+
+		current = next
+	}
+
+	return nil, false
+}
+
+// SetNested sets value at path, creating intermediate maps as needed.
+func SetNested(m map[string]any, value any, path ...string) {
+	if len(path) == 0 {
+		return
+	}
+
+	current := m
+	for _, key := range path[:len(path)-1] {
+		next, ok := asStringMap(current[key])
+		if !ok {
+			next = map[string]any{}
+			current[key] = next
+		}
+
+		current = next
+	}
+
+	current[path[len(path)-1]] = value
+}
+
+// DeleteNested removes the leaf at path. It reports whether something was removed.
+func DeleteNested(m map[string]any, path ...string) bool {
+	if len(path) == 0 {
+		return false
+	}
+
+	current := m
+	for _, key := range path[:len(path)-1] {
+		next, ok := asStringMap(current[key])
+		if !ok {
+			return false
+		}
+
+		current = next
+	}
+
+	leaf := path[len(path)-1]
+	if _, ok := current[leaf]; !ok {
+		return false
+	}
+
+	delete(current, leaf)
+
+	return true
+}
+
+// asStringMap normalizes the two map shapes decoders may produce
+// (map[string]any and map[any]any) into map[string]any.
+func asStringMap(value any) (map[string]any, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed, true
+	case map[any]any:
+		converted := make(map[string]any, len(typed))
+		for k, v := range typed {
+			ks, ok := k.(string)
+			if !ok {
+				return nil, false
+			}
+
+			converted[ks] = v
+		}
+
+		return converted, true
+	default:
+		return nil, false
+	}
+}

--- a/cli/internal/agentcfg/codec/codec_test.go
+++ b/cli/internal/agentcfg/codec/codec_test.go
@@ -1,0 +1,143 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package codec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeEmptyReturnsEmptyMap(t *testing.T) {
+	for _, format := range []Format{JSON, YAML, TOML} {
+		m, err := Decode(format, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, m)
+		assert.Empty(t, m)
+	}
+}
+
+func TestJSONRoundTripPreservesForeignData(t *testing.T) {
+	input := []byte(`{
+  "mcpServers": {
+    "other-server": {
+      "command": "node",
+      "args": ["server.js"],
+      "env": {"FOO": "bar"}
+    }
+  }
+}`)
+
+	m, err := Decode(JSON, input)
+	require.NoError(t, err)
+
+	SetNested(m, map[string]any{"command": "dirctl"}, "mcpServers", "agntcy-dir-mcp")
+
+	out, err := Encode(JSON, m)
+	require.NoError(t, err)
+
+	// Re-decode and assert both entries survive.
+	got, err := Decode(JSON, out)
+	require.NoError(t, err)
+
+	ours, ok := GetNested(got, "mcpServers", "agntcy-dir-mcp")
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"command": "dirctl"}, ours)
+
+	foreign, ok := GetNested(got, "mcpServers", "other-server")
+	require.True(t, ok)
+	foreignMap, ok := foreign.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "node", foreignMap["command"])
+}
+
+func TestGetNestedMissingPath(t *testing.T) {
+	m := map[string]any{"a": map[string]any{"b": 1}}
+
+	_, ok := GetNested(m, "a", "missing")
+	assert.False(t, ok)
+
+	_, ok = GetNested(m, "x", "y")
+	assert.False(t, ok)
+}
+
+func TestSetNestedCreatesIntermediateMaps(t *testing.T) {
+	m := map[string]any{}
+
+	SetNested(m, "value", "a", "b", "c")
+
+	got, ok := GetNested(m, "a", "b", "c")
+	require.True(t, ok)
+	assert.Equal(t, "value", got)
+}
+
+func TestDeleteNestedRemovesOnlyTarget(t *testing.T) {
+	m := map[string]any{
+		"servers": map[string]any{
+			"keep": 1,
+			"drop": 2,
+		},
+	}
+
+	removed := DeleteNested(m, "servers", "drop")
+	assert.True(t, removed)
+
+	_, ok := GetNested(m, "servers", "drop")
+	assert.False(t, ok)
+
+	_, ok = GetNested(m, "servers", "keep")
+	assert.True(t, ok)
+}
+
+func TestDeleteNestedMissingReturnsFalse(t *testing.T) {
+	m := map[string]any{"servers": map[string]any{}}
+
+	assert.False(t, DeleteNested(m, "servers", "absent"))
+	assert.False(t, DeleteNested(m, "missing", "x"))
+}
+
+func TestYAMLRoundTripPreservesForeignData(t *testing.T) {
+	input := []byte("name: continue\nmcpServers:\n  other:\n    command: node\n")
+
+	m, err := Decode(YAML, input)
+	require.NoError(t, err)
+
+	SetNested(m, map[string]any{"command": "dirctl"}, "mcpServers", "agntcy-dir-mcp")
+
+	out, err := Encode(YAML, m)
+	require.NoError(t, err)
+
+	got, err := Decode(YAML, out)
+	require.NoError(t, err)
+
+	assert.Equal(t, "continue", got["name"])
+
+	_, ok := GetNested(got, "mcpServers", "agntcy-dir-mcp")
+	assert.True(t, ok)
+
+	_, ok = GetNested(got, "mcpServers", "other")
+	assert.True(t, ok)
+}
+
+func TestTOMLRoundTripPreservesForeignData(t *testing.T) {
+	input := []byte("[mcp_servers.other]\ncommand = \"node\"\n")
+
+	m, err := Decode(TOML, input)
+	require.NoError(t, err)
+
+	SetNested(m, map[string]any{"command": "dirctl"}, "mcp_servers", "agntcy-dir-mcp")
+
+	out, err := Encode(TOML, m)
+	require.NoError(t, err)
+
+	got, err := Decode(TOML, out)
+	require.NoError(t, err)
+
+	_, ok := GetNested(got, "mcp_servers", "agntcy-dir-mcp")
+	assert.True(t, ok)
+
+	_, ok = GetNested(got, "mcp_servers", "other")
+	assert.True(t, ok)
+}

--- a/cli/internal/agentcfg/codec/codec_test.go
+++ b/cli/internal/agentcfg/codec/codec_test.go
@@ -141,3 +141,106 @@ func TestTOMLRoundTripPreservesForeignData(t *testing.T) {
 	_, ok = GetNested(got, "mcp_servers", "other")
 	assert.True(t, ok)
 }
+
+// --- Decode error cases ---
+
+func TestDecodeMalformedJSON(t *testing.T) {
+	_, err := Decode(JSON, []byte(`{not valid json`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode json")
+}
+
+func TestDecodeMalformedYAML(t *testing.T) {
+	// Tabs are not valid YAML indentation.
+	_, err := Decode(YAML, []byte("key:\n\t- bad"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode yaml")
+}
+
+func TestDecodeMalformedTOML(t *testing.T) {
+	_, err := Decode(TOML, []byte("[[not.valid\n"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode toml")
+}
+
+func TestDecodeUnsupportedFormat(t *testing.T) {
+	_, err := Decode(Format(99), []byte("data"))
+	require.Error(t, err)
+}
+
+func TestEncodeUnsupportedFormat(t *testing.T) {
+	_, err := Encode(Format(99), map[string]any{"a": 1})
+	require.Error(t, err)
+}
+
+// --- GetNested edge cases ---
+
+func TestGetNestedEmptyPath(t *testing.T) {
+	m := map[string]any{"a": 1}
+	_, ok := GetNested(m)
+	assert.False(t, ok)
+}
+
+func TestGetNestedThroughNonMap(t *testing.T) {
+	// Trying to walk through a non-map value should return false.
+	m := map[string]any{"a": "string-value"}
+	_, ok := GetNested(m, "a", "b")
+	assert.False(t, ok)
+}
+
+// --- SetNested edge cases ---
+
+func TestSetNestedEmptyPathIsNoOp(t *testing.T) {
+	m := map[string]any{"a": 1}
+	SetNested(m, "value")
+	assert.Equal(t, map[string]any{"a": 1}, m)
+}
+
+func TestSetNestedOverwritesNonMap(t *testing.T) {
+	// If an intermediate key holds a non-map value, SetNested replaces it.
+	m := map[string]any{"a": "old"}
+	SetNested(m, "new-value", "a", "b")
+	got, ok := GetNested(m, "a", "b")
+	require.True(t, ok)
+	assert.Equal(t, "new-value", got)
+}
+
+// --- DeleteNested edge cases ---
+
+func TestDeleteNestedEmptyPath(t *testing.T) {
+	m := map[string]any{"a": 1}
+	removed := DeleteNested(m)
+	assert.False(t, removed)
+	assert.Equal(t, map[string]any{"a": 1}, m)
+}
+
+func TestDeleteNestedThroughNonMap(t *testing.T) {
+	// Walking through a non-map must not panic and return false.
+	m := map[string]any{"a": "not-a-map"}
+	removed := DeleteNested(m, "a", "b")
+	assert.False(t, removed)
+}
+
+// --- asStringMap via YAML round-trip ---
+
+func TestAsStringMapViaYAMLDecode(t *testing.T) {
+	// YAML decode produces map[string]any; after GetNested wraps it we can still
+	// traverse nested keys, which exercises asStringMap internally.
+	input := []byte("outer:\n  inner:\n    leaf: value\n")
+
+	m, err := Decode(YAML, input)
+	require.NoError(t, err)
+
+	got, ok := GetNested(m, "outer", "inner", "leaf")
+	require.True(t, ok)
+	assert.Equal(t, "value", got)
+}
+
+// --- Format.String() ---
+
+func TestFormatString(t *testing.T) {
+	assert.Equal(t, "json", JSON.String())
+	assert.Equal(t, "yaml", YAML.String())
+	assert.Equal(t, "toml", TOML.String())
+	assert.Equal(t, "unknown", Format(99).String())
+}

--- a/cli/internal/agentcfg/fsutil/atomic.go
+++ b/cli/internal/agentcfg/fsutil/atomic.go
@@ -1,0 +1,57 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fsutil provides filesystem helpers for `dirctl`: atomic
+// writes that never leave partial files behind.
+package fsutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const dirPerm = 0o755
+
+// WriteAtomic writes data to path atomically: it creates parent directories,
+// writes to a temp file in the same directory, then renames it over the target.
+// A rename within a directory is atomic on POSIX filesystems, so readers never
+// observe a partially written file and no .bak file is created.
+func WriteAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return fmt.Errorf("create directory %s: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+
+	tmpName := tmp.Name()
+
+	// Best-effort cleanup if we bail out before the rename succeeds.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+
+		return fmt.Errorf("write temp file %s: %w", tmpName, err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file %s: %w", tmpName, err)
+	}
+
+	// The target path is a known agent config location resolved by the integrate
+	// descriptors, not untrusted input, so writing to it is intentional.
+	if err := os.Chmod(tmpName, perm); err != nil { //nolint:gosec // G703: path is a resolved agent config location
+		return fmt.Errorf("chmod temp file %s: %w", tmpName, err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil { //nolint:gosec // G703: path is a resolved agent config location
+		return fmt.Errorf("rename %s to %s: %w", tmpName, path, err)
+	}
+
+	return nil
+}

--- a/cli/internal/agentcfg/fsutil/atomic_test.go
+++ b/cli/internal/agentcfg/fsutil/atomic_test.go
@@ -1,0 +1,49 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAtomicCreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deep", "file.json")
+
+	err := WriteAtomic(path, []byte("hello"), 0o600)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got))
+}
+
+func TestWriteAtomicOverwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	require.NoError(t, WriteAtomic(path, []byte("first"), 0o600))
+	require.NoError(t, WriteAtomic(path, []byte("second"), 0o600))
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(got))
+}
+
+func TestWriteAtomicLeavesNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	require.NoError(t, WriteAtomic(path, []byte("data"), 0o600))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "file.txt", entries[0].Name())
+}

--- a/cli/internal/agentcfg/mcp_engine.go
+++ b/cli/internal/agentcfg/mcp_engine.go
@@ -1,0 +1,154 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg/codec"
+	"github.com/agntcy/dir/cli/internal/agentcfg/fsutil"
+)
+
+const configFilePerm = 0o600
+
+// InstallMCP upserts the MCP server entry under serverName into the agent's
+// config file, preserving all sibling content. It is idempotent: re-running with
+// an identical entry reports ActionUnchanged and writes nothing. When dryRun is
+// set, it computes the action but does not write.
+func InstallMCP(target *MCPTarget, env Env, entry map[string]any, serverName string, dryRun bool) (Outcome, error) {
+	path, err := target.ConfigPath(env)
+	if err != nil {
+		return failOutcome(Outcome{Artifact: "mcp"}, fmt.Errorf("resolve mcp config path: %w", err))
+	}
+
+	outcome := Outcome{Artifact: "mcp", Path: path}
+
+	m, err := loadConfig(target.Format, path)
+	if err != nil {
+		return failOutcome(outcome, err)
+	}
+
+	keyPath := append(append([]string{}, target.ServersKey...), serverName)
+
+	existing, present := codec.GetNested(m, keyPath...)
+	switch {
+	case !present:
+		outcome.Action = ActionAdded
+	case reflect.DeepEqual(existing, entry):
+		outcome.Action = ActionUnchanged
+	default:
+		outcome.Action = ActionUpdated
+	}
+
+	if dryRun || outcome.Action == ActionUnchanged {
+		return outcome, nil
+	}
+
+	codec.SetNested(m, entry, keyPath...)
+
+	if err := writeConfig(target.Format, path, m); err != nil {
+		return failOutcome(outcome, err)
+	}
+
+	return outcome, nil
+}
+
+// RemoveMCP deletes only the serverName entry from the agent's config file,
+// preserving all sibling servers. It never deletes the config file itself. An
+// absent entry (or missing file) reports ActionUnchanged, so uninstall is
+// idempotent. When dryRun is set, it computes the action but does not write.
+func RemoveMCP(target *MCPTarget, env Env, serverName string, dryRun bool) (Outcome, error) {
+	path, err := target.ConfigPath(env)
+	if err != nil {
+		return failOutcome(Outcome{Artifact: "mcp"}, fmt.Errorf("resolve mcp config path: %w", err))
+	}
+
+	outcome := Outcome{Artifact: "mcp", Path: path}
+
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	}
+
+	m, err := loadConfig(target.Format, path)
+	if err != nil {
+		return failOutcome(outcome, err)
+	}
+
+	keyPath := append(append([]string{}, target.ServersKey...), serverName)
+
+	if _, present := codec.GetNested(m, keyPath...); !present {
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	}
+
+	outcome.Action = ActionRemoved
+
+	if dryRun {
+		return outcome, nil
+	}
+
+	codec.DeleteNested(m, keyPath...)
+
+	if err := writeConfig(target.Format, path, m); err != nil {
+		return failOutcome(outcome, err)
+	}
+
+	return outcome, nil
+}
+
+// writeConfig encodes the map and writes it atomically.
+func writeConfig(format codec.Format, path string, m map[string]any) error {
+	data, err := codec.Encode(format, m)
+	if err != nil {
+		return fmt.Errorf("encode config %s: %w", path, err)
+	}
+
+	if err := fsutil.WriteAtomic(path, data, configFilePerm); err != nil {
+		return fmt.Errorf("write config %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// MCPEntryPresent reports whether our server entry already exists in the config.
+func MCPEntryPresent(target *MCPTarget, env Env, serverName string) bool {
+	path, err := target.ConfigPath(env)
+	if err != nil {
+		return false
+	}
+
+	m, err := loadConfig(target.Format, path)
+	if err != nil {
+		return false
+	}
+
+	keyPath := append(append([]string{}, target.ServersKey...), serverName)
+	_, present := codec.GetNested(m, keyPath...)
+
+	return present
+}
+
+// loadConfig reads and decodes a config file, treating a missing file as empty.
+func loadConfig(format codec.Format, path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]any{}, nil
+		}
+
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	m, err := codec.Decode(format, data)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+
+	return m, nil
+}

--- a/cli/internal/agentcfg/mcp_engine_test.go
+++ b/cli/internal/agentcfg/mcp_engine_test.go
@@ -1,0 +1,114 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg/codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testServerName = "agntcy-dir-mcp"
+
+func testMCPTarget(path string) *MCPTarget {
+	return &MCPTarget{
+		ConfigPath: func(_ Env) (string, error) { return path, nil },
+		Format:     codec.JSON,
+		ServersKey: []string{"mcpServers"},
+		EntryStyle: CommandArgsEnv,
+	}
+}
+
+func sampleEntry() map[string]any {
+	return map[string]any{
+		"command": "dirctl",
+		"args":    []any{"mcp", "serve"},
+		"env":     map[string]any{"DIRECTORY_CLIENT_SERVER_ADDRESS": "h:1"},
+	}
+}
+
+func TestInstallMCPCreatesFileWithEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "mcp.json")
+
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+	assert.Equal(t, path, outcome.Path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	m, err := codec.Decode(codec.JSON, data)
+	require.NoError(t, err)
+
+	_, ok := codec.GetNested(m, "mcpServers", testServerName)
+	assert.True(t, ok)
+}
+
+func TestInstallMCPPreservesForeignServers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"mcpServers":{"other":{"command":"node"}}}`), 0o600))
+
+	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+
+	data, _ := os.ReadFile(path)
+	m, _ := codec.Decode(codec.JSON, data)
+
+	other, ok := codec.GetNested(m, "mcpServers", "other")
+	require.True(t, ok)
+	otherMap, ok := other.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "node", otherMap["command"])
+
+	_, ok = codec.GetNested(m, "mcpServers", testServerName)
+	assert.True(t, ok)
+}
+
+func TestInstallMCPIdempotentSecondRunUnchanged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+
+	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+
+	first, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUnchanged, outcome.Action)
+
+	second, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestInstallMCPUpdatesChangedEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+
+	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+
+	changed := sampleEntry()
+	changed["env"] = map[string]any{"DIRECTORY_CLIENT_SERVER_ADDRESS": "h:2"}
+
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, changed, testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUpdated, outcome.Action)
+}
+
+func TestInstallMCPDryRunWritesNothing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, true)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/cli/internal/agentcfg/mcp_engine_test.go
+++ b/cli/internal/agentcfg/mcp_engine_test.go
@@ -112,3 +112,156 @@ func TestInstallMCPDryRunWritesNothing(t *testing.T) {
 	_, err = os.Stat(path)
 	assert.True(t, os.IsNotExist(err))
 }
+
+// --- YAML format ---
+
+func testYAMLMCPTarget(path string) *MCPTarget {
+	return &MCPTarget{
+		ConfigPath: func(_ Env) (string, error) { return path, nil },
+		Format:     codec.YAML,
+		ServersKey: []string{"mcpServers"},
+		EntryStyle: CommandArgsEnv,
+	}
+}
+
+func TestInstallMCPYAMLCreatesFileWithEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "config.yaml")
+
+	outcome, err := InstallMCP(testYAMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	m, err := codec.Decode(codec.YAML, data)
+	require.NoError(t, err)
+
+	_, ok := codec.GetNested(m, "mcpServers", testServerName)
+	assert.True(t, ok)
+}
+
+func TestInstallMCPYAMLPreservesForeignServers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("mcpServers:\n  other:\n    command: node\n"), 0o600))
+
+	_, err := InstallMCP(testYAMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+
+	data, _ := os.ReadFile(path)
+	m, _ := codec.Decode(codec.YAML, data)
+
+	_, ok := codec.GetNested(m, "mcpServers", "other")
+	assert.True(t, ok, "sibling server must be preserved")
+
+	_, ok = codec.GetNested(m, "mcpServers", testServerName)
+	assert.True(t, ok)
+}
+
+func TestRemoveMCPYAMLDeletesOnlyOurKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("mcpServers:\n  agntcy-dir-mcp:\n    command: dirctl\n  other:\n    command: node\n"), 0o600))
+
+	outcome, err := RemoveMCP(testYAMLMCPTarget(path), Env{}, testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionRemoved, outcome.Action)
+
+	data, _ := os.ReadFile(path)
+	m, _ := codec.Decode(codec.YAML, data)
+
+	_, ok := codec.GetNested(m, "mcpServers", testServerName)
+	assert.False(t, ok)
+
+	_, ok = codec.GetNested(m, "mcpServers", "other")
+	assert.True(t, ok, "foreign server must be preserved")
+}
+
+// --- TOML format ---
+
+func testTOMLMCPTarget(path string) *MCPTarget {
+	return &MCPTarget{
+		ConfigPath: func(_ Env) (string, error) { return path, nil },
+		Format:     codec.TOML,
+		ServersKey: []string{"mcp_servers"},
+		EntryStyle: CommandArgsEnv,
+	}
+}
+
+func TestInstallMCPTOMLCreatesFileWithEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "config.toml")
+
+	outcome, err := InstallMCP(testTOMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	m, err := codec.Decode(codec.TOML, data)
+	require.NoError(t, err)
+
+	_, ok := codec.GetNested(m, "mcp_servers", testServerName)
+	assert.True(t, ok)
+}
+
+func TestInstallMCPTOMLPreservesForeignServers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("[mcp_servers.other]\ncommand = \"node\"\n"), 0o600))
+
+	_, err := InstallMCP(testTOMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	require.NoError(t, err)
+
+	data, _ := os.ReadFile(path)
+	m, _ := codec.Decode(codec.TOML, data)
+
+	_, ok := codec.GetNested(m, "mcp_servers", "other")
+	assert.True(t, ok, "sibling server must be preserved")
+
+	_, ok = codec.GetNested(m, "mcp_servers", testServerName)
+	assert.True(t, ok)
+}
+
+func TestRemoveMCPTOMLDeletesOnlyOurKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("[mcp_servers.agntcy-dir-mcp]\ncommand = \"dirctl\"\n[mcp_servers.other]\ncommand = \"node\"\n"), 0o600))
+
+	outcome, err := RemoveMCP(testTOMLMCPTarget(path), Env{}, testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionRemoved, outcome.Action)
+
+	data, _ := os.ReadFile(path)
+	m, _ := codec.Decode(codec.TOML, data)
+
+	_, ok := codec.GetNested(m, "mcp_servers", testServerName)
+	assert.False(t, ok)
+
+	_, ok = codec.GetNested(m, "mcp_servers", "other")
+	assert.True(t, ok, "foreign server must be preserved")
+}
+
+// --- MCPEntryPresent ---
+
+func TestMCPEntryPresentTrue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"mcpServers":{"agntcy-dir-mcp":{"command":"dirctl"}}}`), 0o600))
+
+	assert.True(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName))
+}
+
+func TestMCPEntryPresentFalseWhenAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"mcpServers":{"other":{}}}`), 0o600))
+
+	assert.False(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName))
+}
+
+func TestMCPEntryPresentFalseWhenFileMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nonexistent.json")
+
+	assert.False(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName))
+}

--- a/cli/internal/agentcfg/mcp_remove_test.go
+++ b/cli/internal/agentcfg/mcp_remove_test.go
@@ -1,0 +1,63 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg/codec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveMCPDeletesOnlyOurKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	require.NoError(t, os.WriteFile(path, []byte(
+		`{"mcpServers":{"agntcy-dir-mcp":{"command":"dirctl"},"other":{"command":"node"}}}`), 0o600))
+
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionRemoved, outcome.Action)
+
+	data, _ := os.ReadFile(path)
+	m, _ := codec.Decode(codec.JSON, data)
+
+	_, ok := codec.GetNested(m, "mcpServers", testServerName)
+	assert.False(t, ok)
+
+	_, ok = codec.GetNested(m, "mcpServers", "other")
+	assert.True(t, ok, "foreign server must be preserved")
+}
+
+func TestRemoveMCPAbsentIsUnchanged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"mcpServers":{"other":{}}}`), 0o600))
+
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUnchanged, outcome.Action)
+}
+
+func TestRemoveMCPMissingFileIsUnchanged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nope.json")
+
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUnchanged, outcome.Action)
+}
+
+func TestRemoveMCPDryRunNoWrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	original := []byte(`{"mcpServers":{"agntcy-dir-mcp":{"command":"dirctl"}}}`)
+	require.NoError(t, os.WriteFile(path, original, 0o600))
+
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, true)
+	require.NoError(t, err)
+	assert.Equal(t, ActionRemoved, outcome.Action)
+
+	data, _ := os.ReadFile(path)
+	assert.Equal(t, original, data)
+}

--- a/cli/internal/agentcfg/options.go
+++ b/cli/internal/agentcfg/options.go
@@ -3,13 +3,6 @@
 
 package agentcfg
 
-// Selection is one agent resolved for action, plus whether it was forced
-// (explicitly selected or --force), which bypasses detection.
-type Selection struct {
-	Agent  Agent
-	Forced bool
-}
-
 // ArtifactSet records which artifacts to act on.
 type ArtifactSet struct {
 	MCP   bool
@@ -26,31 +19,32 @@ func ResolveArtifacts(mcpFlag, skillFlag bool) ArtifactSet {
 	return ArtifactSet{MCP: mcpFlag, Skill: skillFlag}
 }
 
-// ResolveSelection decides which agents to act on:
-//   - explicit per-agent flags → exactly those, forced (detection bypassed);
-//   - --force without explicit flags → all known agents, forced;
-//   - default or --all → detected agents only.
-func ResolveSelection(agents []Agent, env Env, chosen map[string]bool, all, force bool) []Selection {
+// ResolveSelection returns the agents to act on. Detection is always required —
+// an agent is never selected unless it is detected on this machine.
+//
+//   - When chosen is empty ("all"), every detected agent is selected.
+//   - When chosen is non-empty, only the chosen agents that are detected are
+//     selected; chosen agents that are not detected are returned as the second
+//     result so the caller can report them.
+func ResolveSelection(agents []Agent, env Env, chosen map[string]bool) ([]Agent, []string) {
 	explicit := len(chosen) > 0
 
-	var out []Selection
+	var selected []Agent
+
+	var skipped []string
 
 	for _, agent := range agents {
-		switch {
-		case explicit:
-			if chosen[agent.ID] {
-				out = append(out, Selection{Agent: agent, Forced: true})
-			}
-		case force:
-			out = append(out, Selection{Agent: agent, Forced: true})
-		default: // default and --all both act on detected agents
-			_ = all
+		if explicit && !chosen[agent.ID] {
+			continue
+		}
 
-			if agent.Detect(env) {
-				out = append(out, Selection{Agent: agent, Forced: false})
-			}
+		switch {
+		case agent.Detect(env):
+			selected = append(selected, agent)
+		case explicit:
+			skipped = append(skipped, agent.ID)
 		}
 	}
 
-	return out
+	return selected, skipped
 }

--- a/cli/internal/agentcfg/options.go
+++ b/cli/internal/agentcfg/options.go
@@ -1,0 +1,56 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+// Selection is one agent resolved for action, plus whether it was forced
+// (explicitly selected or --force), which bypasses detection.
+type Selection struct {
+	Agent  Agent
+	Forced bool
+}
+
+// ArtifactSet records which artifacts to act on.
+type ArtifactSet struct {
+	MCP   bool
+	Skill bool
+}
+
+// ResolveArtifacts maps the --mcp/--skill flags to the artifact set. Neither or
+// both flags means both artifacts.
+func ResolveArtifacts(mcpFlag, skillFlag bool) ArtifactSet {
+	if mcpFlag == skillFlag {
+		return ArtifactSet{MCP: true, Skill: true}
+	}
+
+	return ArtifactSet{MCP: mcpFlag, Skill: skillFlag}
+}
+
+// ResolveSelection decides which agents to act on:
+//   - explicit per-agent flags → exactly those, forced (detection bypassed);
+//   - --force without explicit flags → all known agents, forced;
+//   - default or --all → detected agents only.
+func ResolveSelection(agents []Agent, env Env, chosen map[string]bool, all, force bool) []Selection {
+	explicit := len(chosen) > 0
+
+	var out []Selection
+
+	for _, agent := range agents {
+		switch {
+		case explicit:
+			if chosen[agent.ID] {
+				out = append(out, Selection{Agent: agent, Forced: true})
+			}
+		case force:
+			out = append(out, Selection{Agent: agent, Forced: true})
+		default: // default and --all both act on detected agents
+			_ = all
+
+			if agent.Detect(env) {
+				out = append(out, Selection{Agent: agent, Forced: false})
+			}
+		}
+	}
+
+	return out
+}

--- a/cli/internal/agentcfg/options.go
+++ b/cli/internal/agentcfg/options.go
@@ -3,22 +3,6 @@
 
 package agentcfg
 
-// ArtifactSet records which artifacts to act on.
-type ArtifactSet struct {
-	MCP   bool
-	Skill bool
-}
-
-// ResolveArtifacts maps the --mcp/--skill flags to the artifact set. Neither or
-// both flags means both artifacts.
-func ResolveArtifacts(mcpFlag, skillFlag bool) ArtifactSet {
-	if mcpFlag == skillFlag {
-		return ArtifactSet{MCP: true, Skill: true}
-	}
-
-	return ArtifactSet{MCP: mcpFlag, Skill: skillFlag}
-}
-
 // ResolveSelection returns the agents to act on. Detection is always required —
 // an agent is never selected unless it is detected on this machine.
 //

--- a/cli/internal/agentcfg/options_test.go
+++ b/cli/internal/agentcfg/options_test.go
@@ -1,0 +1,65 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func fakeAgents() []Agent {
+	return []Agent{
+		{ID: "a", Name: "A", Flag: "a", Detect: func(Env) bool { return true }},
+		{ID: "b", Name: "B", Flag: "b", Detect: func(Env) bool { return false }},
+		{ID: "c", Name: "C", Flag: "c", Detect: func(Env) bool { return true }},
+	}
+}
+
+func selectedIDs(sels []Selection) []string {
+	ids := make([]string, 0, len(sels))
+	for _, s := range sels {
+		ids = append(ids, s.Agent.ID)
+	}
+
+	return ids
+}
+
+func TestResolveSelectionDefaultUsesDetected(t *testing.T) {
+	sels := ResolveSelection(fakeAgents(), Env{}, nil, false, false)
+	assert.Equal(t, []string{"a", "c"}, selectedIDs(sels))
+
+	for _, s := range sels {
+		assert.False(t, s.Forced)
+	}
+}
+
+func TestResolveSelectionExplicitFlagsForceChosen(t *testing.T) {
+	chosen := map[string]bool{"b": true}
+
+	sels := ResolveSelection(fakeAgents(), Env{}, chosen, false, false)
+	assert.Equal(t, []string{"b"}, selectedIDs(sels))
+	assert.True(t, sels[0].Forced)
+}
+
+func TestResolveSelectionAllUsesDetected(t *testing.T) {
+	sels := ResolveSelection(fakeAgents(), Env{}, nil, true, false)
+	assert.Equal(t, []string{"a", "c"}, selectedIDs(sels))
+}
+
+func TestResolveSelectionForceWithoutFlagsActsOnAll(t *testing.T) {
+	sels := ResolveSelection(fakeAgents(), Env{}, nil, false, true)
+	assert.Equal(t, []string{"a", "b", "c"}, selectedIDs(sels))
+
+	for _, s := range sels {
+		assert.True(t, s.Forced)
+	}
+}
+
+func TestResolveArtifacts(t *testing.T) {
+	assert.Equal(t, ArtifactSet{MCP: true, Skill: true}, ResolveArtifacts(false, false))
+	assert.Equal(t, ArtifactSet{MCP: true, Skill: true}, ResolveArtifacts(true, true))
+	assert.Equal(t, ArtifactSet{MCP: true, Skill: false}, ResolveArtifacts(true, false))
+	assert.Equal(t, ArtifactSet{MCP: false, Skill: true}, ResolveArtifacts(false, true))
+}

--- a/cli/internal/agentcfg/options_test.go
+++ b/cli/internal/agentcfg/options_test.go
@@ -17,44 +17,37 @@ func fakeAgents() []Agent {
 	}
 }
 
-func selectedIDs(sels []Selection) []string {
-	ids := make([]string, 0, len(sels))
-	for _, s := range sels {
-		ids = append(ids, s.Agent.ID)
+func agentIDs(agents []Agent) []string {
+	ids := make([]string, 0, len(agents))
+	for _, a := range agents {
+		ids = append(ids, a.ID)
 	}
 
 	return ids
 }
 
-func TestResolveSelectionDefaultUsesDetected(t *testing.T) {
-	sels := ResolveSelection(fakeAgents(), Env{}, nil, false, false)
-	assert.Equal(t, []string{"a", "c"}, selectedIDs(sels))
-
-	for _, s := range sels {
-		assert.False(t, s.Forced)
-	}
+func TestResolveSelectionEmptyChosenUsesDetected(t *testing.T) {
+	selected, skipped := ResolveSelection(fakeAgents(), Env{}, nil)
+	assert.Equal(t, []string{"a", "c"}, agentIDs(selected))
+	assert.Empty(t, skipped)
 }
 
-func TestResolveSelectionExplicitFlagsForceChosen(t *testing.T) {
+func TestResolveSelectionExplicitChosenOnlyDetected(t *testing.T) {
+	// "a" is detected, "b" is not; both requested.
+	chosen := map[string]bool{"a": true, "b": true}
+
+	selected, skipped := ResolveSelection(fakeAgents(), Env{}, chosen)
+	assert.Equal(t, []string{"a"}, agentIDs(selected))
+	assert.Equal(t, []string{"b"}, skipped)
+}
+
+func TestResolveSelectionUndetectedNeverInstalled(t *testing.T) {
+	// Requesting only an undetected agent selects nothing and reports it skipped.
 	chosen := map[string]bool{"b": true}
 
-	sels := ResolveSelection(fakeAgents(), Env{}, chosen, false, false)
-	assert.Equal(t, []string{"b"}, selectedIDs(sels))
-	assert.True(t, sels[0].Forced)
-}
-
-func TestResolveSelectionAllUsesDetected(t *testing.T) {
-	sels := ResolveSelection(fakeAgents(), Env{}, nil, true, false)
-	assert.Equal(t, []string{"a", "c"}, selectedIDs(sels))
-}
-
-func TestResolveSelectionForceWithoutFlagsActsOnAll(t *testing.T) {
-	sels := ResolveSelection(fakeAgents(), Env{}, nil, false, true)
-	assert.Equal(t, []string{"a", "b", "c"}, selectedIDs(sels))
-
-	for _, s := range sels {
-		assert.True(t, s.Forced)
-	}
+	selected, skipped := ResolveSelection(fakeAgents(), Env{}, chosen)
+	assert.Empty(t, selected)
+	assert.Equal(t, []string{"b"}, skipped)
 }
 
 func TestResolveArtifacts(t *testing.T) {

--- a/cli/internal/agentcfg/options_test.go
+++ b/cli/internal/agentcfg/options_test.go
@@ -49,10 +49,3 @@ func TestResolveSelectionUndetectedNeverInstalled(t *testing.T) {
 	assert.Empty(t, selected)
 	assert.Equal(t, []string{"b"}, skipped)
 }
-
-func TestResolveArtifacts(t *testing.T) {
-	assert.Equal(t, ArtifactSet{MCP: true, Skill: true}, ResolveArtifacts(false, false))
-	assert.Equal(t, ArtifactSet{MCP: true, Skill: true}, ResolveArtifacts(true, true))
-	assert.Equal(t, ArtifactSet{MCP: true, Skill: false}, ResolveArtifacts(true, false))
-	assert.Equal(t, ArtifactSet{MCP: false, Skill: true}, ResolveArtifacts(false, true))
-}

--- a/cli/internal/agentcfg/paths.go
+++ b/cli/internal/agentcfg/paths.go
@@ -1,0 +1,257 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// ResolveEnv captures the ambient environment for descriptor resolvers.
+func ResolveEnv() Env {
+	home, _ := os.UserHomeDir()
+	cwd, _ := os.Getwd()
+
+	return Env{Home: home, GOOS: runtime.GOOS, Cwd: cwd}
+}
+
+// vscodeUserDir returns the VS Code "User" config directory for the platform.
+// This is the parent of mcp.json, prompts/, and globalStorage/.
+func vscodeUserDir(env Env) string {
+	switch env.GOOS {
+	case "darwin":
+		return filepath.Join(env.Home, "Library", "Application Support", "Code", "User")
+	case "windows":
+		return filepath.Join(env.Home, "AppData", "Roaming", "Code", "User")
+	default:
+		return filepath.Join(env.Home, ".config", "Code", "User")
+	}
+}
+
+// appDataDir returns the per-platform directory GUI apps store config under.
+func appDataDir(env Env) string {
+	switch env.GOOS {
+	case "darwin":
+		return filepath.Join(env.Home, "Library", "Application Support")
+	case "windows":
+		return filepath.Join(env.Home, "AppData", "Roaming")
+	default:
+		return filepath.Join(env.Home, ".config")
+	}
+}
+
+func requireHome(env Env) error {
+	if env.Home == "" {
+		return fmt.Errorf("could not determine home directory")
+	}
+
+	return nil
+}
+
+// --- MCP config paths ---
+
+func claudeCodeMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".claude.json"), nil
+}
+
+func claudeDesktopMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(appDataDir(env), "Claude", "claude_desktop_config.json"), nil
+}
+
+func cursorMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".cursor", "mcp.json"), nil
+}
+
+func vscodeMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(vscodeUserDir(env), "mcp.json"), nil
+}
+
+func windsurfMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".codeium", "windsurf", "mcp_config.json"), nil
+}
+
+func clineMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(vscodeUserDir(env), "globalStorage",
+		"saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json"), nil
+}
+
+func rooMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(vscodeUserDir(env), "globalStorage",
+		"rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"), nil
+}
+
+func geminiMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".gemini", "settings.json"), nil
+}
+
+func opencodeMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".config", "opencode", "opencode.json"), nil
+}
+
+func zedMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".config", "zed", "settings.json"), nil
+}
+
+func continueMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".continue", "config.yaml"), nil
+}
+
+func codexMCPPath(env Env) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".codex", "config.toml"), nil
+}
+
+// --- skill / rules paths ---
+
+func claudeCodeSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".claude", "skills", slug, "SKILL.md"), nil
+}
+
+func zedSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".agents", "skills", slug, "SKILL.md"), nil
+}
+
+func copilotSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(vscodeUserDir(env), "prompts", slug+".instructions.md"), nil
+}
+
+func windsurfSkillPath(env Env, _ string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".codeium", "windsurf", "memories", "global_rules.md"), nil
+}
+
+func clineSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	// Cline reads global rules from ~/Documents/Cline/Rules on macOS/Windows and
+	// ~/Cline/Rules on Linux.
+	if env.GOOS == "linux" {
+		return filepath.Join(env.Home, "Cline", "Rules", slug+".md"), nil
+	}
+
+	return filepath.Join(env.Home, "Documents", "Cline", "Rules", slug+".md"), nil
+}
+
+func rooSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".roo", "rules", slug+".md"), nil
+}
+
+func continueSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".continue", "rules", slug+".md"), nil
+}
+
+func geminiSkillPath(env Env, _ string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".gemini", "GEMINI.md"), nil
+}
+
+func codexSkillPath(env Env, _ string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".codex", "AGENTS.md"), nil
+}
+
+func opencodeSkillPath(env Env, _ string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".config", "opencode", "AGENTS.md"), nil
+}
+
+// cursorNoGlobalSkill signals that Cursor has no global rules mechanism, so the
+// engine falls back to the project path.
+func cursorNoGlobalSkill(_ Env, _ string) (string, error) {
+	return "", ErrNoGlobalPath
+}
+
+func cursorProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Cursor project rule")
+	}
+
+	return filepath.Join(env.Cwd, ".cursor", "rules", slug+".mdc"), nil
+}
+
+func codexMarker(env Env) (string, error)    { return filepath.Join(env.Home, ".codex"), nil }
+func continueMarker(env Env) (string, error) { return filepath.Join(env.Home, ".continue"), nil }

--- a/cli/internal/agentcfg/paths_test.go
+++ b/cli/internal/agentcfg/paths_test.go
@@ -83,3 +83,296 @@ func TestResolveEnvReadsRealValues(t *testing.T) {
 	assert.NotEmpty(t, env.Home)
 	assert.NotEmpty(t, env.GOOS)
 }
+
+// --- requireHome ---
+
+func TestRequireHomeErrorOnEmpty(t *testing.T) {
+	err := requireHome(Env{Home: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "home directory")
+}
+
+func TestRequireHomeNoErrorWithHome(t *testing.T) {
+	assert.NoError(t, requireHome(Env{Home: "/home/u"}))
+}
+
+// --- MCP path tests for all platforms ---
+
+func TestClaudeDesktopMCPPathAllOS(t *testing.T) {
+	cases := []struct {
+		goos string
+		want []string
+	}{
+		{"darwin", []string{"/home/u", "Library", "Application Support", "Claude", "claude_desktop_config.json"}},
+		{"linux", []string{"/home/u", ".config", "Claude", "claude_desktop_config.json"}},
+		{"windows", []string{"/home/u", "AppData", "Roaming", "Claude", "claude_desktop_config.json"}},
+	}
+	for _, tc := range cases {
+		got, err := claudeDesktopMCPPath(Env{Home: "/home/u", GOOS: tc.goos})
+		require.NoError(t, err, tc.goos)
+		assert.Equal(t, filepath.Join(tc.want...), got, tc.goos)
+	}
+}
+
+func TestClaudeDesktopMCPPathEmptyHome(t *testing.T) {
+	_, err := claudeDesktopMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestWindsurfMCPPath(t *testing.T) {
+	got, err := windsurfMCPPath(Env{Home: "/home/u"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".codeium", "windsurf", "mcp_config.json"), got)
+}
+
+func TestWindsurfMCPPathEmptyHome(t *testing.T) {
+	_, err := windsurfMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestClineMCPPathAllOS(t *testing.T) {
+	cases := []struct {
+		goos string
+		want []string
+	}{
+		{"darwin", []string{"/home/u", "Library", "Application Support", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json"}},
+		{"linux", []string{"/home/u", ".config", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json"}},
+		{"windows", []string{"/home/u", "AppData", "Roaming", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json"}},
+	}
+	for _, tc := range cases {
+		got, err := clineMCPPath(Env{Home: "/home/u", GOOS: tc.goos})
+		require.NoError(t, err, tc.goos)
+		assert.Equal(t, filepath.Join(tc.want...), got, tc.goos)
+	}
+}
+
+func TestClineMCPPathEmptyHome(t *testing.T) {
+	_, err := clineMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestRooMCPPath(t *testing.T) {
+	got, err := rooMCPPath(Env{Home: "/home/u", GOOS: "linux"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".config", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"), got)
+}
+
+func TestRooMCPPathEmptyHome(t *testing.T) {
+	_, err := rooMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestVSCodeMCPPathAllOS(t *testing.T) {
+	cases := []struct {
+		goos string
+		want []string
+	}{
+		{"darwin", []string{"/home/u", "Library", "Application Support", "Code", "User", "mcp.json"}},
+		{"linux", []string{"/home/u", ".config", "Code", "User", "mcp.json"}},
+		{"windows", []string{"/home/u", "AppData", "Roaming", "Code", "User", "mcp.json"}},
+	}
+	for _, tc := range cases {
+		got, err := vscodeMCPPath(Env{Home: "/home/u", GOOS: tc.goos})
+		require.NoError(t, err, tc.goos)
+		assert.Equal(t, filepath.Join(tc.want...), got, tc.goos)
+	}
+}
+
+func TestVSCodeMCPPathEmptyHome(t *testing.T) {
+	_, err := vscodeMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestOpencodeMCPPath(t *testing.T) {
+	got, err := opencodeMCPPath(Env{Home: "/home/u"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".config", "opencode", "opencode.json"), got)
+}
+
+func TestOpencodeMCPPathEmptyHome(t *testing.T) {
+	_, err := opencodeMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestZedMCPPathEmptyHome(t *testing.T) {
+	_, err := zedMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestContinueMCPPath(t *testing.T) {
+	got, err := continueMCPPath(Env{Home: "/home/u"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".continue", "config.yaml"), got)
+}
+
+func TestContinueMCPPathEmptyHome(t *testing.T) {
+	_, err := continueMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+func TestCodexMCPPath(t *testing.T) {
+	got, err := codexMCPPath(Env{Home: "/home/u"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".codex", "config.toml"), got)
+}
+
+func TestCodexMCPPathEmptyHome(t *testing.T) {
+	_, err := codexMCPPath(Env{Home: ""})
+	assert.Error(t, err)
+}
+
+// --- Skill path tests ---
+
+func TestClaudeCodeSkillPath(t *testing.T) {
+	got, err := claudeCodeSkillPath(Env{Home: "/home/u"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".claude", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestClaudeCodeSkillPathEmptyHome(t *testing.T) {
+	_, err := claudeCodeSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestZedSkillPath(t *testing.T) {
+	got, err := zedSkillPath(Env{Home: "/home/u"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".agents", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestZedSkillPathEmptyHome(t *testing.T) {
+	_, err := zedSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestCopilotSkillPath(t *testing.T) {
+	got, err := copilotSkillPath(Env{Home: "/home/u", GOOS: "linux"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".config", "Code", "User", "prompts", "my-skill.instructions.md"), got)
+}
+
+func TestCopilotSkillPathEmptyHome(t *testing.T) {
+	_, err := copilotSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestWindsurfSkillPath(t *testing.T) {
+	got, err := windsurfSkillPath(Env{Home: "/home/u"}, "any-slug")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".codeium", "windsurf", "memories", "global_rules.md"), got)
+}
+
+func TestWindsurfSkillPathEmptyHome(t *testing.T) {
+	_, err := windsurfSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestClineSkillPathLinux(t *testing.T) {
+	got, err := clineSkillPath(Env{Home: "/home/u", GOOS: "linux"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", "Cline", "Rules", "my-skill.md"), got)
+}
+
+func TestClineSkillPathDarwin(t *testing.T) {
+	got, err := clineSkillPath(Env{Home: "/home/u", GOOS: "darwin"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", "Documents", "Cline", "Rules", "my-skill.md"), got)
+}
+
+func TestClineSkillPathWindows(t *testing.T) {
+	got, err := clineSkillPath(Env{Home: "/home/u", GOOS: "windows"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", "Documents", "Cline", "Rules", "my-skill.md"), got)
+}
+
+func TestClineSkillPathEmptyHome(t *testing.T) {
+	_, err := clineSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestRooSkillPath(t *testing.T) {
+	got, err := rooSkillPath(Env{Home: "/home/u"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".roo", "rules", "my-skill.md"), got)
+}
+
+func TestRooSkillPathEmptyHome(t *testing.T) {
+	_, err := rooSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestContinueSkillPath(t *testing.T) {
+	got, err := continueSkillPath(Env{Home: "/home/u"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".continue", "rules", "my-skill.md"), got)
+}
+
+func TestContinueSkillPathEmptyHome(t *testing.T) {
+	_, err := continueSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestGeminiSkillPath(t *testing.T) {
+	got, err := geminiSkillPath(Env{Home: "/home/u"}, "any-slug")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".gemini", "GEMINI.md"), got)
+}
+
+func TestGeminiSkillPathEmptyHome(t *testing.T) {
+	_, err := geminiSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestCodexSkillPath(t *testing.T) {
+	got, err := codexSkillPath(Env{Home: "/home/u"}, "any-slug")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".codex", "AGENTS.md"), got)
+}
+
+func TestCodexSkillPathEmptyHome(t *testing.T) {
+	_, err := codexSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestOpencodeSkillPath(t *testing.T) {
+	got, err := opencodeSkillPath(Env{Home: "/home/u"}, "any-slug")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".config", "opencode", "AGENTS.md"), got)
+}
+
+func TestOpencodeSkillPathEmptyHome(t *testing.T) {
+	_, err := opencodeSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+// --- cursorNoGlobalSkill and cursorProjectSkillPath ---
+
+func TestCursorNoGlobalSkillReturnsErrNoGlobalPath(t *testing.T) {
+	_, err := cursorNoGlobalSkill(Env{Home: "/home/u"}, "slug")
+	assert.ErrorIs(t, err, ErrNoGlobalPath)
+}
+
+func TestCursorProjectSkillPath(t *testing.T) {
+	got, err := cursorProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/repo", ".cursor", "rules", "my-skill.mdc"), got)
+}
+
+func TestCursorProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := cursorProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
+	assert.Error(t, err)
+}
+
+// --- appDataDir ---
+
+func TestAppDataDirByOS(t *testing.T) {
+	assert.Equal(t,
+		filepath.Join("/home/u", "Library", "Application Support"),
+		appDataDir(Env{Home: "/home/u", GOOS: "darwin"}))
+	assert.Equal(t,
+		filepath.Join("/home/u", "AppData", "Roaming"),
+		appDataDir(Env{Home: "/home/u", GOOS: "windows"}))
+	assert.Equal(t,
+		filepath.Join("/home/u", ".config"),
+		appDataDir(Env{Home: "/home/u", GOOS: "linux"}))
+}

--- a/cli/internal/agentcfg/paths_test.go
+++ b/cli/internal/agentcfg/paths_test.go
@@ -1,0 +1,85 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVSCodeUserDirByOS(t *testing.T) {
+	assert.Equal(t,
+		filepath.Join("/home/u", "Library", "Application Support", "Code", "User"),
+		vscodeUserDir(Env{Home: "/home/u", GOOS: "darwin"}))
+	assert.Equal(t,
+		filepath.Join("/home/u", ".config", "Code", "User"),
+		vscodeUserDir(Env{Home: "/home/u", GOOS: "linux"}))
+	assert.Equal(t,
+		filepath.Join("/home/u", "AppData", "Roaming", "Code", "User"),
+		vscodeUserDir(Env{Home: "/home/u", GOOS: "windows"}))
+}
+
+func TestClaudeCodeMCPPath(t *testing.T) {
+	got, err := claudeCodeMCPPath(Env{Home: "/home/u", GOOS: "linux"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".claude.json"), got)
+}
+
+func TestCursorMCPPath(t *testing.T) {
+	got, err := cursorMCPPath(Env{Home: "/home/u"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".cursor", "mcp.json"), got)
+}
+
+func TestVSCodeMCPPathDarwin(t *testing.T) {
+	got, err := vscodeMCPPath(Env{Home: "/home/u", GOOS: "darwin"})
+	require.NoError(t, err)
+	assert.Equal(t,
+		filepath.Join("/home/u", "Library", "Application Support", "Code", "User", "mcp.json"),
+		got)
+}
+
+func TestClaudeDesktopMCPPathByOS(t *testing.T) {
+	got, err := claudeDesktopMCPPath(Env{Home: "/home/u", GOOS: "darwin"})
+	require.NoError(t, err)
+	assert.Equal(t,
+		filepath.Join("/home/u", "Library", "Application Support", "Claude", "claude_desktop_config.json"),
+		got)
+
+	got, err = claudeDesktopMCPPath(Env{Home: "/home/u", GOOS: "linux"})
+	require.NoError(t, err)
+	assert.Equal(t,
+		filepath.Join("/home/u", ".config", "Claude", "claude_desktop_config.json"),
+		got)
+}
+
+func TestClineMCPPathDarwin(t *testing.T) {
+	got, err := clineMCPPath(Env{Home: "/home/u", GOOS: "darwin"})
+	require.NoError(t, err)
+	assert.Equal(t,
+		filepath.Join("/home/u", "Library", "Application Support", "Code", "User",
+			"globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json"),
+		got)
+}
+
+func TestGeminiMCPPath(t *testing.T) {
+	got, err := geminiMCPPath(Env{Home: "/home/u"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".gemini", "settings.json"), got)
+}
+
+func TestZedMCPPath(t *testing.T) {
+	got, err := zedMCPPath(Env{Home: "/home/u"})
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".config", "zed", "settings.json"), got)
+}
+
+func TestResolveEnvReadsRealValues(t *testing.T) {
+	env := ResolveEnv()
+	assert.NotEmpty(t, env.Home)
+	assert.NotEmpty(t, env.GOOS)
+}

--- a/cli/internal/agentcfg/plan.go
+++ b/cli/internal/agentcfg/plan.go
@@ -1,0 +1,41 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatPlan renders prospective (dry-run) outcomes as a preview, one line per
+// artifact with the action that will be taken, so a replace of an existing
+// older artifact (ActionUpdated) is visible before the user confirms.
+func FormatPlan(outcomes []Outcome) string {
+	var b strings.Builder
+
+	b.WriteString("The following changes will be made:\n")
+
+	if len(outcomes) == 0 {
+		b.WriteString("  No supported agents selected or detected.\n")
+
+		return b.String()
+	}
+
+	for _, o := range outcomes {
+		path := o.Path
+		if path == "" {
+			path = "-"
+		}
+
+		fmt.Fprintf(&b, "  %-9s %-5s %s  (%s)", o.Action, o.Artifact, path, o.Agent)
+
+		if o.Reason != "" {
+			fmt.Fprintf(&b, ": %s", o.Reason)
+		}
+
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/cli/internal/agentcfg/plan_test.go
+++ b/cli/internal/agentcfg/plan_test.go
@@ -1,0 +1,29 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatPlanShowsActionsPerArtifact(t *testing.T) {
+	out := FormatPlan([]Outcome{
+		{Agent: "Claude Code", Artifact: "mcp", Path: "/home/u/.claude.json", Action: ActionAdded},
+		{Agent: "Cursor", Artifact: "skill", Path: "/repo/.cursor/rules/rec.mdc", Action: ActionUpdated},
+	})
+
+	for _, want := range []string{"added", "updated", "/home/u/.claude.json", "Cursor", "will be made"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatPlanEmpty(t *testing.T) {
+	out := FormatPlan(nil)
+	if !strings.Contains(out, "No supported agents") {
+		t.Errorf("expected empty-plan notice, got:\n%s", out)
+	}
+}

--- a/cli/internal/agentcfg/registry.go
+++ b/cli/internal/agentcfg/registry.go
@@ -1,0 +1,232 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg/codec"
+)
+
+// Registry returns the descriptors for every supported AI coding agent.
+// Adding an agent is a matter of appending a descriptor here.
+func Registry() []Agent {
+	return []Agent{
+		{
+			ID:     "claude-code",
+			Name:   "Claude Code",
+			Flag:   "claude-code",
+			Detect: detectByMarker(claudeCodeMarker),
+			MCP:    jsonMCP(claudeCodeMCPPath, "mcpServers"),
+			Skill: &SkillTarget{
+				Strategy: SkillFolder,
+				Path:     claudeCodeSkillPath,
+			},
+		},
+		{
+			ID:     "claude-desktop",
+			Name:   "Claude Desktop",
+			Flag:   "claude-desktop",
+			Detect: detectByMarker(claudeDesktopMarker),
+			MCP:    jsonMCP(claudeDesktopMCPPath, "mcpServers"),
+			Skill: &SkillTarget{
+				Strategy:   SkillFolder,
+				Path:       claudeCodeSkillPath, // shares Claude Code's skills folder
+				SharedWith: "claude-code",
+			},
+		},
+		{
+			ID:     "cursor",
+			Name:   "Cursor",
+			Flag:   "cursor",
+			Detect: detectByMarker(cursorMarker),
+			MCP:    jsonMCP(cursorMCPPath, "mcpServers"),
+			Skill: &SkillTarget{
+				Strategy:    DedicatedFile,
+				Path:        cursorNoGlobalSkill, // no global rules mechanism
+				ProjectPath: cursorProjectSkillPath,
+				Render:      renderCursor,
+			},
+		},
+		{
+			ID:     "vscode",
+			Name:   "VS Code (Copilot)",
+			Flag:   "vscode",
+			Detect: detectByMarker(vscodeMarker),
+			MCP:    jsonMCP(vscodeMCPPath, "servers"),
+			Skill: &SkillTarget{
+				Strategy: DedicatedFile,
+				Path:     copilotSkillPath,
+				Render:   renderCopilot,
+			},
+		},
+		{
+			ID:     "windsurf",
+			Name:   "Windsurf",
+			Flag:   "windsurf",
+			Detect: detectByMarker(windsurfMarker),
+			MCP:    jsonMCP(windsurfMCPPath, "mcpServers"),
+			Skill: &SkillTarget{
+				Strategy: ManagedBlock,
+				Path:     windsurfSkillPath,
+				Render:   renderManagedInner,
+			},
+		},
+		{
+			ID:     "cline",
+			Name:   "Cline",
+			Flag:   "cline",
+			Detect: detectByMarker(clineMarker),
+			MCP:    jsonMCP(clineMCPPath, "mcpServers"),
+			Skill: &SkillTarget{
+				Strategy: DedicatedFile,
+				Path:     clineSkillPath,
+				Render:   renderCline,
+			},
+		},
+		{
+			ID:     "roo",
+			Name:   "Roo Code",
+			Flag:   "roo",
+			Detect: detectByMarker(rooMarker),
+			MCP:    jsonMCP(rooMCPPath, "mcpServers"),
+			Skill: &SkillTarget{
+				Strategy: DedicatedFile,
+				Path:     rooSkillPath,
+				Render:   renderRoo,
+			},
+		},
+		{
+			ID:     "gemini",
+			Name:   "Gemini CLI",
+			Flag:   "gemini",
+			Detect: detectByMarker(geminiMarker),
+			MCP:    jsonMCP(geminiMCPPath, "mcpServers"),
+			Skill: &SkillTarget{
+				Strategy: ManagedBlock,
+				Path:     geminiSkillPath,
+				Render:   renderManagedInner,
+			},
+		},
+		{
+			ID:     "opencode",
+			Name:   "OpenCode",
+			Flag:   "opencode",
+			Detect: detectByMarker(opencodeMarker),
+			MCP:    jsonMCP(opencodeMCPPath, "mcp"),
+			Skill: &SkillTarget{
+				Strategy: ManagedBlock,
+				Path:     opencodeSkillPath,
+				Render:   renderManagedInner,
+			},
+		},
+		{
+			ID:     "zed",
+			Name:   "Zed",
+			Flag:   "zed",
+			Detect: detectByMarker(zedMarker),
+			MCP: &MCPTarget{
+				ConfigPath: zedMCPPath,
+				Format:     codec.JSON,
+				ServersKey: []string{"context_servers"},
+				EntryStyle: ZedContextServer,
+			},
+			Skill: &SkillTarget{
+				Strategy: SkillFolder,
+				Path:     zedSkillPath,
+			},
+		},
+		{
+			ID:     "continue",
+			Name:   "Continue",
+			Flag:   "continue",
+			Detect: detectByMarker(continueMarker),
+			MCP: &MCPTarget{
+				ConfigPath: continueMCPPath,
+				Format:     codec.YAML,
+				ServersKey: []string{"mcpServers"},
+				EntryStyle: CommandArgsEnv,
+			},
+			Skill: &SkillTarget{
+				Strategy: DedicatedFile,
+				Path:     continueSkillPath,
+				Render:   renderContinue,
+			},
+		},
+		{
+			ID:     "codex",
+			Name:   "Codex CLI",
+			Flag:   "codex",
+			Detect: detectByMarker(codexMarker),
+			MCP: &MCPTarget{
+				ConfigPath: codexMCPPath,
+				Format:     codec.TOML,
+				ServersKey: []string{"mcp_servers"},
+				EntryStyle: CommandArgsEnv,
+			},
+			Skill: &SkillTarget{
+				Strategy: ManagedBlock,
+				Path:     codexSkillPath,
+				Render:   renderManagedInner,
+			},
+		},
+	}
+}
+
+// jsonMCP is a small constructor for the common JSON MCP target shape.
+func jsonMCP(configPath func(env Env) (string, error), serversKey string) *MCPTarget {
+	return &MCPTarget{
+		ConfigPath: configPath,
+		Format:     codec.JSON,
+		ServersKey: []string{serversKey},
+		EntryStyle: CommandArgsEnv,
+	}
+}
+
+// detectByMarker builds a Detect func that reports whether the resolved marker
+// path exists on disk.
+func detectByMarker(resolve func(env Env) (string, error)) func(env Env) bool {
+	return func(env Env) bool {
+		path, err := resolve(env)
+		if err != nil || path == "" {
+			return false
+		}
+
+		_, statErr := os.Stat(path)
+
+		return statErr == nil
+	}
+}
+
+// --- detection markers (config dirs/files that imply the agent is installed) ---
+
+func claudeCodeMarker(env Env) (string, error) { return filepath.Join(env.Home, ".claude"), nil }
+func cursorMarker(env Env) (string, error)     { return filepath.Join(env.Home, ".cursor"), nil }
+func geminiMarker(env Env) (string, error)     { return filepath.Join(env.Home, ".gemini"), nil }
+func zedMarker(env Env) (string, error)        { return filepath.Join(env.Home, ".config", "zed"), nil }
+
+func windsurfMarker(env Env) (string, error) {
+	return filepath.Join(env.Home, ".codeium", "windsurf"), nil
+}
+
+func opencodeMarker(env Env) (string, error) {
+	return filepath.Join(env.Home, ".config", "opencode"), nil
+}
+
+func claudeDesktopMarker(env Env) (string, error) {
+	return filepath.Join(appDataDir(env), "Claude"), nil
+}
+
+func vscodeMarker(env Env) (string, error) {
+	return vscodeUserDir(env), nil
+}
+
+func clineMarker(env Env) (string, error) {
+	return filepath.Join(vscodeUserDir(env), "globalStorage", "saoudrizwan.claude-dev"), nil
+}
+
+func rooMarker(env Env) (string, error) {
+	return filepath.Join(vscodeUserDir(env), "globalStorage", "rooveterinaryinc.roo-cline"), nil
+}

--- a/cli/internal/agentcfg/registry_test.go
+++ b/cli/internal/agentcfg/registry_test.go
@@ -1,0 +1,92 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryHasUniqueIDsAndFlags(t *testing.T) {
+	agents := Registry()
+	require.NotEmpty(t, agents)
+
+	ids := map[string]bool{}
+	flags := map[string]bool{}
+
+	for _, a := range agents {
+		assert.NotEmpty(t, a.ID, "agent has empty ID")
+		assert.NotEmpty(t, a.Name, "agent %s has empty Name", a.ID)
+		assert.NotEmpty(t, a.Flag, "agent %s has empty Flag", a.ID)
+		assert.NotNil(t, a.Detect, "agent %s has nil Detect", a.ID)
+
+		assert.False(t, ids[a.ID], "duplicate agent ID %s", a.ID)
+		assert.False(t, flags[a.Flag], "duplicate agent flag %s", a.Flag)
+		ids[a.ID] = true
+		flags[a.Flag] = true
+	}
+}
+
+func TestRegistryMCPTargetsResolve(t *testing.T) {
+	env := Env{Home: "/home/u", GOOS: "linux"}
+
+	for _, a := range Registry() {
+		if a.MCP == nil {
+			continue
+		}
+
+		path, err := a.MCP.ConfigPath(env)
+		require.NoError(t, err, "agent %s MCP path", a.ID)
+		assert.NotEmpty(t, path)
+		assert.NotEmpty(t, a.MCP.ServersKey, "agent %s missing ServersKey", a.ID)
+	}
+}
+
+func TestRegistryIncludesExpectedAgents(t *testing.T) {
+	want := []string{
+		"claude-code", "claude-desktop", "cursor", "vscode", "windsurf",
+		"cline", "roo", "gemini", "opencode", "zed", "continue", "codex",
+	}
+
+	have := map[string]bool{}
+	for _, a := range Registry() {
+		have[a.ID] = true
+	}
+
+	for _, id := range want {
+		assert.True(t, have[id], "registry missing agent %s", id)
+	}
+}
+
+func TestRegistrySkillTargetsResolve(t *testing.T) {
+	env := Env{Home: "/home/u", GOOS: "linux", Cwd: "/repo"}
+
+	for _, a := range Registry() {
+		if a.Skill == nil {
+			continue
+		}
+
+		path, _, err := resolveSkillTargetPath(a.Skill, env, "test-slug")
+		require.NoError(t, err, "agent %s skill path", a.ID)
+		assert.NotEmpty(t, path, "agent %s resolved empty skill path", a.ID)
+
+		// DedicatedFile and ManagedBlock targets must carry a renderer.
+		if a.Skill.Strategy != SkillFolder {
+			assert.NotNil(t, a.Skill.Render, "agent %s missing skill renderer", a.ID)
+		}
+	}
+}
+
+func TestDetectByMarkerUsesEnvHome(t *testing.T) {
+	dir := t.TempDir()
+
+	// A marker that exists resolves true; a missing one resolves false.
+	exists := detectByMarker(func(_ Env) (string, error) { return dir, nil })
+	assert.True(t, exists(Env{}))
+
+	missing := detectByMarker(func(_ Env) (string, error) { return dir + "/nope", nil })
+	assert.False(t, missing(Env{}))
+}

--- a/cli/internal/agentcfg/result.go
+++ b/cli/internal/agentcfg/result.go
@@ -1,0 +1,41 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+// Action is the outcome of touching a single artifact location.
+type Action string
+
+const (
+	// ActionAdded means a new entry/file was created.
+	ActionAdded Action = "added"
+	// ActionUpdated means an existing entry/file of ours was replaced.
+	ActionUpdated Action = "updated"
+	// ActionRemoved means our entry/file was deleted.
+	ActionRemoved Action = "removed"
+	// ActionUnchanged means our entry/file already matched; nothing was written.
+	ActionUnchanged Action = "unchanged"
+	// ActionSkipped means we deliberately did not act (with a reason).
+	ActionSkipped Action = "skipped"
+	// ActionFailed means an error occurred for this artifact.
+	ActionFailed Action = "failed"
+)
+
+// failOutcome marks an outcome as failed with err and returns both, so callers
+// can `return failOutcome(outcome, fmt.Errorf(...))` in one line.
+func failOutcome(outcome Outcome, err error) (Outcome, error) {
+	outcome.Action = ActionFailed
+	outcome.Err = err
+
+	return outcome, err
+}
+
+// Outcome records what happened to one artifact (MCP or skill) for one agent.
+type Outcome struct {
+	Agent    string // human-readable agent name
+	Artifact string // "mcp" or "skill"
+	Path     string // absolute path that was (or would be) touched
+	Action   Action
+	Reason   string // populated on skip/fail or notable fallbacks
+	Err      error
+}

--- a/cli/internal/agentcfg/skill_block.go
+++ b/cli/internal/agentcfg/skill_block.go
@@ -1,0 +1,86 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import "strings"
+
+func blockBegin(slug string) string {
+	return "<!-- BEGIN " + slug + " (managed by dirctl) -->"
+}
+
+func blockEnd(slug string) string {
+	return "<!-- END " + slug + " -->"
+}
+
+// hasBlock reports whether the content already contains our managed block for slug.
+func hasBlock(slug, content string) bool {
+	return strings.Contains(content, blockBegin(slug)) && strings.Contains(content, blockEnd(slug))
+}
+
+// upsertBlock inserts our managed block carrying inner, or replaces the existing
+// block for slug in place, preserving all other content.
+func upsertBlock(slug, existing, inner string) string {
+	begin, end := blockBegin(slug), blockEnd(slug)
+	block := begin + "\n" + strings.TrimRight(inner, "\n") + "\n" + end + "\n"
+
+	if hasBlock(slug, existing) {
+		before, _, found := strings.Cut(existing, begin)
+		if !found {
+			return appendBlock(existing, block)
+		}
+
+		_, after, found := strings.Cut(existing, end)
+		if !found {
+			return appendBlock(existing, block)
+		}
+
+		after = strings.TrimPrefix(after, "\n")
+
+		return before + block + after
+	}
+
+	return appendBlock(existing, block)
+}
+
+func appendBlock(existing, block string) string {
+	if existing == "" {
+		return block
+	}
+
+	separator := "\n"
+	if strings.HasSuffix(existing, "\n") {
+		separator = ""
+	}
+
+	return existing + separator + "\n" + block
+}
+
+// removeBlock strips our managed block for slug from content. It reports whether
+// a block was found and removed.
+func removeBlock(slug, content string) (string, bool) {
+	if !hasBlock(slug, content) {
+		return content, false
+	}
+
+	begin, end := blockBegin(slug), blockEnd(slug)
+
+	before, _, found := strings.Cut(content, begin)
+	if !found {
+		return content, false
+	}
+
+	_, after, found := strings.Cut(content, end)
+	if !found {
+		return content, false
+	}
+
+	after = strings.TrimPrefix(after, "\n")
+	result := strings.TrimRight(before, "\n")
+
+	if result != "" && after != "" {
+		result += "\n"
+	}
+
+	return result + after, true
+}

--- a/cli/internal/agentcfg/skill_block_test.go
+++ b/cli/internal/agentcfg/skill_block_test.go
@@ -1,0 +1,83 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testSlug = "agntcy-dir"
+
+func TestUpsertBlockInsertsIntoEmpty(t *testing.T) {
+	out := upsertBlock(testSlug, "", "HELLO")
+
+	assert.True(t, hasBlock(testSlug, out))
+	assert.Contains(t, out, blockBegin(testSlug))
+	assert.Contains(t, out, "HELLO")
+	assert.Contains(t, out, blockEnd(testSlug))
+}
+
+func TestUpsertBlockAppendsPreservingUserContent(t *testing.T) {
+	existing := "# My rules\n\nKeep this.\n"
+
+	out := upsertBlock(testSlug, existing, "OURS")
+
+	assert.Contains(t, out, "Keep this.")
+	assert.Contains(t, out, "OURS")
+	assert.Less(t, strings.Index(out, "Keep this."), strings.Index(out, "OURS"))
+}
+
+func TestUpsertBlockReplacesExistingBlock(t *testing.T) {
+	first := upsertBlock(testSlug, "# Header\n", "OLD CONTENT")
+	second := upsertBlock(testSlug, first, "NEW CONTENT")
+
+	assert.Contains(t, second, "NEW CONTENT")
+	assert.NotContains(t, second, "OLD CONTENT")
+	assert.Contains(t, second, "# Header")
+	// Only one block.
+	assert.Equal(t, 1, strings.Count(second, blockBegin(testSlug)))
+}
+
+func TestRemoveBlockStripsOnlyOurBlock(t *testing.T) {
+	existing := "# Header\n\nUser text.\n"
+	withBlock := upsertBlock(testSlug, existing, "OURS")
+
+	out, removed := removeBlock(testSlug, withBlock)
+	assert.True(t, removed)
+	assert.NotContains(t, out, "OURS")
+	assert.NotContains(t, out, blockBegin(testSlug))
+	assert.Contains(t, out, "User text.")
+}
+
+func TestRemoveBlockAbsentReturnsFalse(t *testing.T) {
+	out, removed := removeBlock(testSlug, "no block here\n")
+	assert.False(t, removed)
+	assert.Equal(t, "no block here\n", out)
+}
+
+func TestManagedBlockTwoSlugsCoexist(t *testing.T) {
+	existing := ""
+	existing = upsertBlock("record-a", existing, "body A")
+	existing = upsertBlock("record-b", existing, "body B")
+
+	if !hasBlock("record-a", existing) || !hasBlock("record-b", existing) {
+		t.Fatalf("both blocks should be present:\n%s", existing)
+	}
+
+	stripped, removed := removeBlock("record-a", existing)
+	if !removed {
+		t.Fatal("record-a block should have been removed")
+	}
+
+	if hasBlock("record-a", stripped) {
+		t.Fatal("record-a block should be gone")
+	}
+
+	if !hasBlock("record-b", stripped) {
+		t.Fatalf("record-b block must survive:\n%s", stripped)
+	}
+}

--- a/cli/internal/agentcfg/skill_engine.go
+++ b/cli/internal/agentcfg/skill_engine.go
@@ -1,0 +1,249 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg/fsutil"
+)
+
+const skillFilePerm = 0o644
+
+// InstallSkill renders and writes the DIR skill/rules for an agent using its
+// strategy. It is idempotent: identical content reports ActionUnchanged. When
+// the global path is unavailable it falls back to the project path and notes
+// this in the outcome reason.
+func InstallSkill(target *SkillTarget, env Env, slug, canonical string, dryRun bool) (Outcome, error) {
+	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+	if err != nil {
+		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
+	}
+
+	outcome := Outcome{Artifact: "skill", Path: path}
+	if usedProject {
+		outcome.Reason = "no global rules path for this agent — wrote a project rule in the current repo"
+	}
+
+	desired, err := renderForTarget(target, slug, canonical, path)
+	if err != nil {
+		outcome.Action = ActionFailed
+		outcome.Err = err
+
+		return outcome, err
+	}
+
+	existing, existed := readFileIfExists(path)
+
+	switch {
+	case target.Strategy == ManagedBlock:
+		hadBlock := hasBlock(slug, string(existing))
+		if bytes.Equal(existing, desired) {
+			outcome.Action = ActionUnchanged
+
+			return outcome, nil
+		}
+
+		if existed && hadBlock {
+			outcome.Action = ActionUpdated
+		} else {
+			outcome.Action = ActionAdded
+		}
+	case !existed:
+		outcome.Action = ActionAdded
+	case bytes.Equal(existing, desired):
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	default:
+		outcome.Action = ActionUpdated
+	}
+
+	if dryRun {
+		return outcome, nil
+	}
+
+	if err := fsutil.WriteAtomic(path, desired, skillFilePerm); err != nil {
+		return failOutcome(outcome, fmt.Errorf("write skill %s: %w", path, err))
+	}
+
+	return outcome, nil
+}
+
+// RemoveSkill removes the DIR skill/rules we installed for an agent, preserving
+// any surrounding user content for managed-block files. Absent artifacts report
+// ActionUnchanged so uninstall is idempotent.
+func RemoveSkill(target *SkillTarget, env Env, slug string, dryRun bool) (Outcome, error) {
+	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+	if err != nil {
+		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
+	}
+
+	outcome := Outcome{Artifact: "skill", Path: path}
+	_ = usedProject
+
+	switch target.Strategy {
+	case SkillFolder:
+		return removeSkillFolder(outcome, path, dryRun)
+	case ManagedBlock:
+		return removeSkillBlock(outcome, path, slug, dryRun)
+	case DedicatedFile:
+		fallthrough
+	default:
+		return removeSkillFile(outcome, path, dryRun)
+	}
+}
+
+// renderForTarget produces the on-disk bytes for the target strategy.
+func renderForTarget(target *SkillTarget, slug, canonical, path string) ([]byte, error) {
+	switch target.Strategy {
+	case SkillFolder:
+		return []byte(canonical), nil
+	case ManagedBlock:
+		if target.Render == nil {
+			return nil, fmt.Errorf("managed-block target %s has no renderer", path)
+		}
+
+		inner, err := target.Render(canonical)
+		if err != nil {
+			return nil, err
+		}
+
+		existing, _ := readFileIfExists(path)
+
+		return []byte(upsertBlock(slug, string(existing), string(inner))), nil
+	case DedicatedFile:
+		fallthrough
+	default:
+		if target.Render == nil {
+			return nil, fmt.Errorf("dedicated-file target %s has no renderer", path)
+		}
+
+		return target.Render(canonical)
+	}
+}
+
+func removeSkillFolder(outcome Outcome, path string, dryRun bool) (Outcome, error) {
+	dir := filepath.Dir(path) // the slug/ folder we own
+	outcome.Path = dir
+
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	}
+
+	outcome.Action = ActionRemoved
+	if dryRun {
+		return outcome, nil
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		return failOutcome(outcome, fmt.Errorf("remove skill folder %s: %w", dir, err))
+	}
+
+	return outcome, nil
+}
+
+func removeSkillFile(outcome Outcome, path string, dryRun bool) (Outcome, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	}
+
+	outcome.Action = ActionRemoved
+	if dryRun {
+		return outcome, nil
+	}
+
+	if err := os.Remove(path); err != nil {
+		return failOutcome(outcome, fmt.Errorf("remove skill file %s: %w", path, err))
+	}
+
+	return outcome, nil
+}
+
+func removeSkillBlock(outcome Outcome, path, slug string, dryRun bool) (Outcome, error) {
+	existing, existed := readFileIfExists(path)
+	if !existed {
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	}
+
+	stripped, removed := removeBlock(slug, string(existing))
+	if !removed {
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	}
+
+	outcome.Action = ActionRemoved
+	if dryRun {
+		return outcome, nil
+	}
+
+	// If our block was the only content, remove the now-empty file.
+	if strings.TrimSpace(stripped) == "" {
+		if err := os.Remove(path); err != nil {
+			return failOutcome(outcome, fmt.Errorf("remove emptied skill file %s: %w", path, err))
+		}
+
+		return outcome, nil
+	}
+
+	if err := fsutil.WriteAtomic(path, []byte(stripped), skillFilePerm); err != nil {
+		return failOutcome(outcome, fmt.Errorf("write skill %s: %w", path, err))
+	}
+
+	return outcome, nil
+}
+
+// resolveSkillTargetPath resolves the global path, falling back to the project
+// path when the global resolver reports ErrNoGlobalPath. It reports whether the
+// project fallback was used.
+func resolveSkillTargetPath(target *SkillTarget, env Env, slug string) (string, bool, error) {
+	if target.Path != nil {
+		path, err := target.Path(env, slug)
+		if err == nil {
+			return path, false, nil
+		}
+
+		if !errors.Is(err, ErrNoGlobalPath) {
+			return "", false, err
+		}
+	}
+
+	if target.ProjectPath != nil {
+		path, err := target.ProjectPath(env, slug)
+		if err != nil {
+			return "", false, err
+		}
+
+		return path, true, nil
+	}
+
+	return "", false, ErrNoGlobalPath
+}
+
+// ResolveSkillTargetPath is the exported wrapper around resolveSkillTargetPath,
+// used by the command layer for dedupe and display.
+func ResolveSkillTargetPath(target *SkillTarget, env Env, slug string) (string, bool, error) {
+	return resolveSkillTargetPath(target, env, slug)
+}
+
+func readFileIfExists(path string) ([]byte, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+
+	return data, true
+}

--- a/cli/internal/agentcfg/skill_engine.go
+++ b/cli/internal/agentcfg/skill_engine.go
@@ -39,7 +39,10 @@ func InstallSkill(target *SkillTarget, env Env, slug, canonical string, dryRun b
 		return outcome, err
 	}
 
-	existing, existed := readFileIfExists(path)
+	existing, existed, err := readFileIfExists(path)
+	if err != nil {
+		return failOutcome(outcome, err)
+	}
 
 	switch {
 	case target.Strategy == ManagedBlock:
@@ -115,7 +118,10 @@ func renderForTarget(target *SkillTarget, slug, canonical, path string) ([]byte,
 			return nil, err
 		}
 
-		existing, _ := readFileIfExists(path)
+		existing, _, err := readFileIfExists(path)
+		if err != nil {
+			return nil, err
+		}
 
 		return []byte(upsertBlock(slug, string(existing), string(inner))), nil
 	case DedicatedFile:
@@ -171,7 +177,11 @@ func removeSkillFile(outcome Outcome, path string, dryRun bool) (Outcome, error)
 }
 
 func removeSkillBlock(outcome Outcome, path, slug string, dryRun bool) (Outcome, error) {
-	existing, existed := readFileIfExists(path)
+	existing, existed, err := readFileIfExists(path)
+	if err != nil {
+		return failOutcome(outcome, err)
+	}
+
 	if !existed {
 		outcome.Action = ActionUnchanged
 
@@ -239,11 +249,18 @@ func ResolveSkillTargetPath(target *SkillTarget, env Env, slug string) (string, 
 	return resolveSkillTargetPath(target, env, slug)
 }
 
-func readFileIfExists(path string) ([]byte, bool) {
+// readFileIfExists reads path and reports whether it exists. A missing file is
+// (nil, false, nil); a real read error (e.g. permissions) is (nil, false, err)
+// so callers can surface it rather than silently treating the file as absent.
+func readFileIfExists(path string) ([]byte, bool, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, false
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+
+		return nil, false, fmt.Errorf("read %s: %w", path, err)
 	}
 
-	return data, true
+	return data, true, nil
 }

--- a/cli/internal/agentcfg/skill_engine_test.go
+++ b/cli/internal/agentcfg/skill_engine_test.go
@@ -1,0 +1,225 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstallSkillFolderWritesVerbatim(t *testing.T) {
+	root := t.TempDir()
+	skillPath := filepath.Join(root, "skills", "test-skill", "SKILL.md")
+
+	target := &SkillTarget{
+		Strategy: SkillFolder,
+		Path:     func(Env, string) (string, error) { return skillPath, nil },
+	}
+
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	got, err := os.ReadFile(skillPath)
+	require.NoError(t, err)
+	assert.Equal(t, sampleDoc, string(got))
+
+	// Idempotent.
+	again, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUnchanged, again.Action)
+
+	// Remove deletes the test-skill folder.
+	rm, err := RemoveSkill(target, Env{}, "test-skill", false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionRemoved, rm.Action)
+
+	_, statErr := os.Stat(filepath.Dir(skillPath))
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestInstallSkillDedicatedFileRendersAndRemoves(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "rules", "test-skill.md")
+
+	target := &SkillTarget{
+		Strategy: DedicatedFile,
+		Path:     func(Env, string) (string, error) { return path, nil },
+		Render:   renderContinue,
+	}
+
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	got, _ := os.ReadFile(path)
+	assert.Contains(t, string(got), "alwaysApply: true")
+
+	rm, err := RemoveSkill(target, Env{}, "test-skill", false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionRemoved, rm.Action)
+
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestInstallSkillManagedBlockPreservesUserContent(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "GEMINI.md")
+	require.NoError(t, os.WriteFile(path, []byte("# My notes\n\nKeep me.\n"), 0o600))
+
+	target := &SkillTarget{
+		Strategy: ManagedBlock,
+		Path:     func(Env, string) (string, error) { return path, nil },
+		Render:   renderManagedInner,
+	}
+
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	got, _ := os.ReadFile(path)
+	assert.Contains(t, string(got), "Keep me.")
+	assert.Contains(t, string(got), blockBegin("test-skill"))
+
+	// Idempotent.
+	again, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUnchanged, again.Action)
+
+	// Remove strips only our block.
+	rm, err := RemoveSkill(target, Env{}, "test-skill", false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionRemoved, rm.Action)
+
+	after, _ := os.ReadFile(path)
+	assert.Contains(t, string(after), "Keep me.")
+	assert.NotContains(t, string(after), blockBegin("test-skill"))
+}
+
+func TestInstallSkillProjectFallback(t *testing.T) {
+	root := t.TempDir()
+	projectPath := filepath.Join(root, "repo", ".cursor", "rules", "test-skill.mdc")
+
+	target := &SkillTarget{
+		Strategy:    DedicatedFile,
+		Path:        func(Env, string) (string, error) { return "", ErrNoGlobalPath },
+		ProjectPath: func(Env, string) (string, error) { return projectPath, nil },
+		Render:      renderCursor,
+	}
+
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+	assert.Equal(t, projectPath, outcome.Path)
+	assert.NotEmpty(t, outcome.Reason, "project fallback should be explained")
+
+	_, statErr := os.Stat(projectPath)
+	assert.NoError(t, statErr)
+}
+
+func TestInstallSkillDryRunWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "test-skill.md")
+
+	target := &SkillTarget{
+		Strategy: DedicatedFile,
+		Path:     func(Env, string) (string, error) { return path, nil },
+		Render:   renderRoo,
+	}
+
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, true)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestRemoveSkillAbsentIsUnchanged(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "test-skill.md")
+
+	target := &SkillTarget{
+		Strategy: DedicatedFile,
+		Path:     func(Env, string) (string, error) { return path, nil },
+		Render:   renderRoo,
+	}
+
+	outcome, err := RemoveSkill(target, Env{}, "test-skill", false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUnchanged, outcome.Action)
+}
+
+func TestInstallSkillVersionReplace(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "rules", "rec.md")
+
+	target := &SkillTarget{
+		Strategy: DedicatedFile,
+		Path:     func(Env, string) (string, error) { return path, nil },
+		Render:   renderContinue,
+	}
+
+	canonicalA := "# Version A\n\nThis is version A.\n"
+	canonicalB := "# Version B\n\nThis is version B.\n"
+
+	// Install canonical A.
+	first, err := InstallSkill(target, Env{}, "rec", canonicalA, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, first.Action)
+
+	// Install canonical B — same slug, different content.
+	second, err := InstallSkill(target, Env{}, "rec", canonicalB, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUpdated, second.Action, "second install of same slug should report ActionUpdated")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	renderedB, err := renderContinue(canonicalB)
+	require.NoError(t, err)
+	assert.Equal(t, string(renderedB), string(got), "file content should equal the render of canonical B")
+}
+
+func TestInstallSkillManagedBlockVersionReplace(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "AGENTS.md")
+
+	target := &SkillTarget{
+		Strategy: ManagedBlock,
+		Path:     func(Env, string) (string, error) { return path, nil },
+		Render:   renderManagedInner,
+	}
+
+	canonicalA := "---\nname: rec\n---\n\n# Version A\n\nThis is version A.\n"
+	canonicalB := "---\nname: rec\n---\n\n# Version B\n\nThis is version B.\n"
+
+	// Install canonical A into a fresh file.
+	first, err := InstallSkill(target, Env{}, "rec", canonicalA, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, first.Action)
+
+	// Install the SAME slug with a DIFFERENT canonical: slug-scoped block
+	// detection must recognize our existing block and replace it in place.
+	second, err := InstallSkill(target, Env{}, "rec", canonicalB, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUpdated, second.Action, "second install of same slug should report ActionUpdated")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	s := string(got)
+
+	// Exactly one managed block for slug "rec" (replaced, not appended).
+	assert.Equal(t, 1, strings.Count(s, blockBegin("rec")), "should have exactly one block marker")
+	// The updated body from B is present; A's body is gone.
+	assert.Contains(t, s, "# Version B")
+	assert.NotContains(t, s, "# Version A")
+}

--- a/cli/internal/agentcfg/skill_frontmatter.go
+++ b/cli/internal/agentcfg/skill_frontmatter.go
@@ -1,0 +1,45 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"fmt"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// frontmatter holds the SKILL.md frontmatter fields the renderers reuse.
+type frontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// splitFrontmatter separates a leading YAML frontmatter block (delimited by ---)
+// from the document body. A document without frontmatter returns an empty
+// frontmatter and the whole document as the body.
+func splitFrontmatter(doc string) (frontmatter, string, error) {
+	const delim = "---"
+
+	normalized := strings.ReplaceAll(doc, "\r\n", "\n")
+	if !strings.HasPrefix(normalized, delim+"\n") {
+		return frontmatter{}, doc, nil
+	}
+
+	rest := normalized[len(delim)+1:]
+
+	fmText, body, found := strings.Cut(rest, "\n"+delim)
+	if !found {
+		return frontmatter{}, doc, nil
+	}
+
+	body = strings.TrimLeft(body, "\n")
+
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(fmText), &fm); err != nil {
+		return frontmatter{}, "", fmt.Errorf("parse skill frontmatter: %w", err)
+	}
+
+	return fm, body, nil
+}

--- a/cli/internal/agentcfg/skill_frontmatter_test.go
+++ b/cli/internal/agentcfg/skill_frontmatter_test.go
@@ -1,0 +1,44 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleDoc = `---
+name: agntcy-dir
+description: Use this skill to interact with DIR.
+metadata:
+  author: AGNTCY Contributors
+  version: 1.0.0
+---
+
+# AGNTCY Directory (DIR)
+
+Body content here.
+`
+
+func TestSplitFrontmatterExtractsFields(t *testing.T) {
+	fm, body, err := splitFrontmatter(sampleDoc)
+	require.NoError(t, err)
+
+	assert.Equal(t, "agntcy-dir", fm.Name)
+	assert.Equal(t, "Use this skill to interact with DIR.", fm.Description)
+	assert.Contains(t, body, "# AGNTCY Directory (DIR)")
+	assert.NotContains(t, body, "name: agntcy-dir")
+}
+
+func TestSplitFrontmatterNoFrontmatterReturnsWholeBody(t *testing.T) {
+	doc := "# Title\n\nNo frontmatter.\n"
+
+	fm, body, err := splitFrontmatter(doc)
+	require.NoError(t, err)
+
+	assert.Empty(t, fm.Name)
+	assert.Equal(t, doc, body)
+}

--- a/cli/internal/agentcfg/skill_path.go
+++ b/cli/internal/agentcfg/skill_path.go
@@ -1,0 +1,31 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import "errors"
+
+// ErrNoGlobalPath is returned by a SkillTarget.Path resolver when the agent has
+// no global mechanism for the skill artifact, signalling the engine to fall back
+// to the project (cwd) path.
+var ErrNoGlobalPath = errors.New("no global skill path for this agent")
+
+// ResolveSkillPath resolves the on-disk path for a skill target for display: the
+// global path when available, otherwise the project (cwd) fallback. It annotates
+// a project fallback and never returns an error (display-only).
+func ResolveSkillPath(target *SkillTarget, env Env, slug string) string {
+	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+	if err != nil {
+		if errors.Is(err, ErrNoGlobalPath) {
+			return "(no global path; run inside a repo for a project rule)"
+		}
+
+		return "(path error: " + err.Error() + ")"
+	}
+
+	if usedProject {
+		return path + " (project fallback)"
+	}
+
+	return path
+}

--- a/cli/internal/agentcfg/skill_render.go
+++ b/cli/internal/agentcfg/skill_render.go
@@ -1,0 +1,106 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"strconv"
+	"strings"
+)
+
+// kv is an ordered frontmatter key/value pair. Value is emitted verbatim, so
+// callers quote strings as needed.
+type kv struct {
+	key   string
+	value string
+}
+
+// withFrontmatter renders a YAML frontmatter block followed by the body.
+func withFrontmatter(pairs []kv, body string) []byte {
+	var b strings.Builder
+
+	b.WriteString("---\n")
+
+	for _, p := range pairs {
+		b.WriteString(p.key)
+		b.WriteString(": ")
+		b.WriteString(p.value)
+		b.WriteString("\n")
+	}
+
+	b.WriteString("---\n\n")
+	b.WriteString(body)
+
+	if !strings.HasSuffix(body, "\n") {
+		b.WriteString("\n")
+	}
+
+	return []byte(b.String())
+}
+
+// renderCursor renders a Cursor project rule (.mdc): description + alwaysApply.
+func renderCursor(canonical string) ([]byte, error) {
+	fm, body, err := splitFrontmatter(canonical)
+	if err != nil {
+		return nil, err
+	}
+
+	return withFrontmatter([]kv{
+		{"description", strconv.Quote(fm.Description)},
+		{"alwaysApply", "true"},
+	}, body), nil
+}
+
+// renderCopilot renders a Copilot instructions file: applyTo glob.
+func renderCopilot(canonical string) ([]byte, error) {
+	_, body, err := splitFrontmatter(canonical)
+	if err != nil {
+		return nil, err
+	}
+
+	return withFrontmatter([]kv{
+		{"applyTo", strconv.Quote("**")},
+	}, body), nil
+}
+
+// renderContinue renders a Continue rule: name + description + alwaysApply.
+func renderContinue(canonical string) ([]byte, error) {
+	fm, body, err := splitFrontmatter(canonical)
+	if err != nil {
+		return nil, err
+	}
+
+	return withFrontmatter([]kv{
+		{"name", fm.Name},
+		{"description", strconv.Quote(fm.Description)},
+		{"alwaysApply", "true"},
+	}, body), nil
+}
+
+// renderRoo renders a Roo rule: body only, frontmatter stripped.
+func renderRoo(canonical string) ([]byte, error) {
+	return renderBodyOnly(canonical)
+}
+
+// renderCline renders a Cline rule: plain markdown body, no frontmatter.
+func renderCline(canonical string) ([]byte, error) {
+	return renderBodyOnly(canonical)
+}
+
+// renderManagedInner renders the inner content for a managed block: body only.
+func renderManagedInner(canonical string) ([]byte, error) {
+	return renderBodyOnly(canonical)
+}
+
+func renderBodyOnly(canonical string) ([]byte, error) {
+	_, body, err := splitFrontmatter(canonical)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+
+	return []byte(body), nil
+}

--- a/cli/internal/agentcfg/skill_render.go
+++ b/cli/internal/agentcfg/skill_render.go
@@ -71,7 +71,7 @@ func renderContinue(canonical string) ([]byte, error) {
 	}
 
 	return withFrontmatter([]kv{
-		{"name", fm.Name},
+		{"name", strconv.Quote(fm.Name)},
 		{"description", strconv.Quote(fm.Description)},
 		{"alwaysApply", "true"},
 	}, body), nil

--- a/cli/internal/agentcfg/skill_render_test.go
+++ b/cli/internal/agentcfg/skill_render_test.go
@@ -58,3 +58,49 @@ func TestRenderManagedInnerIsBodyOnly(t *testing.T) {
 	assert.Contains(t, s, "# AGNTCY Directory (DIR)")
 	assert.NotContains(t, s, "name: agntcy-dir")
 }
+
+// --- New tests ---
+
+func TestRenderClineReturnsBodyOnly(t *testing.T) {
+	out, err := renderCline(sampleDoc)
+	require.NoError(t, err)
+
+	s := string(out)
+	// No frontmatter delimiters.
+	assert.False(t, strings.HasPrefix(s, "---"))
+	assert.NotContains(t, s, "name: agntcy-dir")
+	// Body content is present.
+	assert.Contains(t, s, "# AGNTCY Directory (DIR)")
+	assert.Contains(t, s, "Body content here.")
+}
+
+func TestSplitFrontmatterCRLF(t *testing.T) {
+	// Build a CRLF version of sampleDoc.
+	crlf := strings.ReplaceAll(sampleDoc, "\n", "\r\n")
+	fm, body, err := splitFrontmatter(crlf)
+	require.NoError(t, err)
+
+	assert.Equal(t, "agntcy-dir", fm.Name)
+	assert.Equal(t, "Use this skill to interact with DIR.", fm.Description)
+	assert.Contains(t, body, "# AGNTCY Directory (DIR)")
+}
+
+func TestSplitFrontmatterMalformedYAML(t *testing.T) {
+	// Malformed YAML in the frontmatter block.
+	doc := "---\nkey: [unclosed\n---\n\nbody\n"
+	_, _, err := splitFrontmatter(doc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse skill frontmatter")
+}
+
+func TestRenderContinueQuotesSpecialCharsInName(t *testing.T) {
+	// A name containing "a: b" is YAML-significant; strconv.Quote must escape it.
+	doc := "---\nname: \"a: b\"\ndescription: desc\n---\n\nbody\n"
+	out, err := renderContinue(doc)
+	require.NoError(t, err)
+
+	s := string(out)
+	// The name should be properly quoted so the YAML is still valid.
+	assert.Contains(t, s, `name: "a: b"`)
+	assert.Contains(t, s, "alwaysApply: true")
+}

--- a/cli/internal/agentcfg/skill_render_test.go
+++ b/cli/internal/agentcfg/skill_render_test.go
@@ -1,0 +1,59 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderCursorHasFrontmatterAndBody(t *testing.T) {
+	out, err := renderCursor(sampleDoc)
+	require.NoError(t, err)
+
+	s := string(out)
+	assert.True(t, strings.HasPrefix(s, "---\n"))
+	assert.Contains(t, s, "alwaysApply: true")
+	assert.Contains(t, s, "Use this skill to interact with DIR.")
+	assert.Contains(t, s, "# AGNTCY Directory (DIR)")
+	// Original frontmatter keys must be replaced, not duplicated.
+	assert.NotContains(t, s, "name: agntcy-dir")
+}
+
+func TestRenderCopilotHasApplyTo(t *testing.T) {
+	out, err := renderCopilot(sampleDoc)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `applyTo: "**"`)
+}
+
+func TestRenderContinueHasNameAndAlwaysApply(t *testing.T) {
+	out, err := renderContinue(sampleDoc)
+	require.NoError(t, err)
+
+	s := string(out)
+	assert.Contains(t, s, "name: agntcy-dir")
+	assert.Contains(t, s, "alwaysApply: true")
+}
+
+func TestRenderRooStripsFrontmatter(t *testing.T) {
+	out, err := renderRoo(sampleDoc)
+	require.NoError(t, err)
+
+	s := string(out)
+	assert.False(t, strings.HasPrefix(s, "---"))
+	assert.Contains(t, s, "# AGNTCY Directory (DIR)")
+	assert.NotContains(t, s, "alwaysApply")
+}
+
+func TestRenderManagedInnerIsBodyOnly(t *testing.T) {
+	out, err := renderManagedInner(sampleDoc)
+	require.NoError(t, err)
+
+	s := string(out)
+	assert.Contains(t, s, "# AGNTCY Directory (DIR)")
+	assert.NotContains(t, s, "name: agntcy-dir")
+}

--- a/cli/internal/agentcfg/skill_render_test.go
+++ b/cli/internal/agentcfg/skill_render_test.go
@@ -35,7 +35,8 @@ func TestRenderContinueHasNameAndAlwaysApply(t *testing.T) {
 	require.NoError(t, err)
 
 	s := string(out)
-	assert.Contains(t, s, "name: agntcy-dir")
+	// The name is YAML-quoted so names with YAML-significant characters stay valid.
+	assert.Contains(t, s, `name: "agntcy-dir"`)
 	assert.Contains(t, s, "alwaysApply: true")
 }
 

--- a/cli/internal/agentcfg/summary.go
+++ b/cli/internal/agentcfg/summary.go
@@ -1,0 +1,79 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// FormatSummary renders the per-artifact outcomes into a human-readable report
+// that lists every location touched (absolute path + action) and ends with a
+// tally. On dry runs it notes that nothing was written.
+func FormatSummary(outcomes []Outcome, dryRun bool) string {
+	var b strings.Builder
+
+	b.WriteString("\n=== Summary ===\n")
+
+	if len(outcomes) == 0 {
+		b.WriteString("Nothing to do: no supported agents selected or detected.\n")
+
+		return b.String()
+	}
+
+	for _, o := range outcomes {
+		path := o.Path
+		if path == "" {
+			path = "-"
+		}
+
+		line := fmt.Sprintf("  %-9s %-5s %s  (%s)", o.Action, o.Artifact, path, o.Agent)
+		if o.Reason != "" {
+			line += ": " + o.Reason
+		}
+
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(formatTally(outcomes))
+	b.WriteString("\n")
+
+	if dryRun {
+		b.WriteString("\nNote: This was a dry run. No changes were written.\n")
+	}
+
+	return b.String()
+}
+
+// formatTally counts outcomes by action in a stable order.
+func formatTally(outcomes []Outcome) string {
+	counts := map[Action]int{}
+	for _, o := range outcomes {
+		counts[o.Action]++
+	}
+
+	order := []Action{ActionAdded, ActionUpdated, ActionRemoved, ActionUnchanged, ActionSkipped, ActionFailed}
+
+	parts := make([]string, 0, len(order))
+
+	for _, a := range order {
+		if counts[a] > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", counts[a], a))
+		}
+	}
+
+	if len(parts) == 0 {
+		// Defensive: include any unexpected actions.
+		for a, n := range counts {
+			parts = append(parts, fmt.Sprintf("%d %s", n, a))
+		}
+
+		sort.Strings(parts)
+	}
+
+	return "Tally: " + strings.Join(parts, ", ")
+}

--- a/cli/internal/agentcfg/summary_test.go
+++ b/cli/internal/agentcfg/summary_test.go
@@ -1,0 +1,46 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFormatSummaryListsEveryPathAndAction(t *testing.T) {
+	outcomes := []Outcome{
+		{Agent: "Claude Code", Artifact: "mcp", Path: "/home/u/.claude.json", Action: ActionAdded},
+		{Agent: "Cursor", Artifact: "skill", Path: "/repo/.cursor/rules/agntcy-dir.mdc", Action: ActionSkipped, Reason: "no global rules path"},
+		{Agent: "Gemini CLI", Artifact: "mcp", Path: "/home/u/.gemini/settings.json", Action: ActionFailed, Reason: "permission denied"},
+	}
+
+	out := FormatSummary(outcomes, false)
+
+	assert.Contains(t, out, "/home/u/.claude.json")
+	assert.Contains(t, out, string(ActionAdded))
+	assert.Contains(t, out, "/repo/.cursor/rules/agntcy-dir.mdc")
+	assert.Contains(t, out, "no global rules path")
+	assert.Contains(t, out, "/home/u/.gemini/settings.json")
+	assert.Contains(t, out, "permission denied")
+
+	// Tally reflects counts.
+	assert.Contains(t, out, "1 added")
+	assert.Contains(t, out, "1 skipped")
+	assert.Contains(t, out, "1 failed")
+}
+
+func TestFormatSummaryDryRunNoted(t *testing.T) {
+	out := FormatSummary([]Outcome{
+		{Agent: "Claude Code", Artifact: "mcp", Path: "/p", Action: ActionAdded},
+	}, true)
+
+	assert.Contains(t, strings.ToLower(out), "dry run")
+}
+
+func TestFormatSummaryEmpty(t *testing.T) {
+	out := FormatSummary(nil, false)
+	assert.Contains(t, strings.ToLower(out), "nothing")
+}

--- a/cli/internal/agentcfg/types.go
+++ b/cli/internal/agentcfg/types.go
@@ -1,0 +1,86 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package agentcfg is the shared placement engine for writing artifacts (MCP
+// server entries and Agent Skills) into the configuration files of installed AI
+// coding agents. Callers supply the artifact identity and content; this package
+// owns the per-agent paths, JSON/YAML/TOML codec, managed-block merge, atomic
+// writes, detection, and outcome reporting. Used by `dirctl install` and
+// `dirctl init`.
+package agentcfg
+
+import (
+	"github.com/agntcy/dir/cli/internal/agentcfg/codec"
+)
+
+// Env carries the ambient values descriptors and engines need, injected so
+// resolvers and tests stay pure (no direct os calls inside descriptors).
+type Env struct {
+	Home string
+	GOOS string
+	Cwd  string
+}
+
+// EntryStyle selects how an MCP server entry value is shaped for a given agent.
+type EntryStyle int
+
+const (
+	// CommandArgsEnv is the common {command, args, env} entry shape.
+	CommandArgsEnv EntryStyle = iota
+	// ZedContextServer is Zed's context_servers custom shape ({source, command, args, env}).
+	ZedContextServer
+)
+
+// MCPTarget describes where and how to install the MCP server entry for an agent.
+type MCPTarget struct {
+	// ConfigPath resolves the global config file path for the given environment.
+	ConfigPath func(env Env) (string, error)
+	// Format is the config file encoding.
+	Format codec.Format
+	// ServersKey is the nested key path to the servers map (e.g. ["mcpServers"]).
+	ServersKey []string
+	// EntryStyle shapes the entry value.
+	EntryStyle EntryStyle
+}
+
+// SkillStrategy selects how the DIR skill/rules are rendered into an agent.
+type SkillStrategy int
+
+const (
+	// SkillFolder writes SKILL.md verbatim into an agent's skills directory.
+	SkillFolder SkillStrategy = iota
+	// DedicatedFile writes a single rules file owned by us, with tool-specific frontmatter.
+	DedicatedFile
+	// ManagedBlock inserts/replaces a delimited block inside a shared instruction file.
+	ManagedBlock
+)
+
+// Renderer turns the canonical SKILL.md into the on-disk bytes for a target.
+// Implemented in the skill subsystem (Phase 2).
+type Renderer func(canonical string) ([]byte, error)
+
+// SkillTarget describes where and how to install the DIR skill/rules for an agent.
+type SkillTarget struct {
+	Strategy SkillStrategy
+	// Path resolves the global target from the env and per-record slug. If it
+	// returns ErrNoGlobalPath, the engine retries with ProjectPath.
+	Path func(env Env, slug string) (string, error)
+	// ProjectPath resolves a per-repo (cwd) fallback path from env and slug.
+	ProjectPath func(env Env, slug string) (string, error)
+	// Render produces the on-disk bytes (DedicatedFile/ManagedBlock). Nil for SkillFolder.
+	Render Renderer
+	// SharedWith names another agent ID that resolves to the same file, so the
+	// shared artifact is installed only once.
+	SharedWith string
+}
+
+// Agent is a data descriptor for one supported AI coding agent.
+type Agent struct {
+	ID     string // stable identifier, e.g. "claude-code"
+	Name   string // human-readable name, e.g. "Claude Code"
+	Flag   string // CLI selection flag, e.g. "claude-code"
+	Detect func(env Env) bool
+
+	MCP   *MCPTarget   // nil if we target no MCP config for this agent
+	Skill *SkillTarget // nil if we install no skill for this agent
+}

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -144,43 +144,44 @@ Directory.
 Pulls the record, derives its artifacts, prints the planned changes (per agent and
 artifact, marked add / updated / unchanged), asks for confirmation, then installs.
 `dirctl install <cid-or-name>` is shorthand for `dirctl install run <cid-or-name>`.
-By default it acts on all detected agents.
+By default it acts on all detected agents. Detection is always required — an agent
+is never installed into unless it is detected on this machine; an explicitly
+requested agent that is not detected is reported as skipped.
 
 | Flag | Description | Default |
 |------|-------------|---------|
+| `--agents` | Agents to target: `all` (every detected agent) or a comma-separated list of agent IDs (e.g. `--agents claude-code,cursor`; repeatable) | `all` |
 | `--mcp` | Act only on the MCP server entry | both |
 | `--skill` | Act only on the skill/rules | both |
-| `--all` | Act on all detected agents | - |
-| `--<agent>` | Target a specific agent (e.g. `--claude-code`, `--cursor`); implies force for that agent | - |
-| `--force` | Create config paths even if the agent isn't detected | `false` |
 | `--dry-run` | Preview the plan without writing | `false` |
 | `--yes` / `-y` | Skip the confirmation prompt | `false` |
 
-After completion, a summary lists every location added, updated, removed, or
-skipped with its absolute path.
+Valid agent IDs: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `windsurf`,
+`cline`, `roo`, `gemini`, `opencode`, `zed`, `continue`, `codex` (see
+`dirctl install list`). After completion, a summary lists every location added,
+updated, removed, or skipped with its absolute path.
 
 ```bash
 # Preview what installing a record would change
-dirctl install my-agent:1.0.0 --dry-run
+dirctl install cisco.com/agent:v1.0.0 --dry-run
 
 # Install a record's artifacts into all detected agents
-dirctl install my-agent:1.0.0 --yes
+dirctl install cisco.com/agent:v1.0.0 --yes
 
 # Install only the MCP server into specific agents
-dirctl install my-agent --mcp --claude-code --cursor
+dirctl install cisco.com/agent --mcp --agents claude-code,cursor
 ```
 
 ### `dirctl install uninstall <cid-or-name> [flags]`
 
 Removes what `install` added for that record — its MCP entry and/or skill —
 leaving all other content intact. Shares the same selection/artifact flags as
-install (`--mcp`, `--skill`, `--all`, per-agent flags, `--dry-run`, `--yes`).
-Idempotent: an agent with nothing of ours installed is reported as unchanged,
-never an error.
+install (`--agents`, `--mcp`, `--skill`, `--dry-run`, `--yes`). Idempotent: an
+agent with nothing of ours installed is reported as unchanged, never an error.
 
 ```bash
-dirctl install uninstall my-agent --all --yes
-dirctl install uninstall my-agent --skill --cursor
+dirctl install uninstall cisco.com/agent --yes
+dirctl install uninstall cisco.com/agent --skill --agents cursor
 ```
 
 ## Daemon Operations

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -71,7 +71,7 @@ explicit `--auth-mode`.
 | Sync | `sync create`, `status`, `list`, `delete` |
 | Events | `events listen` |
 | MCP | `mcp serve` |
-| Install | `install run`, `uninstall`, `list` |
+| Install | `install run`, `install uninstall` (or top-level `uninstall`), `install list` |
 | Diagnostics | `doctor`, `version` |
 
 ### Getting help
@@ -181,9 +181,12 @@ leaving all other content intact. Shares the same flags as install (`--agents`,
 `--dry-run`, `--yes`). Idempotent: an agent with nothing of ours installed is
 reported as unchanged, never an error.
 
+`dirctl uninstall <cid-or-name>` is a top-level shorthand for
+`dirctl install uninstall <cid-or-name>` (same flags and behavior).
+
 ```bash
 dirctl install uninstall cisco.com/agent --yes
-dirctl install uninstall cisco.com/agent --agents cursor
+dirctl uninstall cisco.com/agent --agents cursor
 ```
 
 ## Daemon Operations

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -148,11 +148,13 @@ By default it acts on all detected agents. Detection is always required — an a
 is never installed into unless it is detected on this machine; an explicitly
 requested agent that is not detected is reported as skipped.
 
+The artifacts to install are determined entirely by the record's modules (above),
+not by flags. A record carrying neither an MCP nor an Agent Skill module is
+reported as having nothing installable and the command exits without changes.
+
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--agents` | Agents to target: `all` (every detected agent) or a comma-separated list of agent IDs (e.g. `--agents claude-code,cursor`; repeatable) | `all` |
-| `--mcp` | Act only on the MCP server entry | both |
-| `--skill` | Act only on the skill/rules | both |
 | `--dry-run` | Preview the plan without writing | `false` |
 | `--yes` / `-y` | Skip the confirmation prompt | `false` |
 
@@ -168,20 +170,20 @@ dirctl install cisco.com/agent:v1.0.0 --dry-run
 # Install a record's artifacts into all detected agents
 dirctl install cisco.com/agent:v1.0.0 --yes
 
-# Install only the MCP server into specific agents
-dirctl install cisco.com/agent --mcp --agents claude-code,cursor
+# Install into specific agents only
+dirctl install cisco.com/agent --agents claude-code,cursor
 ```
 
 ### `dirctl install uninstall <cid-or-name> [flags]`
 
 Removes what `install` added for that record — its MCP entry and/or skill —
-leaving all other content intact. Shares the same selection/artifact flags as
-install (`--agents`, `--mcp`, `--skill`, `--dry-run`, `--yes`). Idempotent: an
-agent with nothing of ours installed is reported as unchanged, never an error.
+leaving all other content intact. Shares the same flags as install (`--agents`,
+`--dry-run`, `--yes`). Idempotent: an agent with nothing of ours installed is
+reported as unchanged, never an error.
 
 ```bash
 dirctl install uninstall cisco.com/agent --yes
-dirctl install uninstall cisco.com/agent --skill --agents cursor
+dirctl install uninstall cisco.com/agent --agents cursor
 ```
 
 ## Daemon Operations

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -71,6 +71,7 @@ explicit `--auth-mode`.
 | Sync | `sync create`, `status`, `list`, `delete` |
 | Events | `events listen` |
 | MCP | `mcp serve` |
+| Install | `install run`, `uninstall`, `list` |
 | Diagnostics | `doctor`, `version` |
 
 ### Getting help
@@ -102,6 +103,85 @@ Prints the `dirctl` build version.
 
 Starts the built-in MCP server used by external AI tooling. Delegates to the
 [`dir-mcp`](https://github.com/agntcy/dir-mcp) module.
+
+## Agent Install
+
+`dirctl install <cid-or-name>` pulls a record from the active Directory and
+installs its artifacts — an MCP server entry and/or an Agent Skill, derived from
+the record's OASF modules — directly into the configuration of detected AI coding
+agents.
+
+Which artifacts are installed is determined by the record's modules, not a flag:
+
+- `core/language_model/agentskills` → an Agent Skill (`SKILL.md`), rendered into
+  whatever persistent-instruction mechanism each agent supports (a native skill
+  folder, a per-tool rules file, or a managed block in a shared instruction file).
+- `integration/mcp` → an MCP server entry (`command`/`args`/`env`) placed under
+  each agent's MCP servers key.
+- `integration/a2a` → not installable into agent configs; the command errors and
+  points you to `dirctl export`.
+
+A multi-module record installs all applicable artifacts. The per-record identity
+is the sanitized record name, so re-running `install` with a newer version of the
+same-named record replaces the old artifacts cleanly, and different records
+coexist.
+
+Supported agents: Claude Code, Claude Desktop, Cursor, VS Code (Copilot),
+Windsurf, Cline, Roo Code, Gemini CLI, OpenCode, Zed, Continue, and Codex CLI.
+
+Writes are atomic and surgical: only our own MCP entry, skill file/folder, or
+delimited managed block is added/updated/removed — all of your existing
+configuration is preserved.
+
+### `dirctl install list`
+
+Lists every supported agent, whether it is detected on this machine, and the
+config files that install would touch. Makes no changes and does not contact the
+Directory.
+
+### `dirctl install <cid-or-name>` / `dirctl install run <cid-or-name>`
+
+Pulls the record, derives its artifacts, prints the planned changes (per agent and
+artifact, marked add / updated / unchanged), asks for confirmation, then installs.
+`dirctl install <cid-or-name>` is shorthand for `dirctl install run <cid-or-name>`.
+By default it acts on all detected agents.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--mcp` | Act only on the MCP server entry | both |
+| `--skill` | Act only on the skill/rules | both |
+| `--all` | Act on all detected agents | - |
+| `--<agent>` | Target a specific agent (e.g. `--claude-code`, `--cursor`); implies force for that agent | - |
+| `--force` | Create config paths even if the agent isn't detected | `false` |
+| `--dry-run` | Preview the plan without writing | `false` |
+| `--yes` / `-y` | Skip the confirmation prompt | `false` |
+
+After completion, a summary lists every location added, updated, removed, or
+skipped with its absolute path.
+
+```bash
+# Preview what installing a record would change
+dirctl install my-agent:1.0.0 --dry-run
+
+# Install a record's artifacts into all detected agents
+dirctl install my-agent:1.0.0 --yes
+
+# Install only the MCP server into specific agents
+dirctl install my-agent --mcp --claude-code --cursor
+```
+
+### `dirctl install uninstall <cid-or-name> [flags]`
+
+Removes what `install` added for that record — its MCP entry and/or skill —
+leaving all other content intact. Shares the same selection/artifact flags as
+install (`--mcp`, `--skill`, `--all`, per-agent flags, `--dry-run`, `--yes`).
+Idempotent: an agent with nothing of ours installed is reported as unchanged,
+never an error.
+
+```bash
+dirctl install uninstall my-agent --all --yes
+dirctl install uninstall my-agent --skill --cursor
+```
 
 ## Daemon Operations
 

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -149,8 +149,9 @@ is never installed into unless it is detected on this machine; an explicitly
 requested agent that is not detected is reported as skipped.
 
 The artifacts to install are determined entirely by the record's modules (above),
-not by flags. A record carrying neither an MCP nor an Agent Skill module is
-reported as having nothing installable and the command exits without changes.
+not by flags. A record carrying neither an MCP nor an Agent Skill module has
+nothing installable: the command errors (making no changes) and, for an
+A2A-only record, points you to `dirctl export`.
 
 | Flag | Description | Default |
 |------|-------------|---------|


### PR DESCRIPTION
## Summary

Implements `dirctl install` (#1737): pull a record by CID or verifiable name and install its OASF-derived artifacts — an MCP server entry and/or an Agent Skill — directly into the configs of detected AI coding agents (Claude Code, Claude Desktop, Cursor, VS Code, Windsurf, Cline, Roo, Gemini, OpenCode, Zed, Continue, Codex).

The placement machinery is extracted into a shared `cli/internal/agentcfg` engine (per-agent paths, JSON/YAML/TOML codec, managed-block merge, atomic writes, detection, summary) so `dirctl init` (#1705) can reuse it.

## Commands

- `dirctl install <cid-or-name>` (≡ `install run`) — detect → plan → confirm → install
- `dirctl install uninstall <cid-or-name>` (top-level `dirctl uninstall` shorthand) — reverse it
- `dirctl install list` — show detected agents and target paths

## Behavior

- What gets installed is derived from the record's modules, not flags (`agentskills` → skill, `integration/mcp` → MCP entry; `a2a`-only or no installable module → clear error pointing to `dirctl export`).
- `--agents all|<ids>` selects agents; detection is always required — undetected agents are skipped, never forced.
- Identity is the record name, so re-installing a newer version replaces the old artifacts cleanly and different records coexist. Writes are surgical, idempotent, and atomic.

Follow-ups tracked in #1705 (`dirctl init` wizard) and #1742 (batch install).

Closes #1737.
