### PR TITLE
feat(dir): add mcp-claudecode export format

### DIFF
--- a/api/exportfmt/exportfmt.go
+++ b/api/exportfmt/exportfmt.go
@@ -40,6 +40,7 @@ const (
 	FormatAgentSkillBundle = "agent-skill-bundle"
 	FormatSkill            = "skill"
 	FormatMCPGHCopiot      = "mcp-ghcopilot"
+	FormatMCPClaudeCode    = "mcp-claudecode"
 )
 
 var (

--- a/api/exportfmt/exportfmt_test.go
+++ b/api/exportfmt/exportfmt_test.go
@@ -209,6 +209,12 @@ func TestGetFormatter(t *testing.T) {
 		assert.NotNil(t, f)
 	})
 
+	t.Run("returns mcp-claudecode formatter", func(t *testing.T) {
+		f, err := exportfmt.GetFormatter("mcp-claudecode")
+		require.NoError(t, err)
+		assert.NotNil(t, f)
+	})
+
 	t.Run("returns error for unknown format", func(t *testing.T) {
 		f, err := exportfmt.GetFormatter("nonexistent")
 		assert.Nil(t, f)
@@ -225,6 +231,7 @@ func TestKnownFormats(t *testing.T) {
 	assert.Contains(t, formats, "agent-skill-bundle")
 	assert.Contains(t, formats, "skill")
 	assert.Contains(t, formats, "mcp-ghcopilot")
+	assert.Contains(t, formats, "mcp-claudecode")
 }
 
 func TestOASFFormatter_Format(t *testing.T) {

--- a/api/exportfmt/mcp_claudecode.go
+++ b/api/exportfmt/mcp_claudecode.go
@@ -1,0 +1,255 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package exportfmt
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	recordutil "github.com/agntcy/oasf-sdk/pkg/record"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func init() {
+	RegisterFormatter(FormatMCPClaudeCode, &mcpClaudeCodeFormatter{})
+}
+
+// ClaudeCodeMCPServer models a single entry under "mcpServers" in Claude
+// Code's project-scoped .mcp.json configuration file.
+//
+// Command/Args/Env describe a local, stdio-launched server. URL/Headers
+// describe a remote server; Type is only set ("http" or "sse") for remote
+// servers -- Claude Code has no "type" field for stdio and infers it from
+// the presence of Command. See https://code.claude.com/docs/en/mcp.
+type ClaudeCodeMCPServer struct {
+	Type    string            `json:"type,omitempty"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     map[string]string `json:"env,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// ClaudeCodeMCPConfig models Claude Code's project-scoped .mcp.json file.
+type ClaudeCodeMCPConfig struct {
+	MCPServers map[string]ClaudeCodeMCPServer `json:"mcpServers"`
+}
+
+type mcpClaudeCodeFormatter struct{}
+
+func (f *mcpClaudeCodeFormatter) Format(record *corev1.Record) ([]byte, error) {
+	data := record.GetData()
+	if data == nil {
+		return nil, fmt.Errorf("record contains no data")
+	}
+
+	cfg, err := RecordToClaudeCode(data)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to translate record to Claude Code MCP config: %w", ErrUnsupportedRecord, err)
+	}
+
+	raw, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal Claude Code MCP config to JSON: %w", err)
+	}
+
+	raw = append(raw, '\n')
+
+	return raw, nil
+}
+
+func (f *mcpClaudeCodeFormatter) FileExtension() string {
+	return ExtJSON
+}
+
+// RecordToClaudeCode translates a record's "integration/mcp" module (OASF
+// 1.0.0 "connections" format) into a ClaudeCodeMCPConfig. Exported (like
+// translator.RecordToGHCopilot) so cli/cmd/export's batch exporter can merge
+// several records' configs into one .mcp.json without round-tripping
+// through JSON.
+//
+// This is a local implementation rather than a call to an oasf-sdk
+// translator function (issue #1386 proposes a RecordToClaudeCode in
+// oasf-sdk's translator package). Keeping it here lets the format ship
+// without blocking on an oasf-sdk release; it can move upstream later
+// without changing this package's public surface.
+//
+// Only the OASF 1.0.0 "connections" array format is supported. The legacy
+// 0.7.0/0.8.0 "servers" array format (still handled by
+// translator.RecordToGHCopilot for GitHub Copilot) is not.
+func RecordToClaudeCode(record *structpb.Struct) (*ClaudeCodeMCPConfig, error) {
+	found, moduleStruct := recordutil.GetModule(record, translator.MCPModuleName)
+	if !found {
+		return nil, errors.New("MCP module not found in record")
+	}
+
+	moduleData := moduleStruct.GetFields()["data"].GetStructValue()
+	if moduleData == nil {
+		return nil, errors.New("MCP module has no data")
+	}
+
+	nameVal, ok := moduleData.GetFields()["name"]
+	if !ok {
+		return nil, errors.New("missing 'name' in MCP module data")
+	}
+
+	serverName := claudeCodeNormalizeServerName(nameVal.GetStringValue())
+
+	connectionsVal, ok := moduleData.GetFields()["connections"]
+	if !ok {
+		return nil, errors.New("missing 'connections' in MCP module data")
+	}
+
+	connectionsList := connectionsVal.GetListValue()
+	if connectionsList == nil {
+		return nil, errors.New("'connections' must be an array")
+	}
+
+	// Connections are alternative ways to reach the same server. Take the
+	// first one we know how to represent (stdio, streamable-http, or sse).
+	for _, connVal := range connectionsList.GetValues() {
+		connMap := connVal.GetStructValue()
+		if connMap == nil {
+			continue
+		}
+
+		connType := connMap.GetFields()["type"].GetStringValue()
+
+		server, ok := claudeCodeServerFromConnection(connType, connMap)
+		if !ok {
+			continue
+		}
+
+		return &ClaudeCodeMCPConfig{
+			MCPServers: map[string]ClaudeCodeMCPServer{serverName: server},
+		}, nil
+	}
+
+	return nil, errors.New("no supported MCP connection found (stdio, streamable-http, sse)")
+}
+
+// claudeCodeServerFromConnection builds a ClaudeCodeMCPServer from a single
+// OASF connection struct, given its "type" field. ok is false if connType is
+// not one Claude Code can represent.
+func claudeCodeServerFromConnection(connType string, connMap *structpb.Struct) (ClaudeCodeMCPServer, bool) {
+	switch connType {
+	case "stdio":
+		return ClaudeCodeMCPServer{
+			Command: connMap.GetFields()["command"].GetStringValue(),
+			Args:    claudeCodeStringList(connMap.GetFields()["args"]),
+			Env:     claudeCodeEnvFromEnvVars(connMap.GetFields()["env_vars"]),
+		}, true
+	case "streamable-http", "sse":
+		return ClaudeCodeMCPServer{
+			Type:    claudeCodeConnectionType(connType),
+			URL:     connMap.GetFields()["url"].GetStringValue(),
+			Headers: claudeCodeStringMap(connMap.GetFields()["headers"]),
+		}, true
+	default:
+		return ClaudeCodeMCPServer{}, false
+	}
+}
+
+// claudeCodeConnectionType maps an OASF connection "type" to the value
+// Claude Code expects for a remote server's "type" field. OASF's
+// "streamable-http" becomes Claude Code's "http" -- the two schemas use
+// different vocabulary for the same transport.
+func claudeCodeConnectionType(oasfType string) string {
+	if oasfType == "streamable-http" {
+		return "http"
+	}
+
+	return oasfType
+}
+
+// claudeCodeNormalizeServerName strips common MCP server-name suffixes
+// (mirroring translator.RecordToGHCopilot's normalization) so that, e.g.,
+// "github-mcp-server" becomes "github" across every MCP export format in
+// this repo.
+func claudeCodeNormalizeServerName(name string) string {
+	name = strings.TrimSuffix(name, "-mcp-server")
+	name = strings.TrimSuffix(name, "-server")
+	name = strings.TrimSuffix(name, "-mcp")
+
+	return name
+}
+
+// claudeCodeStringList reads a structpb list-of-strings value. Returns nil
+// (omitted from JSON output) if val is not a non-empty list.
+func claudeCodeStringList(val *structpb.Value) []string {
+	list := val.GetListValue()
+	if list == nil || len(list.GetValues()) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(list.GetValues()))
+	for _, v := range list.GetValues() {
+		out = append(out, v.GetStringValue())
+	}
+
+	return out
+}
+
+// claudeCodeStringMap reads a structpb struct value as a flat string map.
+// Returns nil (omitted from JSON output) if val is not a non-empty struct.
+func claudeCodeStringMap(val *structpb.Value) map[string]string {
+	s := val.GetStructValue()
+	if s == nil || len(s.GetFields()) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(s.GetFields()))
+	for k, v := range s.GetFields() {
+		out[k] = v.GetStringValue()
+	}
+
+	return out
+}
+
+// claudeCodeEnvFromEnvVars converts an OASF 1.0.0 "env_vars" array (a list of
+// {name, description, default_value} objects) into the flat env map Claude
+// Code's .mcp.json expects.
+//
+// When an entry has no default_value, this emits "${NAME}" so Claude Code
+// resolves it from the user's shell environment at launch time (Claude Code
+// supports $VAR / ${VAR} expansion in .mcp.json). This differs from
+// translator.RecordToGHCopilot, which emits VS Code's "${input:NAME}" prompt
+// placeholder for the same case -- that mechanism is VS Code/GH Copilot
+// specific and has no Claude Code equivalent.
+func claudeCodeEnvFromEnvVars(val *structpb.Value) map[string]string {
+	list := val.GetListValue()
+	if list == nil || len(list.GetValues()) == 0 {
+		return nil
+	}
+
+	env := make(map[string]string, len(list.GetValues()))
+
+	for _, v := range list.GetValues() {
+		envVar := v.GetStructValue()
+		if envVar == nil {
+			continue
+		}
+
+		name := envVar.GetFields()["name"].GetStringValue()
+		if name == "" {
+			continue
+		}
+
+		if def := envVar.GetFields()["default_value"].GetStringValue(); def != "" {
+			env[name] = def
+		} else {
+			env[name] = fmt.Sprintf("${%s}", name)
+		}
+	}
+
+	if len(env) == 0 {
+		return nil
+	}
+
+	return env
+}

--- a/api/exportfmt/mcp_claudecode_test.go
+++ b/api/exportfmt/mcp_claudecode_test.go
@@ -1,0 +1,155 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package exportfmt_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/api/exportfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const testMCPClaudeCodeStdioRecordJSON = `{
+  "schema_version": "1.0.0",
+  "name": "io.example/code-review-server",
+  "version": "1.0.0",
+  "description": "MCP server for code review",
+  "modules": [
+    {
+      "name": "integration/mcp",
+      "data": {
+        "name": "io.example/code-review-server",
+        "connections": [
+          {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["@example/code-review-server@1.0.0"],
+            "env_vars": [
+              {
+                "name": "API_KEY",
+                "description": "API key for authentication"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}`
+
+const testMCPClaudeCodeRemoteRecordJSON = `{
+  "schema_version": "1.0.0",
+  "name": "io.example/remote-server",
+  "version": "1.0.0",
+  "description": "Remote MCP server",
+  "modules": [
+    {
+      "name": "integration/mcp",
+      "data": {
+        "name": "io.example/remote-server",
+        "connections": [
+          {
+            "type": "streamable-http",
+            "url": "https://api.example.com/mcp",
+            "headers": {
+              "Authorization": "Bearer ${API_KEY}"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}`
+
+func newMCPClaudeCodeTestRecord(t *testing.T, recordJSON string) *corev1.Record {
+	t.Helper()
+
+	var data structpb.Struct
+
+	require.NoError(t, protojson.Unmarshal([]byte(recordJSON), &data))
+
+	return &corev1.Record{Data: &data}
+}
+
+func TestMCPClaudeCodeFormatter_Format(t *testing.T) {
+	f, err := exportfmt.GetFormatter("mcp-claudecode")
+	require.NoError(t, err)
+
+	t.Run("formats a stdio MCP server into mcpServers", func(t *testing.T) {
+		record := newMCPClaudeCodeTestRecord(t, testMCPClaudeCodeStdioRecordJSON)
+
+		output, err := f.Format(record)
+		require.NoError(t, err)
+		assert.NotEmpty(t, output)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(output, &parsed))
+
+		servers, ok := parsed["mcpServers"].(map[string]any)
+		require.True(t, ok, "output should contain an 'mcpServers' map")
+
+		server, ok := servers["io.example/code-review"].(map[string]any)
+		require.True(t, ok, "servers should contain the normalized server name")
+		assert.Equal(t, "npx", server["command"])
+		assert.Nil(t, server["type"], "stdio servers should have no 'type' field")
+
+		env, ok := server["env"].(map[string]any)
+		require.True(t, ok, "expected env map for API_KEY placeholder")
+		assert.Equal(t, "${API_KEY}", env["API_KEY"])
+	})
+
+	t.Run("formats a remote MCP server with type/url/headers", func(t *testing.T) {
+		record := newMCPClaudeCodeTestRecord(t, testMCPClaudeCodeRemoteRecordJSON)
+
+		output, err := f.Format(record)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(output, &parsed))
+
+		servers, ok := parsed["mcpServers"].(map[string]any)
+		require.True(t, ok)
+
+		server, ok := servers["io.example/remote"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "http", server["type"], "OASF 'streamable-http' should map to Claude Code 'http'")
+		assert.Equal(t, "https://api.example.com/mcp", server["url"])
+
+		headers, ok := server["headers"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Bearer ${API_KEY}", headers["Authorization"])
+	})
+
+	t.Run("returns error for record with nil data", func(t *testing.T) {
+		record := &corev1.Record{}
+
+		_, err := f.Format(record)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "record contains no data")
+	})
+
+	t.Run("returns error for record without MCP module data", func(t *testing.T) {
+		record := newMCPClaudeCodeTestRecord(t, `{
+  "schema_version": "1.0.0",
+  "name": "no-mcp-module",
+  "version": "1.0.0",
+  "description": "Record without an MCP module"
+}`)
+
+		_, formatErr := f.Format(record)
+		require.Error(t, formatErr)
+		assert.ErrorIs(t, formatErr, exportfmt.ErrUnsupportedRecord)
+	})
+}
+
+func TestMCPClaudeCodeFormatter_FileExtension(t *testing.T) {
+	f, err := exportfmt.GetFormatter("mcp-claudecode")
+	require.NoError(t, err)
+	assert.Equal(t, ".json", f.FileExtension())
+}

--- a/cli/cmd/export/batch.go
+++ b/cli/cmd/export/batch.go
@@ -34,6 +34,8 @@ func getBatchFormatter(name string) batchFormatter {
 		return &skillBundleBatchExporter{}
 	case "mcp-ghcopilot":
 		return &mcpBatchExporter{}
+	case "mcp-claudecode":
+		return &mcpClaudeCodeBatchExporter{}
 	default:
 		return nil
 	}

--- a/cli/cmd/export/batch_mcp_claudecode.go
+++ b/cli/cmd/export/batch_mcp_claudecode.go
@@ -1,0 +1,63 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package export
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/api/exportfmt"
+	recordutil "github.com/agntcy/dir/cli/util/records"
+)
+
+// mcpClaudeCodeBatchExporter merges all matched MCP servers into a single
+// mcp.json, mirroring mcpBatchExporter's behavior for mcp-ghcopilot.
+type mcpClaudeCodeBatchExporter struct{}
+
+func (f *mcpClaudeCodeBatchExporter) FormatBatch(records []*corev1.Record, outputDir string, allVersions bool) (int, error) {
+	toMerge := records
+	if !allVersions {
+		toMerge = recordutil.LatestByName(records)
+	}
+
+	merged := &exportfmt.ClaudeCodeMCPConfig{
+		MCPServers: make(map[string]exportfmt.ClaudeCodeMCPServer),
+	}
+
+	exported := 0
+
+	for _, record := range toMerge {
+		data := record.GetData()
+		if data == nil {
+			continue
+		}
+
+		cfg, err := exportfmt.RecordToClaudeCode(data)
+		if err != nil {
+			continue
+		}
+
+		maps.Copy(merged.MCPServers, cfg.MCPServers)
+
+		exported++
+	}
+
+	raw, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal merged Claude Code MCP config: %w", err)
+	}
+
+	raw = append(raw, '\n')
+
+	outPath := filepath.Join(outputDir, "mcp.json")
+	if err := os.WriteFile(outPath, raw, 0o600); err != nil { //nolint:mnd
+		return 0, fmt.Errorf("failed to write %s: %w", outPath, err)
+	}
+
+	return exported, nil
+}

--- a/cli/cmd/export/batch_mcp_claudecode_test.go
+++ b/cli/cmd/export/batch_mcp_claudecode_test.go
@@ -1,0 +1,98 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package export
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const testMCPClaudeCodeRecordJSON = `{
+  "schema_version": "1.0.0",
+  "name": "io.example/code-review-server",
+  "version": "1.0.0",
+  "description": "MCP server for code review",
+  "modules": [
+    {
+      "name": "integration/mcp",
+      "data": {
+        "name": "io.example/code-review-server",
+        "connections": [
+          {
+            "type": "stdio",
+            "command": "npx",
+            "args": ["@example/code-review-server@1.0.0"],
+            "env_vars": [
+              {
+                "name": "API_KEY",
+                "description": "API key for authentication"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}`
+
+func newMCPClaudeCodeTestRecord(t *testing.T, recordJSON string) *corev1.Record {
+	t.Helper()
+
+	var data structpb.Struct
+
+	require.NoError(t, protojson.Unmarshal([]byte(recordJSON), &data))
+
+	return &corev1.Record{Data: &data}
+}
+
+func TestMCPClaudeCodeBatchFormatter(t *testing.T) {
+	bf := getBatchFormatter("mcp-claudecode")
+	require.NotNil(t, bf, "mcp-claudecode should have a batch formatter")
+
+	t.Run("merges multiple records into single mcp.json", func(t *testing.T) {
+		dir := t.TempDir()
+		r1 := newMCPClaudeCodeTestRecord(t, testMCPClaudeCodeRecordJSON)
+		records := []*corev1.Record{r1}
+
+		n, err := bf.FormatBatch(records, dir, false)
+		require.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		data, err := os.ReadFile(filepath.Join(dir, "mcp.json"))
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+
+		servers, ok := parsed["mcpServers"].(map[string]any)
+		require.True(t, ok, "output should contain an 'mcpServers' map")
+		assert.NotEmpty(t, servers)
+
+		server, ok := servers["io.example/code-review"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "npx", server["command"])
+	})
+
+	t.Run("returns zero for empty slice", func(t *testing.T) {
+		dir := t.TempDir()
+		n, err := bf.FormatBatch(nil, dir, false)
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+
+		data, err := os.ReadFile(filepath.Join(dir, "mcp.json"))
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		assert.Empty(t, parsed["mcpServers"])
+	})
+}

--- a/cli/cmd/export/export.go
+++ b/cli/cmd/export/export.go
@@ -32,6 +32,7 @@ The --format flag selects the output format (required):
   agent-skill-bundle  Skill bundle archive (.gzip) for multi-file skills
   a2a            A2A AgentCard JSON for Agent-to-Agent protocol interop
   mcp-ghcopilot  GitHub Copilot MCP configuration JSON
+  mcp-claudecode Claude Code MCP configuration JSON (.mcp.json "mcpServers" shape)
 
 For raw OASF record JSON, use 'dirctl pull' (which supports --output-file,
 --output-dir, and search filters for batch retrieval).
@@ -41,6 +42,7 @@ Single-record examples:
   dirctl export bafyreib... --format=a2a --output-file=./agent-card.json
   dirctl export my-agent:1.0 --format=agent-skill --output-file=./SKILL.md
   dirctl export my-agent:1.0 --format=agent-skill-bundle --output-file=./skill.gzip
+  dirctl export my-mcp-server --format=mcp-claudecode --output-file=.mcp.json
 
 Batch export from search results:
 
@@ -48,6 +50,7 @@ Batch export from search results:
   dirctl export --output-dir=./exports/ --format=agent-skill --skill "code*"
   dirctl export --output-dir=./exports/ --format=agent-skill-bundle --skill "code*"
   dirctl export --output-dir=./exports/ --format=mcp-ghcopilot --module "integration/mcp"
+  dirctl export --output-dir=./claude-configs/ --format=mcp-claudecode --module "integration/mcp"
 `,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -73,7 +76,7 @@ Batch export from search results:
 func validateExportFormat(format string) error {
 	switch format {
 	case "":
-		return errors.New("--format is required (agent-skill, a2a, or mcp-ghcopilot); for raw OASF records use `dirctl pull`")
+		return errors.New("--format is required (agent-skill, a2a, mcp-ghcopilot, or mcp-claudecode); for raw OASF records use `dirctl pull`")
 	case exportfmt.FormatOASF:
 		return errors.New("raw OASF export has moved to `dirctl pull` (it supports --output-file, --output-dir, and search filters); `dirctl export` no longer supports --format=oasf")
 	default:

--- a/cli/cmd/export/format_test.go
+++ b/cli/cmd/export/format_test.go
@@ -23,7 +23,7 @@ func TestValidateExportFormatRejectsEmpty(t *testing.T) {
 }
 
 func TestValidateExportFormatAllowsKnownFormats(t *testing.T) {
-	for _, f := range []string{"agent-skill", "skill", "a2a", "mcp-ghcopilot"} {
+	for _, f := range []string{"agent-skill", "skill", "a2a", "mcp-ghcopilot", "mcp-claudecode"} {
 		assert.NoError(t, validateExportFormat(f), "format %q should be allowed", f)
 	}
 }

--- a/cli/cmd/export/options.go
+++ b/cli/cmd/export/options.go
@@ -21,7 +21,7 @@ type options struct {
 
 func init() {
 	flags := Command.Flags()
-	flags.StringVar(&opts.Format, "format", "", "Export format: agent-skill, a2a, mcp-ghcopilot (required). For raw OASF records use `dirctl pull`.")
+	flags.StringVar(&opts.Format, "format", "", "Export format: agent-skill, a2a, mcp-ghcopilot, mcp-claudecode (required). For raw OASF records use `dirctl pull`.")
 	flags.StringVar(&opts.OutputFile, "output-file", "", "File path to write the exported data (default: stdout)")
 	flags.StringVar(&opts.OutputDir, "output-dir", "", "Directory for batch export from search results")
 	flags.Uint32Var(&opts.Limit, "limit", 100, "Maximum number of records to export in batch mode") //nolint:mnd

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -929,6 +929,7 @@ Pull a record and transform it to the requested format.
 | `a2a` | `.json` | A2A AgentCard JSON for Agent-to-Agent protocol interop |
 | `agent-skill` | `.md` | SKILL.md artifact for agentic CLI consumption (Cursor, Claude Code, etc.) |
 | `mcp-ghcopilot` | `.json` | GitHub Copilot MCP configuration JSON |
+| `mcp-claudecode` | `.json` | Claude Code MCP configuration JSON (`.mcp.json` `mcpServers` shape) |
 
 > **Note:** For raw OASF record JSON, use [`dirctl pull`](#dirctl-pull-reference) — it supports `--output-file`, `--output-dir`, and search filters for batch retrieval. `dirctl export` no longer accepts `--format=oasf`.
 
@@ -956,6 +957,7 @@ When `--output-dir` is used, at least one search filter is required. All standar
     - **a2a / oasf**: One file per record (`<name>.json`).
     - **agent-skill**: One subdirectory per skill (`<name>/SKILL.md`).
     - **mcp-ghcopilot**: All matched MCP servers are merged into a single `mcp.json` with combined `servers` and `inputs` maps.
+    - **mcp-claudecode**: All matched MCP servers are merged into a single `mcp.json` with a combined `mcpServers` map.
 
 ??? example
 
@@ -977,6 +979,9 @@ When `--output-dir` is used, at least one search filter is required. All standar
     # Batch export MCP servers (merged into a single config)
     dirctl export --output-dir=./exports/ --format=mcp-ghcopilot \
       --module "integration/mcp"
+
+    # Export a single record as a Claude Code .mcp.json
+    dirctl export my-mcp-server --format=mcp-claudecode --output-file=.mcp.json
 
     # Export all versions instead of only the latest
     dirctl export --output-dir=./exports/ --format=a2a \

--- a/docs/content/dir/dir-component-import.md
+++ b/docs/content/dir/dir-component-import.md
@@ -78,10 +78,11 @@ for [discovery](dir-component-routing.md) (`--name`, `--version`, `--module`, `-
 | `a2a` | `.json` | A2A AgentCard JSON for Agent-to-Agent protocol interop |
 | `agent-skill` | `.md` | `SKILL.md` artifact for agentic CLIs (Cursor, Claude Code, etc.) |
 | `mcp-ghcopilot` | `.json` | GitHub Copilot MCP configuration JSON |
+| `mcp-claudecode` | `.json` | Claude Code MCP configuration JSON (`.mcp.json` `mcpServers` shape) |
 
 Batch behaviour varies by format: `a2a` and `oasf` produce one file per record,
-`agent-skill` produces one subdirectory per skill, and `mcp-ghcopilot` merges all matched
-MCP servers into a single configuration file.
+`agent-skill` produces one subdirectory per skill, and `mcp-ghcopilot` / `mcp-claudecode`
+merge all matched MCP servers into a single configuration file.
 
 ## Related documentation
 


### PR DESCRIPTION
Adds `--format mcp-claudecode` to `dirctl export`, closing #1386.

Pulls an OASF record's `integration/mcp` module (1.0.0 `connections` format) and emits Claude Code's project-scoped `.mcp.json` shape. Batch export (`--output-dir`) merges all matched servers into one `mcp.json`, mirroring the existing `mcp-ghcopilot` behavior.

Judgment calls where the issue was silent, called out for review:
- stdio entries omit `type`, matching what `claude mcp add` actually emits (the issue's stdio example also omits it).
- OASF's `streamable-http` transport maps to Claude Code's `"type": "http"`; `sse` passes through.
- Env vars without a `default_value` emit `"NAME": "${NAME}"`, Claude Code's documented shell-environment expansion. There's no Claude Code equivalent of VS Code's `${input:NAME}` prompt that the ghcopilot exporter uses.

Scope notes:
- Issue Step 1 targets oasf-sdk's translator package. This PR keeps the translator dir-local (`api/exportfmt/mcp_claudecode.go`, exported as `exportfmt.RecordToClaudeCode`) so the feature doesn't block on an oasf-sdk release and dependency bump. Happy to upstream it as a follow-up if you'd rather have the two-repo split.
- Step 2.4 references `mcp/tools/export_record.go`, which doesn't exist on current main; skipped.
- OASF 1.0.0 `connections` only; legacy 0.7.0/0.8.0 `servers` format isn't handled.

Verified: `go build ./...` and the exportfmt + cmd/export test suites pass on both the `api` and `cli` modules. Tests mirror the ghcopilot formatter's coverage (stdio, remote with headers, nil data, missing module, batch merge, empty batch, registration). Commits are DCO signed.
