### PR TITLE
docs(cli): dirctl init, dirctl install missing docs

### DIFF
--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -60,6 +60,7 @@ explicit `--auth-mode`.
 
 | Group | Commands |
 |-------|----------|
+| Setup | `init` |
 | Daemon | `daemon start`, `stop`, `status` |
 | Auth | `auth login`, `logout`, `status` |
 | Context | `context list`, `current`, `set`, `show`, `validate` |
@@ -80,6 +81,46 @@ explicit `--auth-mode`.
 dirctl --help
 dirctl routing --help
 dirctl routing search --help
+```
+
+## Setup
+
+### `dirctl init [flags]`
+
+Guided first-run setup for a new environment — run it once after installing
+`dirctl`. It provisions the **OASF taxonomy extractor**: a small
+sentence-transformer model (`all-MiniLM-L6-v2`, ~89 MB) plus the OASF taxonomy,
+downloaded to a local asset directory. Those assets power local, **LLM-free**
+record enrichment (and, in future, free-text search) that runs in-process — no
+Python, no external inference service, no LLM API. The chosen OASF endpoint and
+asset directory are saved to the `dirctl` config so other commands load the
+provisioned assets automatically.
+
+Provisioning is **opt-out** in an interactive terminal — the prompt defaults to
+yes, so pressing Enter provisions. To avoid an unattended ~89 MB download, a
+**non-interactive** run (no TTY, e.g. CI or a pipe) skips unless you pass
+`--yes`. Re-running is idempotent: nothing is re-downloaded when the assets are
+present and current, and the taxonomy is re-embedded only when it changed.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--oasf-url` | OASF schema endpoint to pull the taxonomy from | `https://schema.oasf.outshift.com` |
+| `--asset-dir` | Local directory for the provisioned assets | `~/.agntcy/oasf-sdk/extractor` |
+| `--yes` / `-y` | Provision without prompting (required for non-interactive runs) | `false` |
+| `--remove` | Remove the provisioned assets and clear the saved config | `false` |
+
+```bash
+# Interactive setup (prompts; Enter accepts)
+dirctl init
+
+# Non-interactive (CI): provision with defaults
+dirctl init --yes
+
+# Provision from a local OASF instance
+dirctl init --oasf-url http://localhost:8080 --yes
+
+# Tear down what init provisioned
+dirctl init --remove --yes
 ```
 
 ## Diagnostics

--- a/docs/content/dir/dir-features-scenarios.md
+++ b/docs/content/dir/dir-features-scenarios.md
@@ -426,3 +426,29 @@ dirctl export --output-dir=./exports/ --format=a2a --module "integration/a2a"
 
 By default, only the latest semver version is exported; use `--all-versions` to export every
 version. See [CLI Reference — Export Operations](dir-cli-reference.md#export-operations).
+
+## Install
+
+Where `export` writes artifacts to files you manage, `install` places them directly into the
+configuration of detected AI coding agents (Claude Code, Cursor, VS Code, Windsurf, and more).
+What gets installed is derived from the record's OASF modules — an MCP server entry and/or an
+Agent Skill — not from a flag; a record with neither errors (an A2A-only record points you to
+`export`). See [CLI Reference — Agent Install](dir-cli-reference.md#agent-install).
+
+```bash
+# Preview what installing a record would change across detected agents
+dirctl install cisco.com/agent:v1.0.0 --dry-run
+
+# Install into all detected agents
+dirctl install cisco.com/agent:v1.0.0 --yes
+
+# Install into specific agents only
+dirctl install cisco.com/agent --agents claude-code,cursor
+
+# Remove what install added (top-level shorthand for `install uninstall`)
+dirctl uninstall cisco.com/agent
+```
+
+Detection is always required — an agent is never written to unless it is detected. Re-installing
+a newer version of the same record replaces the old artifacts cleanly. `dirctl install list`
+shows which agents are detected and the config files install would touch.

--- a/docs/content/dir/dir-quickstart.md
+++ b/docs/content/dir/dir-quickstart.md
@@ -36,6 +36,20 @@ only page on the docs site with CLI installation instructions.
     docker run --rm ghcr.io/agntcy/dir-ctl:latest --help
     ```
 
+## Set up your environment
+
+Run the guided first-run setup once after installing. It provisions the OASF
+taxonomy extractor (a ~89 MB model plus the taxonomy) for local, LLM-free record
+enrichment and future free-text search:
+
+```bash
+dirctl init
+```
+
+In an interactive terminal the prompt defaults to yes — press Enter to provision.
+In non-interactive contexts (CI, pipes) pass `--yes`. See the
+[CLI reference](dir-cli-reference.md#dirctl-init-flags) for flags and `--remove`.
+
 ## Start a local node
 
 The built-in daemon runs a full local Directory node with no external dependencies:

--- a/docs/content/javascripts/dir-graph.js
+++ b/docs/content/javascripts/dir-graph.js
@@ -25,9 +25,10 @@ document$.subscribe(function () {
     up: 250,
     dn: 400,
     verify: 307,
-    con1: 195,
-    con2: 325,
-    con3: 455,
+    con1: 118,
+    con2: 228,
+    con3: 338,
+    con4: 448,
   };
 
   var CW = 152;
@@ -74,6 +75,8 @@ document$.subscribe(function () {
       '<rect width="20" height="8" x="2" y="2" rx="2" ry="2"/>' +
       '<rect width="20" height="8" x="2" y="14" rx="2" ry="2"/>' +
       '<line x1="6" x2="6.01" y1="6" y2="6"/><line x1="6" x2="6.01" y1="18" y2="18"/>',
+    wrench:
+      '<path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>',
   };
 
   var NODES = [
@@ -105,7 +108,8 @@ document$.subscribe(function () {
 
     { id: "pull", label: "Pull", desc: "raw OASF record", icon: "arrowdown", color: PURPLE, cx: COL.con, cy: ROW.con1, monoLabel: true },
     { id: "export", label: "Export", desc: "export to A2A, SKILL.md, GitHub Copilot MCP", icon: "upload", color: PURPLE, cx: COL.con, cy: ROW.con2, monoLabel: true },
-    { id: "mcp", label: "MCP Serve", desc: "AI tools / IDE", icon: "server", color: PURPLE, cx: COL.con, cy: ROW.con3, monoLabel: true },
+    { id: "install", label: "Install", desc: "install artifacts into AI coding agents", icon: "wrench", color: PURPLE, cx: COL.con, cy: ROW.con3, monoLabel: true },
+    { id: "mcp", label: "MCP Serve", desc: "AI tools / IDE", icon: "server", color: PURPLE, cx: COL.con, cy: ROW.con4, monoLabel: true },
   ];
 
   var NODE_BY_ID = {};
@@ -138,6 +142,7 @@ document$.subscribe(function () {
     { from: "rsearch", to: "verify", color: TEAL },
     { from: "verify", to: "pull", color: PURPLE },
     { from: "verify", to: "export", color: PURPLE },
+    { from: "verify", to: "install", color: PURPLE },
     { from: "verify", to: "mcp", color: PURPLE },
   ];
 
@@ -172,6 +177,7 @@ document$.subscribe(function () {
         "rsearch-verify",
         "verify-pull",
         "verify-export",
+        "verify-install",
         "verify-mcp",
       ],
     },


### PR DESCRIPTION
Add section to the docs about the recently added `dirctl init` and `dirctl install` commands, the latter is also added to the diagram (the consume column):

<img width="1773" height="838" alt="Screenshot 2026-07-06 at 16 30 33" src="https://github.com/user-attachments/assets/42790adb-53b6-4c98-a474-a9583e5dad57" />
 