### PR TITLE
feat(reconciler): bundle scanners in image and document scan task setup

### DIFF
--- a/docs/content/dir/dir-deployment-kubernetes.md
+++ b/docs/content/dir/dir-deployment-kubernetes.md
@@ -295,3 +295,34 @@ The Agent Directory Service can be deployed using Helm or GitOps / Argo CD. Helm
 
     !!! important "Trust domain"
         This Quick Start uses `example.org` for local testing only. To federate with the public Directory network, you need a unique trust domain. See [Production Deployment](dir-prod-deployment.md) and [Running a Federated Directory Instance](dir-federation-setup.md).
+
+## Security Scanning
+
+The reconciler image includes [`mcp-scanner`](https://cisco-ai-defense.github.io/docs/mcp-scanner) and [`skill-scanner`](https://cisco-ai-defense.github.io/docs/skill-scanner) pre-installed. The scan task is enabled by default and requires Azure OpenAI credentials to perform LLM-backed analysis.
+
+Inject the credentials via `extraEnv` in your Helm values. Use a Kubernetes Secret to avoid storing keys in plaintext:
+
+```bash
+kubectl create secret generic azure-openai \
+  --namespace dir-dev-dir \
+  --from-literal=api-key=<your-key>
+```
+
+```yaml
+extraEnv:
+  - name: AZURE_OPENAI_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: azure-openai
+        key: api-key
+  - name: AZURE_OPENAI_BASE_URL
+    value: "https://your-instance.openai.azure.com/"
+  - name: AZURE_OPENAI_DEPLOYMENT
+    value: "gpt-4o"
+  - name: AZURE_OPENAI_API_VERSION
+    value: "2024-02-01"
+```
+
+To disable scanning, set `reconciler.config.scan.enabled: false` in your Helm values.
+
+See [Security Scanning](dir-features-scenarios.md#security-scanning) for how to pull and filter scan results.

--- a/docs/content/dir/dir-deployment-local.md
+++ b/docs/content/dir/dir-deployment-local.md
@@ -72,6 +72,50 @@ DIRECTORY_DAEMON_SERVER_LISTEN_ADDRESS="localhost:9999" dirctl daemon start
 
 When `--config` is provided, the file replaces built-in defaults entirely. See the [reference configuration](https://github.com/agntcy/dir/blob/main/cli/cmd/daemon/daemon.config.yaml) for all available options.
 
+## Security Scanning
+
+The reconciler scans records using [`mcp-scanner`](https://cisco-ai-defense.github.io/docs/mcp-scanner) (MCP server source code) and [`skill-scanner`](https://cisco-ai-defense.github.io/docs/skill-scanner) (agent skill bundles). Both are LLM-backed and require Azure OpenAI credentials. See [Security Scanning](dir-features-scenarios.md#security-scanning) for how to pull and filter scan results.
+
+### dirctl daemon
+
+The scanner CLIs are not bundled with `dirctl`. Install them before starting the daemon:
+
+```bash
+task deps:scanners
+```
+
+Then export the LLM credentials and start the daemon:
+
+```bash
+export AZURE_OPENAI_API_KEY=<your-key>
+export AZURE_OPENAI_BASE_URL=<your-endpoint>     # e.g. https://your-instance.openai.azure.com/
+export AZURE_OPENAI_DEPLOYMENT=<deployment-name> # e.g. gpt-4o
+export AZURE_OPENAI_API_VERSION=<api-version>    # e.g. 2024-02-01
+
+dirctl daemon start
+```
+
+If the scanner binaries are not on `PATH`, specify their locations in the daemon config:
+
+```yaml
+reconciler:
+  scan:
+    mcp_cli_path: /path/to/mcp-scanner
+    skill_cli_path: /path/to/skill-scanner
+```
+
+### Docker Compose
+
+The reconciler container image includes both scanner CLIs. Add your Azure OpenAI credentials to `install/docker/reconciler.env` before starting the stack:
+
+```bash
+# install/docker/reconciler.env
+AZURE_OPENAI_API_KEY=<your-key>
+AZURE_OPENAI_BASE_URL=<your-endpoint>
+AZURE_OPENAI_DEPLOYMENT=<deployment-name>
+AZURE_OPENAI_API_VERSION=<api-version>
+```
+
 ## Docker Compose deployment
 
 The Docker Compose stack runs separate containers for the apiserver, reconciler, Zot OCI registry, and PostgreSQL:

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -632,3 +632,10 @@ apiserver:
       signature:
         enabled: true
         interval: "1h"
+
+      # Scan task configuration
+      scan:
+        enabled: true
+        interval: "1h"
+        mcp_cli_path: "mcp-scanner"
+        skill_cli_path: "skill-scanner"

--- a/install/docker/reconciler.env
+++ b/install/docker/reconciler.env
@@ -53,6 +53,21 @@ RECONCILER_SIGNATURE_INTERVAL=1m
 RECONCILER_SIGNATURE_TTL=168h
 RECONCILER_SIGNATURE_RECORD_TIMEOUT=30s
 
+# Scan Task Configuration
+# Runs mcp-scanner and skill-scanner against record artifacts and stores results.
+RECONCILER_SCAN_ENABLED=true
+RECONCILER_SCAN_INTERVAL=1h
+RECONCILER_SCAN_TTL=168h
+RECONCILER_SCAN_RECORD_TIMEOUT=5m
+RECONCILER_SCAN_MCP_CLI_PATH=mcp-scanner
+RECONCILER_SCAN_SKILL_CLI_PATH=skill-scanner
+
+# Azure OpenAI credentials — required for security scanning
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_BASE_URL=
+AZURE_OPENAI_DEPLOYMENT=
+AZURE_OPENAI_API_VERSION=
+
 # Logger Configuration (shared across components)
 # Log levels: DEBUG, INFO, WARN, ERROR
 # Log formats: json, text

--- a/reconciler/Dockerfile
+++ b/reconciler/Dockerfile
@@ -85,3 +85,19 @@ RUN mkdir -p /tmp/coverage && chown -R 55532:55532 /tmp/coverage
 USER 55532:55532
 
 ENTRYPOINT ["./reconciler"]
+
+FROM python:3.13-slim AS scanner
+
+RUN groupadd -g 55532 -r nonroot && useradd -u 55532 -r -g nonroot nonroot
+
+WORKDIR /
+
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
+COPY --from=builder /bin/reconciler ./reconciler
+
+RUN pip install --no-cache-dir cisco-ai-mcp-scanner cisco-ai-skill-scanner
+
+USER 55532:55532
+
+ENTRYPOINT ["./reconciler"]


### PR DESCRIPTION
The reconciler's security scan task previously required users to install `mcp-scanner` and `skill-scanner` themselves with no documentation on how to do so. This PR adds a `scanner` Dockerfile stage based on `python:3.13-slim` that includes both scanners pre-installed, making the scan task operational out of the box for Docker and Kubernetes deployments. Scan configuration is also surfaced in the Helm values and Docker Compose env file (enabled by default in both), and per-deployment-mode setup guides are added to the docs covering scanner installation and Azure OpenAI credential injection.
