### PR TITLE
chore(docs): adding discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ close any lingering issues or pull requests after 60 days of inactivity.
 Please note that all of your interactions in the project are subject to our
 [Code of Conduct](/CODE_OF_CONDUCT.md). This includes creation of issues or pull
 requests, commenting on issues or pull requests, and extends to all interactions
-in any real-time space e.g., Slack, Discord, etc.
+in any real-time space e.g., Discord, etc.
 
 ## Reporting Issues
 

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -11,7 +11,7 @@ hide:
 Contributors to the **Agent Directory Service (ADS)** work in the open on the
 specification, server implementation, client SDKs, and federation deployments.
 If you run a directory node, publish OASF agent records, or integrate discovery
-into your stack, the links below are where the work happens—repos, Slack,
+into your stack, the links below are where the work happens—repos, Discord,
 meetings, and recent posts from the team.
 
 ADS is developed within
@@ -24,7 +24,7 @@ infrastructure for open, vendor-neutral agent discovery.
 
 Stay involved with the AGNTCY community and DIR contributors:
 
-- **[AGNTCY Slack workspace](https://join.slack.com/t/agntcy/shared_invite/zt-3xozr6nzq-i6LXv2P8l2kVW4_Prnny2w)** — chat with maintainers and contributors
+- **[AGNTCY Discord server](https://discord.gg/7dhMdJuc)** — chat with maintainers and contributors
 - **[AGNTCY Meeting Calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/agntcy?view=week)** — working group and community meetings
 - **[AGNTCY on GitHub](https://github.com/agntcy)** — organization home for all IoA projects
 - **[AGNTCY Blogs](https://blogs.agntcy.org/)** — announcements, tutorials, and project updates

--- a/docs/content/llms.txt
+++ b/docs/content/llms.txt
@@ -25,7 +25,7 @@ Internet Draft.
 ## Key documentation pages
 
 - Home: https://agntcy.github.io/dir/
-- Community (Slack, repos, news): https://agntcy.github.io/dir/community/
+- Community (Discord, repos, news): https://agntcy.github.io/dir/community/
 - Overview: https://agntcy.github.io/dir/dir/dir-overview/
 - Architecture: https://agntcy.github.io/dir/dir/dir-architecture/
 - Features and usage scenarios: https://agntcy.github.io/dir/dir/dir-features-scenarios/


### PR DESCRIPTION
This PR changes the Slack links to Discord ones in the docs