### PR TITLE
refactor(ci): update renovate bot config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+      - renovate/**
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/docs-ci.yaml'

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -14,7 +14,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PROJECT_APP_ID }}
+          client-id: ${{ secrets.PROJECT_APP_ID }}
           private-key: ${{ secrets.PROJECT_APP_KEY }}
 
       - name: Checkout

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -18,7 +18,7 @@ jobs:
           private-key: ${{ secrets.PROJECT_APP_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.head_ref }}

--- a/renovate.json
+++ b/renovate.json
@@ -48,7 +48,11 @@
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "enabled": true,
   "minimumReleaseAge": "7 days",
-  "schedule": ["before 8am on Monday"],
+  "schedule": [
+    "before 8am on Monday",
+    "before 8am on Wednesday",
+    "before 8am on Friday"
+  ],
   "prCreation": "not-pending",
   "enabledManagers": [
     "custom.regex",

--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,7 @@
   "dependencyDashboardLabels": ["dependencies"],
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "enabled": true,
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "7 days",
   "schedule": ["before 6am on Monday"],
   "enabledManagers": [
     "custom.regex",

--- a/renovate.json
+++ b/renovate.json
@@ -49,6 +49,7 @@
   "enabled": true,
   "minimumReleaseAge": "7 days",
   "schedule": ["before 6am on Monday"],
+  "prCreation": "not-pending",
   "enabledManagers": [
     "custom.regex",
     "docker-compose",

--- a/renovate.json
+++ b/renovate.json
@@ -48,7 +48,7 @@
   "dependencyDashboardOSVVulnerabilitySummary": "all",
   "enabled": true,
   "minimumReleaseAge": "7 days",
-  "schedule": ["before 6am on Monday"],
+  "schedule": ["before 8am on Monday"],
   "prCreation": "not-pending",
   "enabledManagers": [
     "custom.regex",


### PR DESCRIPTION
Improve renovate bot config by allow raise PRs only when status check met. Some commits can be dropped as more of a preference.