### PR TITLE
ci(codeql): use official taskfile action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,17 +9,17 @@ on:
       - main
       - renovate/**
     paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/docs-ci.yaml'
-      - '.github/workflows/docs-deploy.yml'
-      - '.github/workflows/reusable-docs.yml'
+      - "docs/**"
+      - ".github/workflows/docs-ci.yaml"
+      - ".github/workflows/docs-deploy.yml"
+      - ".github/workflows/reusable-docs.yml"
   pull_request:
     branches: ["main"]
     paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/docs-ci.yaml'
-      - '.github/workflows/docs-deploy.yml'
-      - '.github/workflows/reusable-docs.yml'
+      - "docs/**"
+      - ".github/workflows/docs-ci.yaml"
+      - ".github/workflows/docs-deploy.yml"
+      - ".github/workflows/reusable-docs.yml"
   schedule:
     - cron: "42 5 * * 6"
   workflow_dispatch:
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install Task
         if: matrix.language == 'go'
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The taskfile github action used was replaced and now directly maintained by Taskfile