### PR TITLE
feat(dir): batch install

### DIFF
--- a/api/exportfmt/exportfmt_test.go
+++ b/api/exportfmt/exportfmt_test.go
@@ -406,6 +406,73 @@ func TestExtractSkillBundleArchive(t *testing.T) {
 	})
 }
 
+func TestSkillMarkdownFromArchive(t *testing.T) {
+	archive, err := base64.StdEncoding.DecodeString(skillBundleArchiveBase64(t))
+	require.NoError(t, err)
+
+	md, err := exportfmt.SkillMarkdownFromArchive(archive)
+	require.NoError(t, err)
+	assert.Contains(t, md, "name: code-review")
+
+	plain := []byte("---\nname: plain\ndescription: x\n---\n")
+	md, err = exportfmt.SkillMarkdownFromArchive(plain)
+	require.NoError(t, err)
+	assert.Equal(t, string(plain), md)
+}
+
+func TestSkillBundleMatchesDir(t *testing.T) {
+	archive, err := base64.StdEncoding.DecodeString(skillBundleArchiveBase64(t))
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	matches, err := exportfmt.SkillBundleMatchesDir(archive, dir)
+	require.NoError(t, err)
+	assert.False(t, matches)
+
+	require.NoError(t, exportfmt.ExtractSkillBundleArchive(archive, dir))
+
+	matches, err = exportfmt.SkillBundleMatchesDir(archive, dir)
+	require.NoError(t, err)
+	assert.True(t, matches)
+}
+
+func TestSkillBundleMatchesDirRejectsStaleFiles(t *testing.T) {
+	archive, err := base64.StdEncoding.DecodeString(skillBundleArchiveBase64(t))
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, exportfmt.ExtractSkillBundleArchive(archive, dir))
+
+	stale := filepath.Join(dir, "scripts", "removed.sh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stale), 0o755))
+	require.NoError(t, os.WriteFile(stale, []byte("#!/bin/sh\n"), 0o600))
+
+	matches, err := exportfmt.SkillBundleMatchesDir(archive, dir)
+	require.NoError(t, err)
+	assert.False(t, matches)
+}
+
+func TestExtractSkillBundleArchiveRemovesStaleFiles(t *testing.T) {
+	archive, err := base64.StdEncoding.DecodeString(skillBundleArchiveBase64(t))
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, exportfmt.ExtractSkillBundleArchive(archive, dir))
+
+	stale := filepath.Join(dir, "scripts", "removed.sh")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stale), 0o755))
+	require.NoError(t, os.WriteFile(stale, []byte("#!/bin/sh\n"), 0o600))
+
+	require.NoError(t, exportfmt.ExtractSkillBundleArchive(archive, dir))
+
+	_, err = os.Stat(stale)
+	require.True(t, os.IsNotExist(err))
+
+	matches, err := exportfmt.SkillBundleMatchesDir(archive, dir)
+	require.NoError(t, err)
+	assert.True(t, matches)
+}
+
 func TestMCPGHCopilotFormatter_Format(t *testing.T) {
 	f, err := exportfmt.GetFormatter("mcp-ghcopilot")
 	require.NoError(t, err)

--- a/api/exportfmt/skill_bundle_extract.go
+++ b/api/exportfmt/skill_bundle_extract.go
@@ -6,14 +6,178 @@ package exportfmt
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"fmt"
-	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
 
 const skillManifestFile = "SKILL.md"
+
+// SkillMarkdownFromArchive returns the SKILL.md content from a skill artifact.
+// Plain-text archives are returned as-is; gzip tar bundles must contain SKILL.md.
+func SkillMarkdownFromArchive(archive []byte) (string, error) {
+	if len(archive) == 0 {
+		return "", fmt.Errorf("skill bundle archive is empty")
+	}
+
+	if !isGzipArchive(archive) {
+		return string(archive), nil
+	}
+
+	iterator, err := NewTarIterator(archive, WithTypeflag(tar.TypeReg))
+	if err != nil {
+		return "", fmt.Errorf("invalid gzip archive: %w", err)
+	}
+
+	for entry, err := range iterator {
+		if err != nil {
+			return "", fmt.Errorf("read tar entry: %w", err)
+		}
+
+		rel, err := localTarEntryPath(entry.header.Name)
+		if err != nil {
+			return "", fmt.Errorf("invalid tar entry %q: %w", entry.header.Name, err)
+		}
+
+		if rel != skillManifestFile {
+			continue
+		}
+
+		return string(entry.payload), nil
+	}
+
+	return "", fmt.Errorf("archive does not contain %q", skillManifestFile)
+}
+
+// SkillBundleMatchesDir reports whether dir already contains the same files as archive.
+func SkillBundleMatchesDir(archive []byte, dir string) (bool, error) {
+	if len(archive) == 0 {
+		return false, fmt.Errorf("skill bundle archive is empty")
+	}
+
+	if !isGzipArchive(archive) {
+		return matchesSkillManifest(dir, archive)
+	}
+
+	return matchesGzip(dir, archive)
+}
+
+func matchesSkillManifest(dir string, b []byte) (bool, error) {
+	content, err := os.ReadFile(filepath.Join(dir, skillManifestFile))
+
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("read %s: %w", skillManifestFile, err)
+	}
+
+	return bytes.Equal(content, b), nil
+}
+
+func matchesGzip(dir string, b []byte) (bool, error) {
+	iterator, err := NewTarIterator(b, WithTypeflag(tar.TypeReg))
+	if err != nil {
+		return false, fmt.Errorf("invalid gzip archive: %w", err)
+	}
+
+	paths := make(map[string]bool)
+
+	for entry, err := range iterator {
+		if err != nil {
+			return false, fmt.Errorf("read tar entry: %w", err)
+		}
+
+		path, err := localTarEntryPath(entry.header.Name)
+		if err != nil {
+			return false, fmt.Errorf("invalid tar entry %q: %w", entry.header.Name, err)
+		}
+
+		match, err := matchesTarEntry(dir, entry)
+		if err != nil {
+			return false, err
+		}
+
+		if !match {
+			return false, nil
+		}
+
+		paths[path] = true
+	}
+
+	if len(paths) == 0 {
+		return false, fmt.Errorf("archive contains no regular files")
+	}
+
+	match, err := matchesPaths(dir, paths)
+	if err != nil {
+		return false, err
+	}
+
+	if !match {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func matchesPaths(dir string, paths map[string]bool) (bool, error) {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("stat %s: %w", dir, err)
+	}
+
+	result := true
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return fmt.Errorf("rel path for %q: %w", path, err)
+		}
+
+		if _, ok := paths[rel]; !ok {
+			result = false
+
+			return fs.SkipAll
+		}
+
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("walk %s: %w", dir, err)
+	}
+
+	return result, nil
+}
+
+func matchesTarEntry(dir string, entry *TarEntry) (bool, error) {
+	path, err := localTarEntryPath(entry.header.Name)
+	if err != nil {
+		return false, fmt.Errorf("invalid tar entry %q: %w", entry.header.Name, err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, path))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	if err != nil {
+		return false, fmt.Errorf("read %q: %w", path, err)
+	}
+
+	return bytes.Equal(content, entry.payload), nil
+}
 
 // ExtractSkillBundleArchive extracts a skill artifact into destDir.
 // The artifact is either a gzip-compressed tar bundle (full skill with code samples)
@@ -23,6 +187,38 @@ func ExtractSkillBundleArchive(archive []byte, destDir string) error {
 		return fmt.Errorf("skill bundle archive is empty")
 	}
 
+	parent := filepath.Dir(destDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil { //nolint:mnd
+		return fmt.Errorf("create parent directory: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp(parent, filepath.Base(destDir)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary directory: %w", err)
+	}
+
+	installed := false
+
+	defer func() {
+		if !installed {
+			_ = os.RemoveAll(tmpDir)
+		}
+	}()
+
+	if err := writeSkillBundleContents(archive, tmpDir); err != nil {
+		return err
+	}
+
+	if err := replaceSkillBundleDir(tmpDir, destDir); err != nil {
+		return err
+	}
+
+	installed = true
+
+	return nil
+}
+
+func writeSkillBundleContents(archive []byte, destDir string) error {
 	if err := os.MkdirAll(destDir, 0o755); err != nil { //nolint:mnd
 		return fmt.Errorf("create destination directory: %w", err)
 	}
@@ -37,25 +233,17 @@ func ExtractSkillBundleArchive(archive []byte, destDir string) error {
 	}
 	defer root.Close()
 
-	gzipReader, err := gzip.NewReader(bytes.NewReader(archive))
+	iterator, err := NewTarIterator(archive)
 	if err != nil {
 		return fmt.Errorf("invalid gzip archive: %w", err)
 	}
-	defer gzipReader.Close()
 
-	tarReader := tar.NewReader(gzipReader)
-
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			break
-		}
-
+	for entry, err := range iterator {
 		if err != nil {
 			return fmt.Errorf("read tar entry: %w", err)
 		}
 
-		if err := extractTarEntry(tarReader, header, root); err != nil {
+		if err := extractTarEntry(root, entry); err != nil {
 			return err
 		}
 	}
@@ -63,7 +251,21 @@ func ExtractSkillBundleArchive(archive []byte, destDir string) error {
 	return nil
 }
 
-func extractTarEntry(tarReader *tar.Reader, header *tar.Header, root *os.Root) error {
+func replaceSkillBundleDir(tmpDir, destDir string) error {
+	if err := os.RemoveAll(destDir); err != nil {
+		return fmt.Errorf("remove existing skill directory: %w", err)
+	}
+
+	if err := os.Rename(tmpDir, destDir); err != nil {
+		return fmt.Errorf("install skill directory: %w", err)
+	}
+
+	return nil
+}
+
+func extractTarEntry(root *os.Root, entry *TarEntry) error {
+	header := entry.header
+
 	rel, err := localTarEntryPath(header.Name)
 	if err != nil {
 		return fmt.Errorf("invalid tar entry %q: %w", header.Name, err)
@@ -88,12 +290,7 @@ func extractTarEntry(tarReader *tar.Reader, header *tar.Header, root *os.Root) e
 			return fmt.Errorf("create file %q: %w", header.Name, err)
 		}
 
-		reader := io.Reader(tarReader)
-		if header.Size >= 0 {
-			reader = io.LimitReader(tarReader, header.Size)
-		}
-
-		if _, err := io.Copy(file, reader); err != nil {
+		if _, err := file.Write(entry.payload); err != nil {
 			_ = file.Close()
 
 			return fmt.Errorf("write file %q: %w", header.Name, err)

--- a/api/exportfmt/tar_iterator.go
+++ b/api/exportfmt/tar_iterator.go
@@ -1,0 +1,97 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package exportfmt
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"iter"
+	"slices"
+)
+
+type TarIteratorOptions struct {
+	typeflags []byte
+}
+
+type TarIteratorOption func(*TarIteratorOptions)
+
+func WithTypeflag(typeflag byte) TarIteratorOption {
+	return func(opts *TarIteratorOptions) {
+		opts.typeflags = append(opts.typeflags, typeflag)
+	}
+}
+
+type TarIterator iter.Seq2[*TarEntry, error]
+
+type TarEntry struct {
+	header  *tar.Header
+	payload []byte
+}
+
+func NewTarIterator(raw []byte, opts ...TarIteratorOption) (TarIterator, error) {
+	var o TarIteratorOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("invalid gzip: %w", err)
+	}
+
+	tarReader := tar.NewReader(gzipReader)
+
+	return func(yield func(*TarEntry, error) bool) {
+		defer gzipReader.Close()
+
+		for {
+			header, err := tarReader.Next()
+			if errors.Is(err, io.EOF) {
+				return
+			}
+
+			if err != nil {
+				yield(nil, err)
+
+				return
+			}
+
+			entry, err := readTarEntry(tarReader, header)
+			if err != nil {
+				yield(nil, err)
+
+				return
+			}
+
+			if o.typeflags != nil && !slices.Contains(o.typeflags, header.Typeflag) {
+				continue
+			}
+
+			if !yield(entry, nil) {
+				return
+			}
+		}
+	}, nil
+}
+
+func readTarEntry(tarReader *tar.Reader, header *tar.Header) (*TarEntry, error) {
+	reader := io.Reader(tarReader)
+	if header.Size >= 0 {
+		reader = io.LimitReader(tarReader, header.Size)
+	}
+
+	payload, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read tar entry: %w", err)
+	}
+
+	return &TarEntry{
+		header:  header,
+		payload: payload,
+	}, nil
+}

--- a/cli/cmd/install/apply.go
+++ b/cli/cmd/install/apply.go
@@ -9,6 +9,8 @@ import (
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 )
 
+const skillBundleFolderOnlyReason = "skill bundle requires a multi-file skills directory; this agent only supports single instruction files"
+
 // runInstall applies the record's artifacts to the selected agents, one outcome
 // per touched artifact. Errors on one agent never abort the rest.
 func runInstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, dryRun bool) []agentcfg.Outcome {
@@ -26,12 +28,29 @@ func runInstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, dryRu
 			}
 		}
 
-		if agent.Skill != nil && arts.skill != "" {
+		if agent.Skill != nil && arts.hasSkill() {
+			if arts.hasSkillBundle() && agent.Skill.Strategy != agentcfg.SkillFolder {
+				outcomes = append(outcomes, agentcfg.Outcome{
+					Agent:    agent.Name,
+					Artifact: "skill",
+					Action:   agentcfg.ActionSkipped,
+					Reason:   skillBundleFolderOnlyReason,
+				})
+
+				continue
+			}
+
 			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
 				continue
 			}
 
-			o, _ := agentcfg.InstallSkill(agent.Skill, env, arts.slug, arts.skill, dryRun)
+			var o agentcfg.Outcome
+			if arts.hasSkillBundle() {
+				o, _ = agentcfg.InstallSkillBundle(agent.Skill, env, arts.slug, arts.skillBundle, dryRun)
+			} else {
+				o, _ = agentcfg.InstallSkill(agent.Skill, env, arts.slug, arts.skill, dryRun)
+			}
+
 			o.Agent = agent.Name
 			outcomes = append(outcomes, o)
 		}
@@ -55,7 +74,11 @@ func runUninstall(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, dry
 			}
 		}
 
-		if agent.Skill != nil && arts.skill != "" {
+		if agent.Skill != nil && arts.hasSkill() {
+			if arts.hasSkillBundle() && agent.Skill.Strategy != agentcfg.SkillFolder {
+				continue
+			}
+
 			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
 				continue
 			}

--- a/cli/cmd/install/apply_test.go
+++ b/cli/cmd/install/apply_test.go
@@ -4,6 +4,9 @@
 package install
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"testing"
@@ -218,4 +221,133 @@ func TestRunInstallDedupesSharedSkillPath(t *testing.T) {
 	// shared target to a single skill outcome.
 	require.Len(t, outcomes, 1)
 	require.Equal(t, "skill", outcomes[0].Artifact)
+}
+
+func TestRunInstallWritesSkillBundle(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	var target *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		if a.ID == claudeCodeID {
+			target = a.Skill
+		}
+	}
+
+	require.NotNil(t, target)
+
+	arts := artifacts{
+		slug:        "summarize",
+		skill:       "---\nname: summarize\ndescription: x\n---\n\nbody\n",
+		skillBundle: skillBundleArchiveBytes(t),
+	}
+	agent := agentcfg.Agent{Name: "Claude Code", Skill: target}
+	outcomes := runInstall(env, arts, []agentcfg.Agent{agent}, false)
+	require.Len(t, outcomes, 1)
+	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
+
+	skillFile := filepath.Join(home, ".claude", "skills", "summarize", "SKILL.md")
+	raw, err := os.ReadFile(skillFile)
+	require.NoError(t, err)
+	require.Contains(t, string(raw), "name: summarize")
+
+	extraFile := filepath.Join(home, ".claude", "skills", "summarize", "scripts", "run.sh")
+	extra, err := os.ReadFile(extraFile)
+	require.NoError(t, err)
+	require.Equal(t, "#!/bin/sh\n", string(extra))
+}
+
+func TestRunInstallExtractsSkillBundleToFolderAgents(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	var claudeCode, cursor, vscode *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		switch a.ID {
+		case claudeCodeID:
+			claudeCode = a.Skill
+		case "cursor":
+			cursor = a.Skill
+		case "vscode":
+			vscode = a.Skill
+		}
+	}
+
+	require.NotNil(t, claudeCode)
+	require.NotNil(t, cursor)
+	require.NotNil(t, vscode)
+
+	arts := artifacts{
+		slug:        "summarize",
+		skill:       "---\nname: summarize\ndescription: x\n---\n\nbody\n",
+		skillBundle: skillBundleArchiveBytes(t),
+	}
+	agents := []agentcfg.Agent{
+		{Name: "Claude Code", Skill: claudeCode},
+		{Name: "Cursor", Skill: cursor},
+		{Name: "VS Code (Copilot)", Skill: vscode},
+	}
+
+	outcomes := runInstall(env, arts, agents, true)
+	require.Len(t, outcomes, 3)
+
+	byAgent := map[string]agentcfg.Outcome{}
+	for _, o := range outcomes {
+		byAgent[o.Agent] = o
+	}
+
+	require.Equal(t, agentcfg.ActionAdded, byAgent["Claude Code"].Action)
+	require.Equal(t, agentcfg.ActionAdded, byAgent["Cursor"].Action)
+	require.Equal(t, agentcfg.ActionAdded, byAgent["VS Code (Copilot)"].Action)
+}
+
+func TestRunInstallSkipsSkillBundleForNonFolderAgents(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	var continueAgent *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		if a.ID == "continue" {
+			continueAgent = a.Skill
+		}
+	}
+
+	require.NotNil(t, continueAgent)
+
+	arts := artifacts{
+		slug:        "summarize",
+		skill:       "---\nname: summarize\ndescription: x\n---\n\nbody\n",
+		skillBundle: skillBundleArchiveBytes(t),
+	}
+	outcomes := runInstall(env, arts, []agentcfg.Agent{{Name: "Continue", Skill: continueAgent}}, true)
+	require.Len(t, outcomes, 1)
+	require.Equal(t, agentcfg.ActionSkipped, outcomes[0].Action)
+	require.Equal(t, skillBundleFolderOnlyReason, outcomes[0].Reason)
+}
+
+func skillBundleArchiveBytes(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+
+	writeFile := func(name, content string) {
+		data := []byte(content)
+		hdr := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(data)), Typeflag: tar.TypeReg}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write(data)
+		require.NoError(t, err)
+	}
+
+	writeFile("SKILL.md", "---\nname: summarize\ndescription: x\n---\n\nbody\n")
+	writeFile("scripts/run.sh", "#!/bin/sh\n")
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	return buf.Bytes()
 }

--- a/cli/cmd/install/batch.go
+++ b/cli/cmd/install/batch.go
@@ -1,0 +1,251 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	searchv1 "github.com/agntcy/dir/api/search/v1"
+	"github.com/agntcy/dir/cli/cmd/search"
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/presenter"
+	ctxUtils "github.com/agntcy/dir/cli/util/context"
+	"github.com/agntcy/dir/cli/util/records"
+	"github.com/spf13/cobra"
+)
+
+type skippedRecord struct {
+	label  string
+	reason string
+}
+
+var errBatchInputConflict = errors.New("positional argument and search filters are mutually exclusive")
+
+func resolveBatchOrInput(
+	hasInput bool,
+	hasFilters bool,
+	batchFn func() error,
+	singleFn func() error,
+	helpFn func() error,
+) error {
+	switch {
+	case hasInput && hasFilters:
+		return errBatchInputConflict
+	case !hasInput && hasFilters:
+		return batchFn()
+	case !hasInput && !hasFilters:
+		return helpFn()
+	default:
+		return singleFn()
+	}
+}
+
+func requireBatchQueries() ([]*searchv1.RecordQuery, error) {
+	queries := search.BuildQueries(&opts.filters)
+	if len(queries) == 0 {
+		return nil, errors.New("at least one search filter is required for batch mode (e.g. --name, --module)")
+	}
+
+	return queries, nil
+}
+
+func getRecordLabel(record *corev1.Record) string {
+	name := record.GetName()
+	if name == "" {
+		return record.GetCid()
+	}
+
+	if version := record.GetVersion(); version != "" {
+		return name + ":" + version
+	}
+
+	return name
+}
+
+func selectRecords(recs []*corev1.Record) []*corev1.Record {
+	if opts.allVersions {
+		return recs
+	}
+
+	return records.LatestByName(recs)
+}
+
+func tagOutcomes(outcomes []agentcfg.Outcome, record string) {
+	for i := range outcomes {
+		outcomes[i].Record = record
+	}
+}
+
+func formatSkippedSummary(skipped []skippedRecord) string {
+	if len(skipped) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+
+	b.WriteString("\n=== Skipped records ===\n")
+
+	for _, s := range skipped {
+		fmt.Fprintf(&b, "  %s: %s\n", s.label, s.reason)
+	}
+
+	return b.String()
+}
+
+type installTarget struct {
+	label string
+	arts  artifacts
+}
+
+type recordApplyFn func(env agentcfg.Env, arts artifacts, agents []agentcfg.Agent, dryRun bool) []agentcfg.Outcome
+
+func buildTaggedOutcomes(
+	env agentcfg.Env,
+	targets []installTarget,
+	selected []agentcfg.Agent,
+	dryRun bool,
+	apply recordApplyFn,
+) []agentcfg.Outcome {
+	var outcomes []agentcfg.Outcome
+
+	for _, target := range targets {
+		recordOutcomes := apply(env, target.arts, selected, dryRun)
+		tagOutcomes(recordOutcomes, target.label)
+		outcomes = append(outcomes, recordOutcomes...)
+	}
+
+	return outcomes
+}
+
+func pullBatchRecords(cmd *cobra.Command, queries []*searchv1.RecordQuery) ([]*corev1.Record, error) {
+	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
+	if !ok {
+		return nil, errors.New("failed to get client from context")
+	}
+
+	recs, err := records.SearchAndPull(cmd.Context(), c, queries, opts.limit)
+	if err != nil {
+		return nil, fmt.Errorf("search records: %w", err)
+	}
+
+	return recs, nil
+}
+
+func buildBatchTargets(cmd *cobra.Command, recs []*corev1.Record) ([]installTarget, []skippedRecord) {
+	targets := make([]installTarget, 0, len(recs))
+
+	var skipped []skippedRecord
+
+	for _, record := range recs {
+		label := getRecordLabel(record)
+
+		arts, err := deriveArtifacts(record)
+		if err != nil {
+			skipped = append(skipped, skippedRecord{label: label, reason: err.Error()})
+			presenter.Printf(cmd, "Warning: skipping %s: %s\n", label, err.Error())
+
+			continue
+		}
+
+		targets = append(targets, installTarget{label: label, arts: arts})
+	}
+
+	return targets, skipped
+}
+
+func printSkippedSummary(cmd *cobra.Command, skipped []skippedRecord) {
+	if len(skipped) > 0 {
+		presenter.Printf(cmd, "%s", formatSkippedSummary(skipped))
+	}
+}
+
+func confirmBatch(cmd *cobra.Command, prompt string) (bool, error) {
+	if opts.yes || opts.dryRun {
+		return true, nil
+	}
+
+	ok, err := confirm(cmd, prompt)
+	if err != nil {
+		return false, err
+	}
+
+	if !ok {
+		presenter.Printf(cmd, "Aborted. No changes made.\n")
+
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func confirmBatchChanges(cmd *cobra.Command) (bool, error) {
+	return confirmBatch(cmd, "\nProceed with these changes?")
+}
+
+func confirmBatchUninstall(cmd *cobra.Command) (bool, error) {
+	return confirmBatch(cmd, "\nRemove these artifacts?")
+}
+
+func runBatch(cmd *cobra.Command, apply recordApplyFn, confirmFn func(*cobra.Command) (bool, error)) error {
+	queries, err := requireBatchQueries()
+	if err != nil {
+		return err
+	}
+
+	recs, err := pullBatchRecords(cmd, queries)
+	if err != nil {
+		return err
+	}
+
+	if len(recs) == 0 {
+		presenter.PrintSmartf(cmd, "No records matched the search criteria\n")
+
+		return nil
+	}
+
+	env := agentcfg.ResolveEnv()
+
+	selected, err := selectAgents(cmd, env)
+	if err != nil {
+		return err
+	}
+
+	targets, skipped := buildBatchTargets(cmd, selectRecords(recs))
+	plan := buildTaggedOutcomes(env, targets, selected, true, apply)
+
+	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
+	printSkippedSummary(cmd, skipped)
+
+	if len(plan) == 0 {
+		return nil
+	}
+
+	proceed, err := confirmFn(cmd)
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		return nil
+	}
+
+	outcomes := buildTaggedOutcomes(env, targets, selected, opts.dryRun, apply)
+	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
+	printSkippedSummary(cmd, skipped)
+
+	return nil
+}
+
+// runBatchInstall searches for records and installs each into the selected agents.
+func runBatchInstall(cmd *cobra.Command) error {
+	return runBatch(cmd, runInstall, confirmBatchChanges)
+}
+
+// runBatchUninstall searches for records and removes each from the selected agents.
+func runBatchUninstall(cmd *cobra.Command) error {
+	return runBatch(cmd, runUninstall, confirmBatchUninstall)
+}

--- a/cli/cmd/install/batch_test.go
+++ b/cli/cmd/install/batch_test.go
@@ -1,0 +1,102 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"testing"
+
+	oasfv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1alpha1"
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBatchOrInputMutuallyExclusive(t *testing.T) {
+	err := resolveBatchOrInput(true, true, nil, nil, nil)
+	require.ErrorIs(t, err, errBatchInputConflict)
+}
+
+func TestResolveBatchOrInputBatch(t *testing.T) {
+	called := false
+
+	err := resolveBatchOrInput(false, true, func() error {
+		called = true
+
+		return nil
+	}, nil, nil)
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestResolveBatchOrInputSingle(t *testing.T) {
+	called := false
+
+	err := resolveBatchOrInput(true, false, nil, func() error {
+		called = true
+
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	require.True(t, called)
+}
+
+func TestRecordLabel(t *testing.T) {
+	require.Equal(t, "agent-a:1.0.0", getRecordLabel(corev1.New(&oasfv1alpha1.Record{
+		Name:    "agent-a",
+		Version: "1.0.0",
+	})))
+	require.Equal(t, "agent-b", getRecordLabel(corev1.New(&oasfv1alpha1.Record{Name: "agent-b"})))
+}
+
+func TestSelectRecordsLatestByName(t *testing.T) {
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	opts.allVersions = false
+
+	recs := []*corev1.Record{
+		corev1.New(&oasfv1alpha1.Record{Name: "a", Version: "1.0.0"}),
+		corev1.New(&oasfv1alpha1.Record{Name: "a", Version: "2.0.0"}),
+		corev1.New(&oasfv1alpha1.Record{Name: "b", Version: "1.0.0"}),
+	}
+
+	selected := selectRecords(recs)
+	require.Len(t, selected, 2)
+	require.Equal(t, "2.0.0", selected[0].GetVersion())
+	require.Equal(t, "b", selected[1].GetName())
+}
+
+func TestSelectRecordsAllVersions(t *testing.T) {
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	opts.allVersions = true
+
+	recs := []*corev1.Record{
+		corev1.New(&oasfv1alpha1.Record{Name: "a", Version: "1.0.0"}),
+		corev1.New(&oasfv1alpha1.Record{Name: "a", Version: "2.0.0"}),
+	}
+
+	require.Len(t, selectRecords(recs), 2)
+}
+
+func TestFormatSkippedSummary(t *testing.T) {
+	out := formatSkippedSummary([]skippedRecord{
+		{label: "bare", reason: "no installable module"},
+	})
+	require.Contains(t, out, "Skipped records")
+	require.Contains(t, out, "bare")
+	require.Contains(t, out, "no installable module")
+}
+
+func TestBatchInstallSkipsUnsuitableRecords(t *testing.T) {
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	_, err := deriveArtifacts(loadRecord(t, "bare.json"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no installable")
+}

--- a/cli/cmd/install/derive.go
+++ b/cli/cmd/install/derive.go
@@ -8,8 +8,10 @@ import (
 	"sort"
 	"strings"
 
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/dir/api/exportfmt"
+	"github.com/agntcy/dir/cli/util/records"
 	recordutil "github.com/agntcy/oasf-sdk/pkg/record"
 	"github.com/agntcy/oasf-sdk/pkg/translator"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -24,9 +26,18 @@ type mcpServer struct {
 
 // artifacts is the set of installable artifacts derived from a record's modules.
 type artifacts struct {
-	slug       string // sanitized record name; skill folder/file + block marker id
-	skill      string // canonical SKILL.md content, empty if the record has no skill
-	mcpServers []mcpServer
+	slug        string // sanitized record name; skill folder/file + block marker id
+	skill       string // canonical SKILL.md content for single-file skill targets
+	skillBundle []byte // gzip skill bundle when the record stores application/agent-skills+gzip
+	mcpServers  []mcpServer
+}
+
+func (a artifacts) hasSkill() bool {
+	return a.skill != "" || a.hasSkillBundle()
+}
+
+func (a artifacts) hasSkillBundle() bool {
+	return len(a.skillBundle) > 0
 }
 
 // deriveArtifacts inspects the record's OASF modules and builds the installable
@@ -41,17 +52,9 @@ func deriveArtifacts(record *corev1.Record) (artifacts, error) {
 	arts := artifacts{slug: sanitizeSlug(record.GetName())}
 
 	if ok, _ := recordutil.GetModule(data, translator.AgentSkillsModuleName); ok {
-		f, err := exportfmt.GetFormatter(exportfmt.FormatAgentSkill)
-		if err != nil {
-			return artifacts{}, fmt.Errorf("get agent-skill formatter: %w", err)
+		if err := deriveSkillArtifacts(record, &arts); err != nil {
+			return artifacts{}, err
 		}
-
-		out, err := f.Format(record)
-		if err != nil {
-			return artifacts{}, fmt.Errorf("render skill: %w", err)
-		}
-
-		arts.skill = string(out)
 	}
 
 	if ok, _ := recordutil.GetModule(data, translator.MCPModuleName); ok {
@@ -77,7 +80,7 @@ func deriveArtifacts(record *corev1.Record) (artifacts, error) {
 		}
 	}
 
-	if arts.skill == "" && len(arts.mcpServers) == 0 {
+	if !arts.hasSkill() && len(arts.mcpServers) == 0 {
 		if ok, _ := recordutil.GetModule(data, translator.A2AModuleName); ok {
 			return artifacts{}, fmt.Errorf(
 				"record carries an A2A AgentCard (%s), which cannot be installed into agent configs; use `dirctl export` instead",
@@ -95,6 +98,52 @@ func deriveArtifacts(record *corev1.Record) (artifacts, error) {
 	}
 
 	return arts, nil
+}
+
+func deriveSkillArtifacts(record *corev1.Record, arts *artifacts) error {
+	data := record.GetData()
+	mediaType := agentSkillsArtifactMediaType(data)
+
+	formatName := exportfmt.FormatAgentSkill
+	if mediaType == catalogv1.ProtocolAgentSkillsBundleMediaType {
+		formatName = exportfmt.FormatAgentSkillBundle
+	}
+
+	f, err := exportfmt.GetFormatter(formatName)
+	if err != nil {
+		return fmt.Errorf("get %s formatter: %w", formatName, err)
+	}
+
+	out, err := f.Format(record)
+	if err != nil {
+		return fmt.Errorf("render skill: %w", err)
+	}
+
+	if formatName == exportfmt.FormatAgentSkillBundle {
+		arts.skillBundle = out
+
+		md, err := exportfmt.SkillMarkdownFromArchive(out)
+		if err != nil {
+			return fmt.Errorf("read SKILL.md from bundle: %w", err)
+		}
+
+		arts.skill = md
+
+		return nil
+	}
+
+	arts.skill = string(out)
+
+	return nil
+}
+
+func agentSkillsArtifactMediaType(data *structpb.Struct) string {
+	ok, module := recordutil.GetModule(data, translator.AgentSkillsModuleName)
+	if !ok || module == nil {
+		return ""
+	}
+
+	return module.GetFields()["artifact"].GetStructValue().GetFields()["media_type"].GetStringValue()
 }
 
 // mcpEntry converts a translator MCP server into a config entry using any-typed
@@ -142,11 +191,5 @@ func moduleNames(data *structpb.Struct) []string {
 
 // sanitizeSlug turns a record name into a filesystem/marker-safe slug.
 func sanitizeSlug(name string) string {
-	r := strings.NewReplacer("/", "-", "\\", "-", ":", "-", " ", "-")
-
-	// Trim leading/trailing "." as well as "-" so a name of "." or ".." (and
-	// "../../etc" after the separator replacement above) cannot escape a parent
-	// directory when the slug is used as a filesystem path component. Embedded
-	// dots (e.g. "io.example") are preserved as a single filename component.
-	return strings.Trim(r.Replace(name), "-.")
+	return records.SanitizeSlug(name)
 }

--- a/cli/cmd/install/derive_test.go
+++ b/cli/cmd/install/derive_test.go
@@ -4,11 +4,17 @@
 package install
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
 	"os"
 	"strings"
 	"testing"
 
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
 	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -53,6 +59,55 @@ func TestDeriveMulti(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, arts.skill)
 	require.NotEmpty(t, arts.mcpServers)
+}
+
+func TestDeriveSkillBundle(t *testing.T) {
+	arts, err := deriveArtifacts(newSkillBundleRecord(t))
+	require.NoError(t, err)
+	require.NotEmpty(t, arts.skillBundle)
+	require.NotEmpty(t, arts.skill)
+	require.Contains(t, arts.skill, "name:")
+}
+
+func TestAgentSkillsArtifactMediaType(t *testing.T) {
+	record := loadRecord(t, "skill.json")
+	require.Empty(t, agentSkillsArtifactMediaType(record.GetData()))
+
+	bundle := newSkillBundleRecord(t)
+	require.Equal(t, catalogv1.ProtocolAgentSkillsBundleMediaType, agentSkillsArtifactMediaType(bundle.GetData()))
+}
+
+func newSkillBundleRecord(t *testing.T) *corev1.Record {
+	t.Helper()
+
+	skillMarkdown := `---
+name: summarize
+description: Summarize content.
+---
+`
+
+	var buf bytes.Buffer
+
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	content := []byte(skillMarkdown)
+	hdr := &tar.Header{Name: "SKILL.md", Mode: 0o600, Size: int64(len(content))}
+	require.NoError(t, tw.WriteHeader(hdr))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	skillInput, err := structpb.NewStruct(map[string]any{
+		"skillMarkdown": skillMarkdown,
+		"skillArchive":  base64.StdEncoding.EncodeToString(buf.Bytes()),
+	})
+	require.NoError(t, err)
+
+	recordStruct, err := translator.SkillBundleToRecord(skillInput)
+	require.NoError(t, err)
+
+	return &corev1.Record{Data: recordStruct}
 }
 
 func TestDeriveA2AErrors(t *testing.T) {

--- a/cli/cmd/install/flags.go
+++ b/cli/cmd/install/flags.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/agntcy/dir/cli/cmd/search"
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,15 @@ func addSelectionFlags(cmd *cobra.Command, opts *options) {
 			allAgents, strings.Join(agentIDs(), ", ")))
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Preview changes without writing")
 	flags.BoolVarP(&opts.yes, "yes", "y", false, "Skip the confirmation prompt")
+}
+
+func addBatchFlags(cmd *cobra.Command, opts *options) {
+	flags := cmd.PersistentFlags()
+
+	flags.Uint32Var(&opts.limit, "limit", 100, "Maximum number of records to process in batch mode") //nolint:mnd
+	flags.BoolVar(&opts.allVersions, "all-versions", false, "Process all matched versions (default: latest per name wins)")
+
+	search.RegisterPersistentFilterFlags(cmd, &opts.filters)
 }
 
 // agentIDs returns the known agent IDs from the registry, for flag help and

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/cmd/search"
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/agntcy/dir/cli/presenter"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
@@ -36,6 +37,16 @@ directly into the configuration of detected AI coding agents.
   dirctl install uninstall <cid-or-name>  remove what install added
   dirctl install list                     show detected agents and target paths
 
+Batch install from search filters (no positional argument):
+
+  dirctl install --module integration/mcp --name "web*" --agents all
+  dirctl install --skill "code*" --dry-run
+
+Batch uninstall from search filters:
+
+  dirctl install uninstall --module integration/mcp --name "web*"
+  dirctl uninstall --skill "code*" --dry-run
+
 Examples:
   dirctl install cisco.com/agent:v1.0.0
   dirctl install bafyrei... --dry-run
@@ -44,16 +55,28 @@ Examples:
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return cmd.Help()
+		var input string
+		if len(args) > 0 {
+			input = args[0]
 		}
 
-		return runInstallCmd(cmd, args[0])
+		queries := search.BuildQueries(&opts.filters)
+		hasInput := input != ""
+		hasFilters := len(queries) > 0
+
+		return resolveBatchOrInput(
+			hasInput,
+			hasFilters,
+			func() error { return runBatchInstall(cmd) },
+			func() error { return runInstallCmd(cmd, input) },
+			func() error { return cmd.Help() },
+		)
 	},
 }
 
 func init() {
 	addSelectionFlags(Command, &opts)
+	addBatchFlags(Command, &opts)
 
 	Command.AddCommand(runCmd)
 	Command.AddCommand(uninstallCmd)

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -43,6 +43,8 @@ func TestTopLevelUninstallShorthand(t *testing.T) {
 	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("agents"))
 	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("dry-run"))
 	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("yes"))
+	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("limit"))
+	require.NotNil(t, UninstallCommand.PersistentFlags().Lookup("module"))
 }
 
 // --- confirm tests ---

--- a/cli/cmd/install/options.go
+++ b/cli/cmd/install/options.go
@@ -3,9 +3,14 @@
 
 package install
 
+import "github.com/agntcy/dir/cli/cmd/search"
+
 // options holds the shared flags for the install subcommands.
 type options struct {
-	agents []string
-	dryRun bool
-	yes    bool
+	agents      []string
+	dryRun      bool
+	yes         bool
+	limit       uint32
+	allVersions bool
+	filters     search.Filters
 }

--- a/cli/cmd/install/uninstall.go
+++ b/cli/cmd/install/uninstall.go
@@ -4,19 +4,42 @@
 package install
 
 import (
+	"github.com/agntcy/dir/cli/cmd/search"
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/agntcy/dir/cli/presenter"
 	"github.com/spf13/cobra"
 )
 
 // uninstallCmd is the `dirctl install uninstall` subcommand. It inherits the
-// selection flags from the `install` parent's persistent flags.
+// selection and batch flags from the `install` parent's persistent flags.
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall <cid-or-name[:version][@digest]>",
 	Short: "Remove a record's artifacts from detected agents",
-	Args:  cobra.ExactArgs(1),
+	Long: `Remove artifacts that install added for a record from detected agents.
+
+  dirctl install uninstall <cid-or-name>   remove from detected agents
+  dirctl install uninstall --module integration/mcp --name "web*"  batch remove
+
+Batch uninstall uses the same search filters as batch install (--name, --module,
+--skill, etc.).`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runUninstallCmd(cmd, args[0])
+		var input string
+		if len(args) > 0 {
+			input = args[0]
+		}
+
+		queries := search.BuildQueries(&opts.filters)
+		hasInput := input != ""
+		hasFilters := len(queries) > 0
+
+		return resolveBatchOrInput(
+			hasInput,
+			hasFilters,
+			func() error { return runBatchUninstall(cmd) },
+			func() error { return runUninstallCmd(cmd, input) },
+			func() error { return cmd.Help() },
+		)
 	},
 }
 
@@ -26,14 +49,34 @@ var uninstallCmd = &cobra.Command{
 var UninstallCommand = &cobra.Command{
 	Use:   "uninstall <cid-or-name[:version][@digest]>",
 	Short: "Remove a record's artifacts from detected agents (shorthand for 'install uninstall')",
-	Args:  cobra.ExactArgs(1),
+	Long: `Remove artifacts that install added for a record from detected agents.
+
+  dirctl uninstall <cid-or-name>              remove from detected agents
+  dirctl uninstall --module integration/mcp   batch remove matched records`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runUninstallCmd(cmd, args[0])
+		var input string
+		if len(args) > 0 {
+			input = args[0]
+		}
+
+		queries := search.BuildQueries(&opts.filters)
+		hasInput := input != ""
+		hasFilters := len(queries) > 0
+
+		return resolveBatchOrInput(
+			hasInput,
+			hasFilters,
+			func() error { return runBatchUninstall(cmd) },
+			func() error { return runUninstallCmd(cmd, input) },
+			func() error { return cmd.Help() },
+		)
 	},
 }
 
 func init() {
 	addSelectionFlags(UninstallCommand, &opts)
+	addBatchFlags(UninstallCommand, &opts)
 }
 
 // runUninstallCmd is the shared body for both `install uninstall` and the

--- a/cli/cmd/search/filters.go
+++ b/cli/cmd/search/filters.go
@@ -6,6 +6,7 @@ package search
 import (
 	searchv1 "github.com/agntcy/dir/api/search/v1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // Filters holds the values for all record-search filter flags.
@@ -33,8 +34,16 @@ type Filters struct {
 // RegisterFilterFlags binds the standard search-filter flags to cmd, storing
 // values in f. Call this from your command's init().
 func RegisterFilterFlags(cmd *cobra.Command, f *Filters) {
-	flags := cmd.Flags()
+	registerFilterFlags(cmd.Flags(), f)
+}
 
+// RegisterPersistentFilterFlags binds search-filter flags as persistent flags on
+// cmd so subcommands inherit them.
+func RegisterPersistentFilterFlags(cmd *cobra.Command, f *Filters) {
+	registerFilterFlags(cmd.PersistentFlags(), f)
+}
+
+func registerFilterFlags(flags *pflag.FlagSet, f *Filters) {
 	flags.StringArrayVar(&f.Names, "name", nil,
 		"Search for records with specific name (e.g., --name 'my-agent' --name 'web-*')")
 	flags.StringArrayVar(&f.Versions, "version", nil,

--- a/cli/internal/agentcfg/format_grouped.go
+++ b/cli/internal/agentcfg/format_grouped.go
@@ -1,0 +1,65 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"fmt"
+	"strings"
+)
+
+func needsRecordGrouping(outcomes []Outcome) bool {
+	for _, o := range outcomes {
+		if o.Record != "" {
+			return true
+		}
+	}
+
+	return false
+}
+
+func recordOrder(outcomes []Outcome) []string {
+	seen := map[string]bool{}
+
+	var order []string
+
+	for _, o := range outcomes {
+		if o.Record == "" || seen[o.Record] {
+			continue
+		}
+
+		seen[o.Record] = true
+		order = append(order, o.Record)
+	}
+
+	return order
+}
+
+func outcomesForRecord(outcomes []Outcome, record string) []Outcome {
+	var filtered []Outcome
+
+	for _, o := range outcomes {
+		if o.Record == record {
+			filtered = append(filtered, o)
+		}
+	}
+
+	return filtered
+}
+
+func writeOutcomeLines(b *strings.Builder, outcomes []Outcome) {
+	for _, o := range outcomes {
+		path := o.Path
+		if path == "" {
+			path = "-"
+		}
+
+		fmt.Fprintf(b, "  %-9s %-5s %s  (%s)", o.Action, o.Artifact, path, o.Agent)
+
+		if o.Reason != "" {
+			fmt.Fprintf(b, ": %s", o.Reason)
+		}
+
+		b.WriteString("\n")
+	}
+}

--- a/cli/internal/agentcfg/format_grouped_test.go
+++ b/cli/internal/agentcfg/format_grouped_test.go
@@ -1,0 +1,36 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentcfg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatPlanGroupedByRecord(t *testing.T) {
+	out := FormatPlan([]Outcome{
+		{Record: "agent-a:1.0", Agent: "Claude Code", Artifact: "mcp", Path: "/a.json", Action: ActionAdded},
+		{Record: "agent-b:2.0", Agent: "Cursor", Artifact: "skill", Path: "/b.mdc", Action: ActionAdded},
+	})
+
+	require.Contains(t, out, "Record: agent-a:1.0")
+	require.Contains(t, out, "Record: agent-b:2.0")
+	require.Contains(t, out, "/a.json")
+	require.Contains(t, out, "/b.mdc")
+
+	aIdx := strings.Index(out, "Record: agent-a:1.0")
+	bIdx := strings.Index(out, "Record: agent-b:2.0")
+	require.Less(t, aIdx, bIdx)
+}
+
+func TestFormatSummaryGroupedByRecord(t *testing.T) {
+	out := FormatSummary([]Outcome{
+		{Record: "agent-a:1.0", Agent: "Claude Code", Artifact: "mcp", Path: "/a.json", Action: ActionAdded},
+	}, false)
+
+	require.Contains(t, out, "Record: agent-a:1.0")
+	require.Contains(t, out, "Tally:")
+}

--- a/cli/internal/agentcfg/paths.go
+++ b/cli/internal/agentcfg/paths.go
@@ -161,7 +161,7 @@ func claudeCodeSkillPath(env Env, slug string) (string, error) {
 	return filepath.Join(env.Home, ".claude", "skills", slug, "SKILL.md"), nil
 }
 
-func zedSkillPath(env Env, slug string) (string, error) {
+func zedUserSkillPath(env Env, slug string) (string, error) {
 	if err := requireHome(env); err != nil {
 		return "", err
 	}
@@ -169,42 +169,76 @@ func zedSkillPath(env Env, slug string) (string, error) {
 	return filepath.Join(env.Home, ".agents", "skills", slug, "SKILL.md"), nil
 }
 
-func copilotSkillPath(env Env, slug string) (string, error) {
-	if err := requireHome(env); err != nil {
-		return "", err
+func zedProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Zed project skill")
 	}
 
-	return filepath.Join(vscodeUserDir(env), "prompts", slug+".instructions.md"), nil
+	return filepath.Join(env.Cwd, ".agents", "skills", slug, "SKILL.md"), nil
 }
 
-func windsurfSkillPath(env Env, _ string) (string, error) {
+func copilotUserSkillPath(env Env, slug string) (string, error) {
 	if err := requireHome(env); err != nil {
 		return "", err
 	}
 
-	return filepath.Join(env.Home, ".codeium", "windsurf", "memories", "global_rules.md"), nil
+	return filepath.Join(env.Home, ".copilot", "skills", slug, "SKILL.md"), nil
 }
 
-func clineSkillPath(env Env, slug string) (string, error) {
-	if err := requireHome(env); err != nil {
-		return "", err
+func copilotProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Copilot project skill")
 	}
 
-	// Cline reads global rules from ~/Documents/Cline/Rules on macOS/Windows and
-	// ~/Cline/Rules on Linux.
-	if env.GOOS == "linux" {
-		return filepath.Join(env.Home, "Cline", "Rules", slug+".md"), nil
-	}
-
-	return filepath.Join(env.Home, "Documents", "Cline", "Rules", slug+".md"), nil
+	return filepath.Join(env.Cwd, ".github", "skills", slug, "SKILL.md"), nil
 }
 
-func rooSkillPath(env Env, slug string) (string, error) {
+func windsurfUserSkillPath(env Env, slug string) (string, error) {
 	if err := requireHome(env); err != nil {
 		return "", err
 	}
 
-	return filepath.Join(env.Home, ".roo", "rules", slug+".md"), nil
+	return filepath.Join(env.Home, ".codeium", "windsurf", "skills", slug, "SKILL.md"), nil
+}
+
+func windsurfProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Windsurf project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".windsurf", "skills", slug, "SKILL.md"), nil
+}
+
+func clineUserSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".cline", "skills", slug, "SKILL.md"), nil
+}
+
+func clineProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Cline project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".cline", "skills", slug, "SKILL.md"), nil
+}
+
+func rooUserSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".roo", "skills", slug, "SKILL.md"), nil
+}
+
+func rooProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Roo Code project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".roo", "skills", slug, "SKILL.md"), nil
 }
 
 func continueSkillPath(env Env, slug string) (string, error) {
@@ -215,42 +249,68 @@ func continueSkillPath(env Env, slug string) (string, error) {
 	return filepath.Join(env.Home, ".continue", "rules", slug+".md"), nil
 }
 
-func geminiSkillPath(env Env, _ string) (string, error) {
+func geminiUserSkillPath(env Env, slug string) (string, error) {
 	if err := requireHome(env); err != nil {
 		return "", err
 	}
 
-	return filepath.Join(env.Home, ".gemini", "GEMINI.md"), nil
+	return filepath.Join(env.Home, ".gemini", "skills", slug, "SKILL.md"), nil
 }
 
-func codexSkillPath(env Env, _ string) (string, error) {
+func geminiProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Gemini CLI project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".gemini", "skills", slug, "SKILL.md"), nil
+}
+
+func codexUserSkillPath(env Env, slug string) (string, error) {
 	if err := requireHome(env); err != nil {
 		return "", err
 	}
 
-	return filepath.Join(env.Home, ".codex", "AGENTS.md"), nil
+	return filepath.Join(env.Home, ".agents", "skills", slug, "SKILL.md"), nil
 }
 
-func opencodeSkillPath(env Env, _ string) (string, error) {
+func codexProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Codex CLI project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".agents", "skills", slug, "SKILL.md"), nil
+}
+
+func opencodeUserSkillPath(env Env, slug string) (string, error) {
 	if err := requireHome(env); err != nil {
 		return "", err
 	}
 
-	return filepath.Join(env.Home, ".config", "opencode", "AGENTS.md"), nil
+	return filepath.Join(env.Home, ".config", "opencode", "skills", slug, "SKILL.md"), nil
 }
 
-// cursorNoGlobalSkill signals that Cursor has no global rules mechanism, so the
-// engine falls back to the project path.
-func cursorNoGlobalSkill(_ Env, _ string) (string, error) {
-	return "", ErrNoGlobalPath
+func opencodeProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for OpenCode project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".opencode", "skills", slug, "SKILL.md"), nil
+}
+
+func cursorUserSkillPath(env Env, slug string) (string, error) {
+	if err := requireHome(env); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Home, ".cursor", "skills", slug, "SKILL.md"), nil
 }
 
 func cursorProjectSkillPath(env Env, slug string) (string, error) {
 	if env.Cwd == "" {
-		return "", fmt.Errorf("cannot determine current directory for Cursor project rule")
+		return "", fmt.Errorf("cannot determine current directory for Cursor project skill")
 	}
 
-	return filepath.Join(env.Cwd, ".cursor", "rules", slug+".mdc"), nil
+	return filepath.Join(env.Cwd, ".cursor", "skills", slug, "SKILL.md"), nil
 }
 
 func codexMarker(env Env) (string, error)    { return filepath.Join(env.Home, ".codex"), nil }

--- a/cli/internal/agentcfg/paths_test.go
+++ b/cli/internal/agentcfg/paths_test.go
@@ -234,70 +234,113 @@ func TestClaudeCodeSkillPathEmptyHome(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestZedSkillPath(t *testing.T) {
-	got, err := zedSkillPath(Env{Home: "/home/u"}, "my-skill")
+func TestZedUserSkillPath(t *testing.T) {
+	got, err := zedUserSkillPath(Env{Home: "/home/u"}, "my-skill")
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Join("/home/u", ".agents", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestZedSkillPathEmptyHome(t *testing.T) {
-	_, err := zedSkillPath(Env{Home: ""}, "slug")
+func TestZedUserSkillPathEmptyHome(t *testing.T) {
+	_, err := zedUserSkillPath(Env{Home: ""}, "slug")
 	assert.Error(t, err)
 }
 
-func TestCopilotSkillPath(t *testing.T) {
-	got, err := copilotSkillPath(Env{Home: "/home/u", GOOS: "linux"}, "my-skill")
+func TestZedProjectSkillPath(t *testing.T) {
+	got, err := zedProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", ".config", "Code", "User", "prompts", "my-skill.instructions.md"), got)
+	assert.Equal(t, filepath.Join("/repo", ".agents", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestCopilotSkillPathEmptyHome(t *testing.T) {
-	_, err := copilotSkillPath(Env{Home: ""}, "slug")
+func TestZedProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := zedProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
 	assert.Error(t, err)
 }
 
-func TestWindsurfSkillPath(t *testing.T) {
-	got, err := windsurfSkillPath(Env{Home: "/home/u"}, "any-slug")
+func TestCopilotUserSkillPath(t *testing.T) {
+	got, err := copilotUserSkillPath(Env{Home: "/home/u", GOOS: "linux"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", ".codeium", "windsurf", "memories", "global_rules.md"), got)
+	assert.Equal(t, filepath.Join("/home/u", ".copilot", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestWindsurfSkillPathEmptyHome(t *testing.T) {
-	_, err := windsurfSkillPath(Env{Home: ""}, "slug")
+func TestCopilotUserSkillPathEmptyHome(t *testing.T) {
+	_, err := copilotUserSkillPath(Env{Home: ""}, "slug")
 	assert.Error(t, err)
 }
 
-func TestClineSkillPathLinux(t *testing.T) {
-	got, err := clineSkillPath(Env{Home: "/home/u", GOOS: "linux"}, "my-skill")
+func TestCopilotProjectSkillPath(t *testing.T) {
+	got, err := copilotProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", "Cline", "Rules", "my-skill.md"), got)
+	assert.Equal(t, filepath.Join("/repo", ".github", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestClineSkillPathDarwin(t *testing.T) {
-	got, err := clineSkillPath(Env{Home: "/home/u", GOOS: "darwin"}, "my-skill")
-	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", "Documents", "Cline", "Rules", "my-skill.md"), got)
-}
-
-func TestClineSkillPathWindows(t *testing.T) {
-	got, err := clineSkillPath(Env{Home: "/home/u", GOOS: "windows"}, "my-skill")
-	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", "Documents", "Cline", "Rules", "my-skill.md"), got)
-}
-
-func TestClineSkillPathEmptyHome(t *testing.T) {
-	_, err := clineSkillPath(Env{Home: ""}, "slug")
+func TestCopilotProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := copilotProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
 	assert.Error(t, err)
 }
 
-func TestRooSkillPath(t *testing.T) {
-	got, err := rooSkillPath(Env{Home: "/home/u"}, "my-skill")
+func TestWindsurfUserSkillPath(t *testing.T) {
+	got, err := windsurfUserSkillPath(Env{Home: "/home/u"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", ".roo", "rules", "my-skill.md"), got)
+	assert.Equal(t, filepath.Join("/home/u", ".codeium", "windsurf", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestRooSkillPathEmptyHome(t *testing.T) {
-	_, err := rooSkillPath(Env{Home: ""}, "slug")
+func TestWindsurfUserSkillPathEmptyHome(t *testing.T) {
+	_, err := windsurfUserSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestWindsurfProjectSkillPath(t *testing.T) {
+	got, err := windsurfProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/repo", ".windsurf", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestWindsurfProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := windsurfProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestClineUserSkillPath(t *testing.T) {
+	got, err := clineUserSkillPath(Env{Home: "/home/u", GOOS: "linux"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".cline", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestClineUserSkillPathEmptyHome(t *testing.T) {
+	_, err := clineUserSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestClineProjectSkillPath(t *testing.T) {
+	got, err := clineProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/repo", ".cline", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestClineProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := clineProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestRooUserSkillPath(t *testing.T) {
+	got, err := rooUserSkillPath(Env{Home: "/home/u"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".roo", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestRooUserSkillPathEmptyHome(t *testing.T) {
+	_, err := rooUserSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestRooProjectSkillPath(t *testing.T) {
+	got, err := rooProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/repo", ".roo", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestRooProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := rooProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
 	assert.Error(t, err)
 }
 
@@ -312,50 +355,89 @@ func TestContinueSkillPathEmptyHome(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestGeminiSkillPath(t *testing.T) {
-	got, err := geminiSkillPath(Env{Home: "/home/u"}, "any-slug")
+func TestGeminiUserSkillPath(t *testing.T) {
+	got, err := geminiUserSkillPath(Env{Home: "/home/u"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", ".gemini", "GEMINI.md"), got)
+	assert.Equal(t, filepath.Join("/home/u", ".gemini", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestGeminiSkillPathEmptyHome(t *testing.T) {
-	_, err := geminiSkillPath(Env{Home: ""}, "slug")
+func TestGeminiUserSkillPathEmptyHome(t *testing.T) {
+	_, err := geminiUserSkillPath(Env{Home: ""}, "slug")
 	assert.Error(t, err)
 }
 
-func TestCodexSkillPath(t *testing.T) {
-	got, err := codexSkillPath(Env{Home: "/home/u"}, "any-slug")
+func TestGeminiProjectSkillPath(t *testing.T) {
+	got, err := geminiProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", ".codex", "AGENTS.md"), got)
+	assert.Equal(t, filepath.Join("/repo", ".gemini", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestCodexSkillPathEmptyHome(t *testing.T) {
-	_, err := codexSkillPath(Env{Home: ""}, "slug")
+func TestGeminiProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := geminiProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
 	assert.Error(t, err)
 }
 
-func TestOpencodeSkillPath(t *testing.T) {
-	got, err := opencodeSkillPath(Env{Home: "/home/u"}, "any-slug")
+func TestCodexUserSkillPath(t *testing.T) {
+	got, err := codexUserSkillPath(Env{Home: "/home/u"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/home/u", ".config", "opencode", "AGENTS.md"), got)
+	assert.Equal(t, filepath.Join("/home/u", ".agents", "skills", "my-skill", "SKILL.md"), got)
 }
 
-func TestOpencodeSkillPathEmptyHome(t *testing.T) {
-	_, err := opencodeSkillPath(Env{Home: ""}, "slug")
+func TestCodexUserSkillPathEmptyHome(t *testing.T) {
+	_, err := codexUserSkillPath(Env{Home: ""}, "slug")
 	assert.Error(t, err)
 }
 
-// --- cursorNoGlobalSkill and cursorProjectSkillPath ---
+func TestCodexProjectSkillPath(t *testing.T) {
+	got, err := codexProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/repo", ".agents", "skills", "my-skill", "SKILL.md"), got)
+}
 
-func TestCursorNoGlobalSkillReturnsErrNoGlobalPath(t *testing.T) {
-	_, err := cursorNoGlobalSkill(Env{Home: "/home/u"}, "slug")
-	assert.ErrorIs(t, err, ErrNoGlobalPath)
+func TestCodexProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := codexProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestOpencodeUserSkillPath(t *testing.T) {
+	got, err := opencodeUserSkillPath(Env{Home: "/home/u"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".config", "opencode", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestOpencodeUserSkillPathEmptyHome(t *testing.T) {
+	_, err := opencodeUserSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
+}
+
+func TestOpencodeProjectSkillPath(t *testing.T) {
+	got, err := opencodeProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/repo", ".opencode", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestOpencodeProjectSkillPathEmptyCwd(t *testing.T) {
+	_, err := opencodeProjectSkillPath(Env{Home: "/home/u", Cwd: ""}, "slug")
+	assert.Error(t, err)
+}
+
+// --- cursorUserSkillPath and cursorProjectSkillPath ---
+
+func TestCursorUserSkillPath(t *testing.T) {
+	got, err := cursorUserSkillPath(Env{Home: "/home/u"}, "my-skill")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/home/u", ".cursor", "skills", "my-skill", "SKILL.md"), got)
+}
+
+func TestCursorUserSkillPathEmptyHome(t *testing.T) {
+	_, err := cursorUserSkillPath(Env{Home: ""}, "slug")
+	assert.Error(t, err)
 }
 
 func TestCursorProjectSkillPath(t *testing.T) {
 	got, err := cursorProjectSkillPath(Env{Home: "/home/u", Cwd: "/repo"}, "my-skill")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Join("/repo", ".cursor", "rules", "my-skill.mdc"), got)
+	assert.Equal(t, filepath.Join("/repo", ".cursor", "skills", "my-skill", "SKILL.md"), got)
 }
 
 func TestCursorProjectSkillPathEmptyCwd(t *testing.T) {

--- a/cli/internal/agentcfg/plan.go
+++ b/cli/internal/agentcfg/plan.go
@@ -22,20 +22,20 @@ func FormatPlan(outcomes []Outcome) string {
 		return b.String()
 	}
 
-	for _, o := range outcomes {
-		path := o.Path
-		if path == "" {
-			path = "-"
+	if needsRecordGrouping(outcomes) {
+		for i, record := range recordOrder(outcomes) {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+
+			fmt.Fprintf(&b, "Record: %s\n", record)
+			writeOutcomeLines(&b, outcomesForRecord(outcomes, record))
 		}
 
-		fmt.Fprintf(&b, "  %-9s %-5s %s  (%s)", o.Action, o.Artifact, path, o.Agent)
-
-		if o.Reason != "" {
-			fmt.Fprintf(&b, ": %s", o.Reason)
-		}
-
-		b.WriteString("\n")
+		return b.String()
 	}
+
+	writeOutcomeLines(&b, outcomes)
 
 	return b.String()
 }

--- a/cli/internal/agentcfg/plan_test.go
+++ b/cli/internal/agentcfg/plan_test.go
@@ -11,7 +11,7 @@ import (
 func TestFormatPlanShowsActionsPerArtifact(t *testing.T) {
 	out := FormatPlan([]Outcome{
 		{Agent: "Claude Code", Artifact: "mcp", Path: "/home/u/.claude.json", Action: ActionAdded},
-		{Agent: "Cursor", Artifact: "skill", Path: "/repo/.cursor/rules/rec.mdc", Action: ActionUpdated},
+		{Agent: "Cursor", Artifact: "skill", Path: "/repo/.cursor/skills/rec", Action: ActionUpdated},
 	})
 
 	for _, want := range []string{"added", "updated", "/home/u/.claude.json", "Cursor", "will be made"} {

--- a/cli/internal/agentcfg/registry.go
+++ b/cli/internal/agentcfg/registry.go
@@ -44,10 +44,9 @@ func Registry() []Agent {
 			Detect: detectByMarker(cursorMarker),
 			MCP:    jsonMCP(cursorMCPPath, "mcpServers"),
 			Skill: &SkillTarget{
-				Strategy:    DedicatedFile,
-				Path:        cursorNoGlobalSkill, // no global rules mechanism
+				Strategy:    SkillFolder,
+				Path:        cursorUserSkillPath,
 				ProjectPath: cursorProjectSkillPath,
-				Render:      renderCursor,
 			},
 		},
 		{
@@ -57,9 +56,9 @@ func Registry() []Agent {
 			Detect: detectByMarker(vscodeMarker),
 			MCP:    jsonMCP(vscodeMCPPath, "servers"),
 			Skill: &SkillTarget{
-				Strategy: DedicatedFile,
-				Path:     copilotSkillPath,
-				Render:   renderCopilot,
+				Strategy:    SkillFolder,
+				Path:        copilotUserSkillPath,
+				ProjectPath: copilotProjectSkillPath,
 			},
 		},
 		{
@@ -69,9 +68,9 @@ func Registry() []Agent {
 			Detect: detectByMarker(windsurfMarker),
 			MCP:    jsonMCP(windsurfMCPPath, "mcpServers"),
 			Skill: &SkillTarget{
-				Strategy: ManagedBlock,
-				Path:     windsurfSkillPath,
-				Render:   renderManagedInner,
+				Strategy:    SkillFolder,
+				Path:        windsurfUserSkillPath,
+				ProjectPath: windsurfProjectSkillPath,
 			},
 		},
 		{
@@ -81,9 +80,9 @@ func Registry() []Agent {
 			Detect: detectByMarker(clineMarker),
 			MCP:    jsonMCP(clineMCPPath, "mcpServers"),
 			Skill: &SkillTarget{
-				Strategy: DedicatedFile,
-				Path:     clineSkillPath,
-				Render:   renderCline,
+				Strategy:    SkillFolder,
+				Path:        clineUserSkillPath,
+				ProjectPath: clineProjectSkillPath,
 			},
 		},
 		{
@@ -93,9 +92,9 @@ func Registry() []Agent {
 			Detect: detectByMarker(rooMarker),
 			MCP:    jsonMCP(rooMCPPath, "mcpServers"),
 			Skill: &SkillTarget{
-				Strategy: DedicatedFile,
-				Path:     rooSkillPath,
-				Render:   renderRoo,
+				Strategy:    SkillFolder,
+				Path:        rooUserSkillPath,
+				ProjectPath: rooProjectSkillPath,
 			},
 		},
 		{
@@ -105,9 +104,9 @@ func Registry() []Agent {
 			Detect: detectByMarker(geminiMarker),
 			MCP:    jsonMCP(geminiMCPPath, "mcpServers"),
 			Skill: &SkillTarget{
-				Strategy: ManagedBlock,
-				Path:     geminiSkillPath,
-				Render:   renderManagedInner,
+				Strategy:    SkillFolder,
+				Path:        geminiUserSkillPath,
+				ProjectPath: geminiProjectSkillPath,
 			},
 		},
 		{
@@ -117,9 +116,9 @@ func Registry() []Agent {
 			Detect: detectByMarker(opencodeMarker),
 			MCP:    jsonMCP(opencodeMCPPath, "mcp"),
 			Skill: &SkillTarget{
-				Strategy: ManagedBlock,
-				Path:     opencodeSkillPath,
-				Render:   renderManagedInner,
+				Strategy:    SkillFolder,
+				Path:        opencodeUserSkillPath,
+				ProjectPath: opencodeProjectSkillPath,
 			},
 		},
 		{
@@ -134,8 +133,9 @@ func Registry() []Agent {
 				EntryStyle: ZedContextServer,
 			},
 			Skill: &SkillTarget{
-				Strategy: SkillFolder,
-				Path:     zedSkillPath,
+				Strategy:    SkillFolder,
+				Path:        zedUserSkillPath,
+				ProjectPath: zedProjectSkillPath,
 			},
 		},
 		{
@@ -167,9 +167,9 @@ func Registry() []Agent {
 				EntryStyle: CommandArgsEnv,
 			},
 			Skill: &SkillTarget{
-				Strategy: ManagedBlock,
-				Path:     codexSkillPath,
-				Render:   renderManagedInner,
+				Strategy:    SkillFolder,
+				Path:        codexUserSkillPath,
+				ProjectPath: codexProjectSkillPath,
 			},
 		},
 	}

--- a/cli/internal/agentcfg/result.go
+++ b/cli/internal/agentcfg/result.go
@@ -32,6 +32,7 @@ func failOutcome(outcome Outcome, err error) (Outcome, error) {
 
 // Outcome records what happened to one artifact (MCP or skill) for one agent.
 type Outcome struct {
+	Record   string // optional record label for batch install grouping
 	Agent    string // human-readable agent name
 	Artifact string // "mcp" or "skill"
 	Path     string // absolute path that was (or would be) touched

--- a/cli/internal/agentcfg/skill_engine.go
+++ b/cli/internal/agentcfg/skill_engine.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/agntcy/dir/api/exportfmt"
 	"github.com/agntcy/dir/cli/internal/agentcfg/fsutil"
 )
 
@@ -74,6 +75,51 @@ func InstallSkill(target *SkillTarget, env Env, slug, canonical string, dryRun b
 
 	if err := fsutil.WriteAtomic(path, desired, skillFilePerm); err != nil {
 		return failOutcome(outcome, fmt.Errorf("write skill %s: %w", path, err))
+	}
+
+	return outcome, nil
+}
+
+// InstallSkillBundle extracts a skill bundle archive into an agent's skill folder.
+// It is idempotent: identical on-disk content reports ActionUnchanged.
+func InstallSkillBundle(target *SkillTarget, env Env, slug string, archive []byte, dryRun bool) (Outcome, error) {
+	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+	if err != nil {
+		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
+	}
+
+	destDir := filepath.Dir(path)
+
+	outcome := Outcome{Artifact: "skill", Path: destDir}
+	if usedProject {
+		outcome.Reason = "no global rules path for this agent — wrote a project rule in the current repo"
+	}
+
+	matches, err := exportfmt.SkillBundleMatchesDir(archive, destDir)
+	if err != nil {
+		return failOutcome(outcome, fmt.Errorf("compare skill bundle %s: %w", destDir, err))
+	}
+
+	if matches {
+		outcome.Action = ActionUnchanged
+
+		return outcome, nil
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		outcome.Action = ActionUpdated
+	} else if os.IsNotExist(err) {
+		outcome.Action = ActionAdded
+	} else {
+		return failOutcome(outcome, fmt.Errorf("stat skill %s: %w", path, err))
+	}
+
+	if dryRun {
+		return outcome, nil
+	}
+
+	if err := exportfmt.ExtractSkillBundleArchive(archive, destDir); err != nil {
+		return failOutcome(outcome, fmt.Errorf("extract skill bundle %s: %w", destDir, err))
 	}
 
 	return outcome, nil

--- a/cli/internal/agentcfg/skill_engine_test.go
+++ b/cli/internal/agentcfg/skill_engine_test.go
@@ -4,6 +4,9 @@
 package agentcfg
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -105,13 +108,12 @@ func TestInstallSkillManagedBlockPreservesUserContent(t *testing.T) {
 
 func TestInstallSkillProjectFallback(t *testing.T) {
 	root := t.TempDir()
-	projectPath := filepath.Join(root, "repo", ".cursor", "rules", "test-skill.mdc")
+	projectPath := filepath.Join(root, "repo", ".cursor", "skills", "test-skill", "SKILL.md")
 
 	target := &SkillTarget{
-		Strategy:    DedicatedFile,
+		Strategy:    SkillFolder,
 		Path:        func(Env, string) (string, error) { return "", ErrNoGlobalPath },
 		ProjectPath: func(Env, string) (string, error) { return projectPath, nil },
-		Render:      renderCursor,
 	}
 
 	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
@@ -186,6 +188,58 @@ func TestInstallSkillVersionReplace(t *testing.T) {
 	renderedB, err := renderContinue(canonicalB)
 	require.NoError(t, err)
 	assert.Equal(t, string(renderedB), string(got), "file content should equal the render of canonical B")
+}
+
+func TestInstallSkillBundleExtractsArchive(t *testing.T) {
+	root := t.TempDir()
+	skillPath := filepath.Join(root, "skills", "test-skill", "SKILL.md")
+	archive := skillBundleArchive(t)
+
+	target := &SkillTarget{
+		Strategy: SkillFolder,
+		Path:     func(Env, string) (string, error) { return skillPath, nil },
+	}
+
+	outcome, err := InstallSkillBundle(target, Env{}, "test-skill", archive, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+
+	got, err := os.ReadFile(skillPath)
+	require.NoError(t, err)
+	assert.Equal(t, sampleDoc, string(got))
+
+	extraPath := filepath.Join(root, "skills", "test-skill", "scripts", "run.sh")
+	extra, err := os.ReadFile(extraPath)
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/sh\n", string(extra))
+
+	again, err := InstallSkillBundle(target, Env{}, "test-skill", archive, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionUnchanged, again.Action)
+}
+
+func skillBundleArchive(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+
+	writeFile := func(name, content string) {
+		data := []byte(content)
+		hdr := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(data)), Typeflag: tar.TypeReg}
+		require.NoError(t, tw.WriteHeader(hdr))
+		_, err := tw.Write(data)
+		require.NoError(t, err)
+	}
+
+	writeFile("SKILL.md", sampleDoc)
+	writeFile("scripts/run.sh", "#!/bin/sh\n")
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	return buf.Bytes()
 }
 
 func TestInstallSkillManagedBlockVersionReplace(t *testing.T) {

--- a/cli/internal/agentcfg/summary.go
+++ b/cli/internal/agentcfg/summary.go
@@ -23,6 +23,31 @@ func FormatSummary(outcomes []Outcome, dryRun bool) string {
 		return b.String()
 	}
 
+	if needsRecordGrouping(outcomes) {
+		for i, record := range recordOrder(outcomes) {
+			if i > 0 {
+				b.WriteString("\n")
+			}
+
+			fmt.Fprintf(&b, "Record: %s\n", record)
+			writeSummaryOutcomeLines(&b, outcomesForRecord(outcomes, record))
+		}
+	} else {
+		writeSummaryOutcomeLines(&b, outcomes)
+	}
+
+	b.WriteString("\n")
+	b.WriteString(formatTally(outcomes))
+	b.WriteString("\n")
+
+	if dryRun {
+		b.WriteString("\nNote: This was a dry run. No changes were written.\n")
+	}
+
+	return b.String()
+}
+
+func writeSummaryOutcomeLines(b *strings.Builder, outcomes []Outcome) {
 	for _, o := range outcomes {
 		path := o.Path
 		if path == "" {
@@ -37,16 +62,6 @@ func FormatSummary(outcomes []Outcome, dryRun bool) string {
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
-
-	b.WriteString("\n")
-	b.WriteString(formatTally(outcomes))
-	b.WriteString("\n")
-
-	if dryRun {
-		b.WriteString("\nNote: This was a dry run. No changes were written.\n")
-	}
-
-	return b.String()
 }
 
 // formatTally counts outcomes by action in a stable order.

--- a/cli/internal/agentcfg/summary_test.go
+++ b/cli/internal/agentcfg/summary_test.go
@@ -13,7 +13,7 @@ import (
 func TestFormatSummaryListsEveryPathAndAction(t *testing.T) {
 	outcomes := []Outcome{
 		{Agent: "Claude Code", Artifact: "mcp", Path: "/home/u/.claude.json", Action: ActionAdded},
-		{Agent: "Cursor", Artifact: "skill", Path: "/repo/.cursor/rules/agntcy-dir.mdc", Action: ActionSkipped, Reason: "no global rules path"},
+		{Agent: "Cursor", Artifact: "skill", Path: "/repo/.cursor/skills/agntcy-dir", Action: ActionSkipped, Reason: "no global rules path"},
 		{Agent: "Gemini CLI", Artifact: "mcp", Path: "/home/u/.gemini/settings.json", Action: ActionFailed, Reason: "permission denied"},
 	}
 
@@ -21,7 +21,7 @@ func TestFormatSummaryListsEveryPathAndAction(t *testing.T) {
 
 	assert.Contains(t, out, "/home/u/.claude.json")
 	assert.Contains(t, out, string(ActionAdded))
-	assert.Contains(t, out, "/repo/.cursor/rules/agntcy-dir.mdc")
+	assert.Contains(t, out, "/repo/.cursor/skills/agntcy-dir")
 	assert.Contains(t, out, "no global rules path")
 	assert.Contains(t, out, "/home/u/.gemini/settings.json")
 	assert.Contains(t, out, "permission denied")

--- a/cli/util/records/records.go
+++ b/cli/util/records/records.go
@@ -73,6 +73,13 @@ func SanitizeName(name string) string {
 	return r.Replace(name)
 }
 
+// SanitizeSlug is SanitizeName with leading/trailing dots and hyphens trimmed so
+// a slug cannot be "." or ".." or escape a parent directory when used as a path
+// component.
+func SanitizeSlug(name string) string {
+	return strings.Trim(SanitizeName(name), "-.")
+}
+
 // LatestByName deduplicates records by name, keeping the highest semver version
 // for each unique name while preserving first-seen order.
 func LatestByName(records []*corev1.Record) []*corev1.Record {

--- a/cli/util/records/records_test.go
+++ b/cli/util/records/records_test.go
@@ -21,6 +21,14 @@ func TestSanitizeName(t *testing.T) {
 	assert.Equal(t, "a-b-c", SanitizeName("a:b c"))
 }
 
+func TestSanitizeSlug(t *testing.T) {
+	assert.Equal(t, "io.example-code-review-server", SanitizeSlug("io.example/code-review-server"))
+	assert.Equal(t, "my-agent", SanitizeSlug("my agent"))
+	assert.Empty(t, SanitizeSlug(".."))
+	assert.Empty(t, SanitizeSlug("."))
+	assert.Equal(t, "etc", SanitizeSlug("../../etc"))
+}
+
 func TestLatestByNameKeepsHighestSemver(t *testing.T) {
 	records := []*corev1.Record{
 		rec("agent-a", "1.0.0"),

--- a/samples/ard-over-ads/go.mod
+++ b/samples/ard-over-ads/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/agntcy/dir/reconciler v1.5.0 // indirect
 	github.com/agntcy/dir/server v1.5.0 // indirect
 	github.com/agntcy/dir/utils v1.5.0 // indirect
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
@@ -345,7 +345,7 @@ require (
 	github.com/libp2p/go-libp2p v0.48.0 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.4.1 // indirect
 	github.com/libp2p/go-libp2p-gorpc v0.6.0 // indirect
-	github.com/libp2p/go-libp2p-kad-dht v0.40.0 // indirect
+	github.com/libp2p/go-libp2p-kad-dht v0.41.0 // indirect
 	github.com/libp2p/go-libp2p-kbucket v0.8.0 // indirect
 	github.com/libp2p/go-libp2p-pubsub v0.16.0 // indirect
 	github.com/libp2p/go-libp2p-record v0.3.1 // indirect
@@ -612,7 +612,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260504160031-60b97b32f348 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260622175928-b703f567277d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260618152121-87f3d3e198d3 // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/samples/ard-over-ads/go.sum
+++ b/samples/ard-over-ads/go.sum
@@ -214,6 +214,7 @@ github.com/agntcy/dir-runtime/utils v1.3.2/go.mod h1:kPyp84+ER5CTtZkzVVJijNDx3Vo
 github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8 h1:wvavxaeUuqyKzGU2JZhHshFrl7l74ADEKBiBfg4rgN8=
 github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260612113147-8fdda6fd3eb8/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
 github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -1179,6 +1180,7 @@ github.com/libp2p/go-libp2p-gorpc v0.6.0 h1:Z3ODCzbKe+2lUtEjRc+W+l8Olj63r68G5w1w
 github.com/libp2p/go-libp2p-gorpc v0.6.0/go.mod h1:jGTsI/yn1xL/9VupJ+DIXo8ExobWDKjwVdjNAfhFKxk=
 github.com/libp2p/go-libp2p-kad-dht v0.40.0 h1:as8U7Y1RX9CTKCBiFBHWKZ6tSS+rE+6WNz+H1+M+wbo=
 github.com/libp2p/go-libp2p-kad-dht v0.40.0/go.mod h1:iLUjII47u3/HjxyhucI2lhsl29lrzlAs/ym16+H40jE=
+github.com/libp2p/go-libp2p-kad-dht v0.41.0/go.mod h1:2qc4QGLvmIdznYbNg++FF76vp4q2SaBZyr76jHV8xgs=
 github.com/libp2p/go-libp2p-kbucket v0.8.0 h1:QAK7RzKJpYe+EuSEATAaaHYMYLkPDGC18m9jxPLnU8s=
 github.com/libp2p/go-libp2p-kbucket v0.8.0/go.mod h1:JMlxqcEyKwO6ox716eyC0hmiduSWZZl6JY93mGaaqc4=
 github.com/libp2p/go-libp2p-pubsub v0.16.0 h1:j7G2C8kJwkcAQqYR7Wmq3d75d3Sgw/N0Hhiv0dVx7OY=
@@ -2377,6 +2379,7 @@ google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
 google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6 h1:ExN12ndbJ608cboPYflpTny6mXSzPrDLh0iTaVrRrds=
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=


### PR DESCRIPTION
If install receives filters, use those filters to fetch the records and install them

If a tool doesn't support skill directories, skip installing

Note, this PR changes the Copilot and Cursor paths so skills are stored in directories instead of markdown files