### PR TITLE
feat(cli): seed a default local context in dirctl init

### DIFF
--- a/cli/cmd/init/context.go
+++ b/cli/cmd/init/context.go
@@ -1,0 +1,77 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package init
+
+import (
+	"fmt"
+
+	"github.com/agntcy/dir/cli/presenter"
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/spf13/cobra"
+)
+
+const (
+	localContextName   = "local"
+	localServerAddress = "localhost:8888"
+	localAuthMode      = "insecure"
+)
+
+// defaultLocalContext is the context seeded for a fresh environment: the local
+// daemon reached over an insecure connection.
+func defaultLocalContext() clientconfig.Context {
+	return clientconfig.Context{
+		ServerAddress: localServerAddress,
+		AuthMode:      localAuthMode,
+	}
+}
+
+// runContextSetup seeds a default `local` client context (and makes it current)
+// when no context is configured yet, so later commands reach a local node
+// without --server-addr. It is opt-out on a TTY and skips non-interactively
+// without --yes. It never touches an existing context or current_context: if any
+// context is already configured, the step is a no-op.
+func runContextSetup(cmd *cobra.Command, opts *options) error {
+	presenter.Printf(cmd, "\nStep 1 — Client context\n")
+
+	summaries, err := clientconfig.ListContexts("")
+	if err != nil {
+		return fmt.Errorf("read client config: %w", err)
+	}
+
+	if len(summaries) > 0 {
+		presenter.Printf(cmd, "A client context is already configured; leaving it untouched.\n")
+
+		return nil
+	}
+
+	presenter.Printf(cmd, "Point dirctl at a Directory node. This adds a %q context (server %s, insecure\nauth) and makes it the default, so push/search/pull reach a local daemon\nwithout --server-addr.\n",
+		localContextName, localServerAddress)
+
+	if !opts.yes {
+		if !isInteractive(cmd) {
+			presenter.Printf(cmd, "Skipping context setup (non-interactive). Pass --yes to configure.\n")
+
+			return nil
+		}
+
+		ok, err := confirm(cmd, fmt.Sprintf("Configure a %q context → %s?", localContextName, localServerAddress), true)
+		if err != nil {
+			return err
+		}
+
+		if !ok {
+			presenter.Printf(cmd, "Skipped context setup.\n")
+
+			return nil
+		}
+	}
+
+	if err := clientconfig.SaveContext("", localContextName, defaultLocalContext(), true); err != nil {
+		return fmt.Errorf("save local context: %w", err)
+	}
+
+	presenter.Printf(cmd, "✔ Context %q configured and set as current (server %s).\n", localContextName, localServerAddress)
+
+	return nil
+}

--- a/cli/cmd/init/context_test.go
+++ b/cli/cmd/init/context_test.go
@@ -1,0 +1,68 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package init
+
+import (
+	"path/filepath"
+	"testing"
+
+	clientconfig "github.com/agntcy/dir/client/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunContextSetupSeedsLocalWithYes(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+	cmd, _ := newTestCmd("")
+	require.NoError(t, runContextSetup(cmd, &options{yes: true}))
+
+	summaries, err := clientconfig.ListContexts("")
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, localContextName, summaries[0].Name)
+	assert.True(t, summaries[0].Current, "seeded context must be current")
+
+	got, err := clientconfig.LoadFile(mustDefaultPath(t))
+	require.NoError(t, err)
+	assert.Equal(t, localServerAddress, got.Contexts[localContextName].ServerAddress)
+	assert.Equal(t, localAuthMode, got.Contexts[localContextName].AuthMode)
+}
+
+func TestRunContextSetupSkipsWhenConfigured(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+	require.NoError(t, clientconfig.SaveContext("", "prod",
+		clientconfig.Context{ServerAddress: "prod:443"}, true))
+
+	cmd, out := newTestCmd("")
+	require.NoError(t, runContextSetup(cmd, &options{yes: true}))
+
+	// Existing config untouched: only prod, still current; no local added.
+	summaries, err := clientconfig.ListContexts("")
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	assert.Equal(t, "prod", summaries[0].Name)
+	assert.Contains(t, out.String(), "already configured")
+}
+
+func TestRunContextSetupNonTTYWithoutYesSkips(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+	cmd, out := newTestCmd("") // non-TTY (strings.Reader), no --yes
+	require.NoError(t, runContextSetup(cmd, &options{}))
+
+	summaries, err := clientconfig.ListContexts("")
+	require.NoError(t, err)
+	assert.Empty(t, summaries, "must not seed a context non-interactively without --yes")
+	assert.Contains(t, out.String(), "non-interactive")
+}
+
+func mustDefaultPath(t *testing.T) string {
+	t.Helper()
+
+	path, err := clientconfig.DefaultPath()
+	require.NoError(t, err)
+
+	return path
+}

--- a/cli/cmd/init/run.go
+++ b/cli/cmd/init/run.go
@@ -27,27 +27,28 @@ func isInteractive(cmd *cobra.Command) bool {
 	return ok && term.IsTerminal(int(f.Fd())) //nolint:gosec // G115: a file descriptor fits in an int.
 }
 
-// printWelcome prints the wizard's opening banner and the Step 1 explanation.
+// printWelcome prints the wizard's opening banner and the list of steps.
 func printWelcome(cmd *cobra.Command) {
 	presenter.Printf(cmd, `Welcome to dirctl — the CLI for the AGNTCY Directory, a distributed registry
 of AI agent records described in OASF.
 
 This wizard sets up your local environment. Steps:
-  1. Provision the OASF taxonomy extractor   ← now
+  1. Configure a local client context
+  2. Provision the OASF taxonomy extractor
   (more steps — MCP server & skills — coming soon)
-
-Step 1 — OASF taxonomy extractor
-Maps free-form text onto the OASF taxonomy so dirctl can enrich records and
-(soon) answer free-text searches locally — in-process, with no LLM or API
-calls. It needs a one-time ~89 MB model + the taxonomy downloaded to your
-machine; provisioned once, reused everywhere.
 `)
 }
 
-// run dispatches to the remove or provision flow.
+// run dispatches to the remove flow, or runs the setup steps in order.
 func run(cmd *cobra.Command, opts *options) error {
 	if opts.remove {
 		return runRemove(cmd, opts)
+	}
+
+	printWelcome(cmd)
+
+	if err := runContextSetup(cmd, opts); err != nil {
+		return err
 	}
 
 	return runProvision(cmd, opts)
@@ -99,7 +100,13 @@ func resolveConfig(cmd *cobra.Command, opts *options) (extractor.Config, error) 
 // runProvision provisions the extractor assets, persists the choice, and runs a
 // smoke check. It prompts for confirmation and the OASF URL unless --yes.
 func runProvision(cmd *cobra.Command, opts *options) error {
-	printWelcome(cmd)
+	presenter.Printf(cmd, `
+Step 2 — OASF taxonomy extractor
+Maps free-form text onto the OASF taxonomy so dirctl can enrich records and
+(soon) answer free-text searches locally — in-process, with no LLM or API
+calls. It needs a one-time ~89 MB model + the taxonomy downloaded to your
+machine; provisioned once, reused everywhere.
+`)
 
 	cfg, err := resolveConfig(cmd, opts)
 	if err != nil {

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -415,6 +415,29 @@ func SaveExtractor(path string, e *Extractor) error {
 	return SaveFile(resolvedPath, file)
 }
 
+// SaveContext adds or replaces a named context, preserving all other config. When
+// setCurrent is true it also marks that context as current_context. Callers that
+// must not overwrite an existing context should check first (e.g. ListContexts).
+func SaveContext(path string, name string, ctx Context, setCurrent bool) error {
+	resolvedPath, _, err := resolvePath(path)
+	if err != nil {
+		return err
+	}
+
+	file, err := loadOptionalFile(resolvedPath, false, true)
+	if err != nil {
+		return err
+	}
+
+	file.Contexts[name] = ctx
+
+	if setCurrent {
+		file.CurrentContext = name
+	}
+
+	return SaveFile(resolvedPath, file)
+}
+
 // ClearExtractor removes the machine-wide extractor section, preserving all
 // other config. It is a genuine no-op when the section is already absent (or no
 // config file exists): it does not create or rewrite the file in that case.

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -374,8 +374,49 @@ func SaveFile(path string, file *File) error {
 		return fmt.Errorf("failed to create client config directory %s: %w", filepath.Dir(path), err)
 	}
 
-	if err := os.WriteFile(path, data, configFilePerm); err != nil {
+	if err := atomicWriteFile(path, data, configFilePerm); err != nil {
 		return fmt.Errorf("failed to write client config file %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// atomicWriteFile writes data to a temp file in the same directory and renames it
+// over path, so an interrupted write can never leave a partially-written config
+// (rename is atomic within a filesystem). The temp file is removed on any failure
+// before the rename.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+
+	tmpName := tmp.Name()
+
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+
+		return fmt.Errorf("close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+
+		return fmt.Errorf("rename temp file into place: %w", err)
 	}
 
 	return nil
@@ -415,9 +456,10 @@ func SaveExtractor(path string, e *Extractor) error {
 	return SaveFile(resolvedPath, file)
 }
 
-// SaveContext adds or replaces a named context, preserving all other config. When
-// setCurrent is true it also marks that context as current_context. Callers that
-// must not overwrite an existing context should check first (e.g. ListContexts).
+// SaveContext adds or replaces a named context, preserving the other recognized
+// config (current_context, extractor, and the other contexts). When setCurrent is
+// true it also marks that context as current_context. Callers that must not
+// overwrite an existing context should check first (e.g. ListContexts).
 func SaveContext(path string, name string, ctx Context, setCurrent bool) error {
 	resolvedPath, _, err := resolvePath(path)
 	if err != nil {

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -675,6 +675,27 @@ func TestSaveContextPreservesOtherConfigAndHonorsSetCurrentFalse(t *testing.T) {
 	assert.Equal(t, "https://x", file.Extractor.OASFURL)
 }
 
+func TestSaveFileAtomicLeavesNoTempFiles(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+	path, err := DefaultPath()
+	require.NoError(t, err)
+
+	require.NoError(t, SaveContext("", "local", Context{ServerAddress: "localhost:8888"}, true))
+
+	entries, err := os.ReadDir(filepath.Dir(path))
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), ".tmp-", "atomic write must not leave temp files behind")
+	}
+
+	// The final file is intact and parseable.
+	file, err := LoadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, file.Contexts, "local")
+}
+
 func TestClearExtractorAbsentFileDoesNotCreateFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
 

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -635,6 +635,46 @@ func TestLoadExtractorAbsentFile(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+func TestSaveContextSeedsAndSetsCurrent(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+	path, err := DefaultPath()
+	require.NoError(t, err)
+
+	ctx := Context{ServerAddress: "localhost:8888", AuthMode: "insecure"}
+	require.NoError(t, SaveContext("", "local", ctx, true))
+
+	file, err := LoadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "local", file.CurrentContext)
+	require.Contains(t, file.Contexts, "local")
+	assert.Equal(t, "localhost:8888", file.Contexts["local"].ServerAddress)
+	assert.Equal(t, "insecure", file.Contexts["local"].AuthMode)
+}
+
+func TestSaveContextPreservesOtherConfigAndHonorsSetCurrentFalse(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+	path, err := DefaultPath()
+	require.NoError(t, err)
+
+	// Seed an extractor section and a pre-existing current_context.
+	require.NoError(t, SaveExtractor("", &Extractor{OASFURL: "https://x", AssetDir: "/a"}))
+	require.NoError(t, SaveContext("", "prod", Context{ServerAddress: "prod:443"}, true))
+
+	// Adding another context with setCurrent=false must not change current_context
+	// and must preserve the extractor section and the existing context.
+	require.NoError(t, SaveContext("", "local", Context{ServerAddress: "localhost:8888"}, false))
+
+	file, err := LoadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", file.CurrentContext)
+	require.Contains(t, file.Contexts, "prod")
+	require.Contains(t, file.Contexts, "local")
+	require.NotNil(t, file.Extractor)
+	assert.Equal(t, "https://x", file.Extractor.OASFURL)
+}
+
 func TestClearExtractorAbsentFileDoesNotCreateFile(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
 


### PR DESCRIPTION
Current wizard texts:

```
$ dirctl init

Welcome to dirctl — the CLI for the AGNTCY Directory, a distributed registry
of AI agent records described in OASF.

This wizard sets up your local environment. Steps:
  1. Configure a local client context
  2. Provision the OASF taxonomy extractor
  (more steps — MCP server & skills — coming soon)

Step 1 — Client context
Point dirctl at a Directory node. This adds a "local" context (server localhost:8888, insecure
auth) and makes it the default, so push/search/pull reach a local daemon
without --server-addr.
Configure a "local" context → localhost:8888? [Y/n]:
✔ Context "local" configured and set as current (server localhost:8888).

Step 2 — OASF taxonomy extractor
Maps free-form text onto the OASF taxonomy so dirctl can enrich records and
(soon) answer free-text searches locally — in-process, with no LLM or API
calls. It needs a one-time ~89 MB model + the taxonomy downloaded to your
machine; provisioned once, reused everywhere.

Provision the OASF extractor (~89 MB)? [Y/n]:
OASF URL [https://schema.oasf.outshift.com]:

Provisioning extractor assets to /Users/*****/.agntcy/oasf-sdk/extractor
✔ Extractor ready.
  asset dir: /Users/ajaky/.agntcy/oasf-sdk/extractor
  OASF URL:  https://schema.oasf.outshift.com
Enrichment and free-text search can now run locally.
```

Closes #1762 