### PR TITLE
feat(dir): add a2a-scanner support

### DIFF
--- a/Taskfile.deps.yml
+++ b/Taskfile.deps.yml
@@ -420,8 +420,18 @@ tasks:
       - cmd: >-
           {{.UV_BIN}} tool install --python 3.13 cisco-ai-skill-scanner
 
+  deps:a2a-scanner:
+    desc: Install a2a-scanner CLI via uv
+    deps:
+      - task: deps:uv
+    cmds:
+      - cmd: echo "Installing a2a-scanner"
+      - cmd: >-
+          {{.UV_BIN}} tool install --python 3.13 cisco-ai-a2a-scanner
+
   deps:scanners:
-    desc: Install all security scanner CLIs (mcp-scanner and skill-scanner) via uv
+    desc: Install all security scanner CLIs (mcp-scanner, skill-scanner, and a2a-scanner) via uv
     cmds:
       - task: deps:mcp-scanner
       - task: deps:skill-scanner
+      - task: deps:a2a-scanner

--- a/cli/cmd/daemon/daemon.config.yaml
+++ b/cli/cmd/daemon/daemon.config.yaml
@@ -96,6 +96,7 @@ reconciler:
     record_timeout: 2m
     mcp_cli_path: "mcp-scanner"
     skill_cli_path: "skill-scanner"
+    a2a_cli_path: "a2a-scanner"
   local_registry:
     registry_address: "localhost:5555"
     repository_name: "dir"

--- a/reconciler/config/config.go
+++ b/reconciler/config/config.go
@@ -225,6 +225,9 @@ func LoadConfig() (*Config, error) {
 	_ = v.BindEnv("scan.skill_cli_path")
 	v.SetDefault("scan.skill_cli_path", scan.DefaultSkillCLIPath)
 
+	_ = v.BindEnv("scan.a2a_cli_path")
+	v.SetDefault("scan.a2a_cli_path", scan.DefaultA2ACLIPath)
+
 	//
 	// Providers task configuration (provider-count gauge)
 	//

--- a/reconciler/tasks/scan/config.go
+++ b/reconciler/tasks/scan/config.go
@@ -23,6 +23,9 @@ const (
 
 	// DefaultSkillCLIPath is the default binary name for the skill scanner.
 	DefaultSkillCLIPath = "skill-scanner"
+
+	// DefaultA2ACLIPath is the default binary name for the A2A scanner.
+	DefaultA2ACLIPath = "a2a-scanner"
 )
 
 // Config holds configuration for the security scan reconciliation task.
@@ -44,6 +47,9 @@ type Config struct {
 
 	// SkillCLIPath is the path to the skill-scanner binary.
 	SkillCLIPath string `json:"skill_cli_path,omitempty" mapstructure:"skill_cli_path"`
+
+	// A2ACLIPath is the path to the a2a-scanner binary.
+	A2ACLIPath string `json:"a2a_cli_path,omitempty" mapstructure:"a2a_cli_path"`
 }
 
 // GetInterval returns the interval with default fallback.
@@ -89,4 +95,13 @@ func (c *Config) GetSkillCLIPath() string {
 	}
 
 	return c.SkillCLIPath
+}
+
+// GetA2ACLIPath returns the A2A scanner binary path with default fallback.
+func (c *Config) GetA2ACLIPath() string {
+	if c.A2ACLIPath == "" {
+		return DefaultA2ACLIPath
+	}
+
+	return c.A2ACLIPath
 }

--- a/reconciler/tasks/scan/config_test.go
+++ b/reconciler/tasks/scan/config_test.go
@@ -32,6 +32,10 @@ func TestConfig_Defaults(t *testing.T) {
 	if got := c.GetSkillCLIPath(); got != DefaultSkillCLIPath {
 		t.Errorf("GetSkillCLIPath() = %q, want %q", got, DefaultSkillCLIPath)
 	}
+
+	if got := c.GetA2ACLIPath(); got != DefaultA2ACLIPath {
+		t.Errorf("GetA2ACLIPath() = %q, want %q", got, DefaultA2ACLIPath)
+	}
 }
 
 func TestConfig_CustomValues(t *testing.T) {
@@ -43,6 +47,7 @@ func TestConfig_CustomValues(t *testing.T) {
 		RecordTimeout: 10 * time.Minute,
 		MCPCLIPath:    "/opt/mcp-scanner",
 		SkillCLIPath:  "/opt/skill-scanner",
+		A2ACLIPath:    "/opt/a2a-scanner",
 	}
 
 	if got := c.GetInterval(); got != 2*time.Hour {
@@ -63,5 +68,9 @@ func TestConfig_CustomValues(t *testing.T) {
 
 	if got := c.GetSkillCLIPath(); got != "/opt/skill-scanner" {
 		t.Errorf("GetSkillCLIPath() = %q", got)
+	}
+
+	if got := c.GetA2ACLIPath(); got != "/opt/a2a-scanner" {
+		t.Errorf("GetA2ACLIPath() = %q", got)
 	}
 }

--- a/reconciler/tasks/scan/task.go
+++ b/reconciler/tasks/scan/task.go
@@ -37,6 +37,7 @@ func NewTask(config Config, db types.DatabaseAPI, store types.StoreAPI, refStore
 	runners := []scanner.Runner{
 		scanner.NewMCPRunner(scanner.MCPConfig{CLIPath: config.GetMCPCLIPath()}),
 		scanner.NewSkillRunner(scanner.SkillConfig{CLIPath: config.GetSkillCLIPath()}),
+		scanner.NewA2ARunner(scanner.A2AConfig{CLIPath: config.GetA2ACLIPath()}),
 	}
 
 	return &Task{

--- a/utils/scanner/a2a.go
+++ b/utils/scanner/a2a.go
@@ -1,0 +1,253 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/utils/logging"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// DefaultA2ACLIPath is the default binary name resolved via PATH.
+const DefaultA2ACLIPath = "a2a-scanner"
+
+var a2aLogger = logging.Logger("utils/scanner/a2a")
+
+// A2AConfig holds configuration for the A2A runner.
+type A2AConfig struct {
+	// CLIPath is the path to the a2a-scanner binary. Defaults to DefaultA2ACLIPath.
+	CLIPath string
+}
+
+// A2ARunner invokes a2a-scanner to scan an Agent-to-Agent (A2A) protocol
+// AgentCard. It reads the a2a_data module stored on the record, writes the
+// card to a temporary file, and runs `a2a-scanner scan-card`.
+type A2ARunner struct {
+	cfg A2AConfig
+}
+
+// NewA2ARunner creates an A2ARunner. If cfg.CLIPath is empty, DefaultA2ACLIPath is used.
+func NewA2ARunner(cfg A2AConfig) *A2ARunner {
+	if cfg.CLIPath == "" {
+		cfg.CLIPath = DefaultA2ACLIPath
+	}
+
+	return &A2ARunner{cfg: cfg}
+}
+
+// Name returns the runner name.
+func (r *A2ARunner) Name() string { return "a2a" }
+
+// Run extracts the A2A AgentCard from the record, writes it to a temporary
+// file, and runs `a2a-scanner scan-card` against it.
+func (r *A2ARunner) Run(ctx context.Context, record *corev1.Record) (*ScanResult, error) {
+	card, ok := extractA2ACard(record)
+	if !ok {
+		return &ScanResult{Skipped: true, SkippedReason: "no A2A agent card found"}, nil
+	}
+
+	cardJSON, err := json.Marshal(card)
+	if err != nil {
+		return nil, fmt.Errorf("marshal A2A agent card: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "a2a-scan-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	cardPath := filepath.Join(tmpDir, "agent-card.json")
+	if err := os.WriteFile(cardPath, cardJSON, 0o600); err != nil { //nolint:mnd
+		return nil, fmt.Errorf("write agent card: %w", err)
+	}
+
+	outputPath := filepath.Join(tmpDir, "scan-result.json")
+
+	if err := runA2AScanner(ctx, r.cfg.CLIPath, cardPath, outputPath); err != nil {
+		return nil, fmt.Errorf("a2a-scanner: %w", err)
+	}
+
+	rawOutput, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("read a2a-scanner output: %w", err)
+	}
+
+	result, err := parseA2AOutput(rawOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Version = getVersion(r.cfg.CLIPath, "--version")
+	// heuristic, spec, and yara are zero-dependency analyzers (no third-party
+	// credentials or live endpoint required) so they are always run. llm requires
+	// third-party credentials and endpoint requires a reachable A2A server; both are
+	// opt-in only and wiring them up is left as follow-up work (mirroring the mcp
+	// runner's llm/api analyzers and the separate RemoteRunner for live endpoints).
+	result.Analyzers = []string{"heuristic", "spec", "yara"}
+
+	return result, nil
+}
+
+// extractA2ACard decodes the record and returns the A2A AgentCard stored in
+// the a2a_data module's card_data field, if present. The bool return
+// indicates whether a card was found.
+func extractA2ACard(record *corev1.Record) (map[string]any, bool) {
+	if record == nil {
+		return nil, false
+	}
+
+	decoded, err := record.Decode()
+	if err != nil {
+		return nil, false
+	}
+
+	if !decoded.HasV1() {
+		return nil, false
+	}
+
+	for _, mod := range decoded.GetV1().GetModules() {
+		if card := getNestedStructValue(mod.GetData(), "a2a_data", "card_data"); card != nil {
+			return card.AsMap(), true
+		}
+	}
+
+	return nil, false
+}
+
+// getNestedStructValue traverses nested protobuf Structs by the given keys
+// and returns the struct value at the final key, or nil if any step is
+// missing or not itself a struct.
+func getNestedStructValue(s *structpb.Struct, keys ...string) *structpb.Struct {
+	cur := s
+
+	for _, k := range keys {
+		if cur == nil {
+			return nil
+		}
+
+		v := cur.GetFields()[k]
+		if v == nil {
+			return nil
+		}
+
+		cur = v.GetStructValue()
+	}
+
+	return cur
+}
+
+func runA2AScanner(ctx context.Context, cliPath, cardPath, outputPath string) error {
+	var stdout, stderr bytes.Buffer
+
+	cmd := exec.CommandContext(ctx, cliPath, "scan-card", cardPath,
+		"--analyzers", "heuristic,spec,yara",
+		"--output", outputPath,
+	)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = buildA2AScannerEnv()
+
+	if err := cmd.Run(); err != nil {
+		a2aLogger.Warn("a2a-scanner stderr", "output", strings.TrimSpace(stderr.String()))
+
+		return fmt.Errorf("a2a-scanner exited with error: %w", err)
+	}
+
+	return nil
+}
+
+// buildA2AScannerEnv returns the parent env with A2A_SCANNER_LLM_* vars derived
+// from the AZURE_* equivalents so CI config does not need to duplicate them.
+// These are only consumed if the llm analyzer is enabled in the future; they
+// are harmless no-ops while llm stays out of the default analyzer set.
+func buildA2AScannerEnv() []string {
+	env := os.Environ()
+	env = appendEnvIfMissing(env, "A2A_SCANNER_LLM_API_KEY", os.Getenv("AZURE_OPENAI_API_KEY"))
+	env = appendEnvIfMissing(env, "A2A_SCANNER_LLM_BASE_URL", os.Getenv("AZURE_OPENAI_BASE_URL"))
+	env = appendEnvIfMissing(env, "A2A_SCANNER_LLM_MODEL", "azure/"+os.Getenv("AZURE_OPENAI_DEPLOYMENT"))
+	env = appendEnvIfMissing(env, "A2A_SCANNER_LLM_API_VERSION", os.Getenv("AZURE_OPENAI_API_VERSION"))
+	env = appendEnvIfMissing(env, "A2A_SCANNER_LLM_PROVIDER", "openai-compatible")
+
+	return env
+}
+
+// --- output parsing ---
+
+// a2aScanResult represents the single-object result of `a2a-scanner scan-card`.
+//
+// NOTE: a2a-scanner's JSON output schema is not fully documented upstream at
+// the time of writing (see https://cisco-ai-defense.github.io/docs/a2a-scanner).
+// The field names below follow the same is_safe/findings[severity,category,
+// rule_id,description,remediation] contract already exposed by skill-scanner,
+// the other single-artifact scanner in this family. If the installed
+// a2a-scanner binary uses different field names, update this struct and
+// parseA2AOutput to match — the CLI invocation and record-extraction logic
+// above are unaffected by this assumption.
+type a2aScanResult struct {
+	IsSafe   bool         `json:"is_safe"`
+	Findings []a2aFinding `json:"findings"`
+}
+
+type a2aFinding struct {
+	Severity    string `json:"severity"`
+	Category    string `json:"category"`
+	RuleID      string `json:"rule_id"`
+	Description string `json:"description"`
+	Remediation string `json:"remediation"`
+}
+
+func parseA2AOutput(raw []byte) (*ScanResult, error) {
+	raw = bytes.TrimSpace(trimToA2AJSON(raw))
+
+	if len(raw) == 0 {
+		return &ScanResult{Safe: true}, nil
+	}
+
+	var result a2aScanResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, fmt.Errorf("parse a2a-scanner output: %w", err)
+	}
+
+	var findings []Finding
+
+	for _, f := range result.Findings {
+		findings = append(findings, Finding{
+			Severity: mapA2ASeverity(f.Severity),
+			Message:  fmt.Sprintf("[%s] %s: %s", f.RuleID, f.Category, f.Description),
+		})
+	}
+
+	return &ScanResult{Safe: result.IsSafe, Findings: findings}, nil
+}
+
+// trimToA2AJSON strips leading non-JSON bytes by finding the first '{' or '['.
+func trimToA2AJSON(raw []byte) []byte {
+	if idx := bytes.IndexAny(raw, "{["); idx > 0 {
+		return raw[idx:]
+	}
+
+	return raw
+}
+
+func mapA2ASeverity(s string) FindingSeverity {
+	switch strings.ToUpper(s) {
+	case "CRITICAL", "HIGH":
+		return SeverityError
+	case "MEDIUM":
+		return SeverityWarning
+	default:
+		return SeverityInfo
+	}
+}

--- a/utils/scanner/a2a.go
+++ b/utils/scanner/a2a.go
@@ -227,7 +227,7 @@ func parseA2AOutput(raw []byte) (*ScanResult, error) {
 
 	for _, f := range result.Findings {
 		findings = append(findings, Finding{
-			Severity: mapA2ASeverity(f.Severity),
+			Severity: mapScannerSeverity(f.Severity),
 			Message:  fmt.Sprintf("[%s] %s: %s", f.RuleID, f.Category, f.Description),
 		})
 	}
@@ -242,15 +242,4 @@ func trimToA2AJSON(raw []byte) []byte {
 	}
 
 	return raw
-}
-
-func mapA2ASeverity(s string) FindingSeverity {
-	switch strings.ToUpper(s) {
-	case "CRITICAL", "HIGH":
-		return SeverityError
-	case "MEDIUM":
-		return SeverityWarning
-	default:
-		return SeverityInfo
-	}
 }

--- a/utils/scanner/a2a.go
+++ b/utils/scanner/a2a.go
@@ -188,27 +188,27 @@ func buildA2AScannerEnv() []string {
 
 // --- output parsing ---
 
-// a2aScanResult represents the single-object result of `a2a-scanner scan-card`.
+// a2aScanResult represents the JSON result of `a2a-scanner scan-card --output`.
 //
-// NOTE: a2a-scanner's JSON output schema is not fully documented upstream at
-// the time of writing (see https://cisco-ai-defense.github.io/docs/a2a-scanner).
-// The field names below follow the same is_safe/findings[severity,category,
-// rule_id,description,remediation] contract already exposed by skill-scanner,
-// the other single-artifact scanner in this family. If the installed
-// a2a-scanner binary uses different field names, update this struct and
-// parseA2AOutput to match — the CLI invocation and record-extraction logic
-// above are unaffected by this assumption.
+// The field names are verified against cisco-ai-a2a-scanner v1.0.0
+// (a2ascanner.core.models.ScanResult.to_dict /
+// a2ascanner.core.analyzers.base.SecurityFinding.to_dict): the result object
+// carries a findings[] array plus a total_findings count, and — unlike
+// skill-scanner and mcp-scanner — does NOT emit an is_safe flag. Safety is
+// therefore derived from the finding count. Each finding exposes
+// severity/threat_name/scanner_category/description/summary (there is no
+// rule_id/category/remediation triple).
 type a2aScanResult struct {
-	IsSafe   bool         `json:"is_safe"`
-	Findings []a2aFinding `json:"findings"`
+	Findings      []a2aFinding `json:"findings"`
+	TotalFindings int          `json:"total_findings"`
 }
 
 type a2aFinding struct {
-	Severity    string `json:"severity"`
-	Category    string `json:"category"`
-	RuleID      string `json:"rule_id"`
-	Description string `json:"description"`
-	Remediation string `json:"remediation"`
+	Severity        string `json:"severity"`
+	ThreatName      string `json:"threat_name"`
+	ScannerCategory string `json:"scanner_category"`
+	Description     string `json:"description"`
+	Summary         string `json:"summary"`
 }
 
 func parseA2AOutput(raw []byte) (*ScanResult, error) {
@@ -226,13 +226,23 @@ func parseA2AOutput(raw []byte) (*ScanResult, error) {
 	var findings []Finding
 
 	for _, f := range result.Findings {
+		desc := f.Description
+		if desc == "" {
+			desc = f.Summary
+		}
+
 		findings = append(findings, Finding{
 			Severity: mapScannerSeverity(f.Severity),
-			Message:  fmt.Sprintf("[%s] %s: %s", f.RuleID, f.Category, f.Description),
+			Message:  fmt.Sprintf("[%s] %s: %s", f.ThreatName, f.ScannerCategory, desc),
 		})
 	}
 
-	return &ScanResult{Safe: result.IsSafe, Findings: findings}, nil
+	// a2a-scanner emits no is_safe flag; a card is safe when the scan produced
+	// zero findings, mirroring the scanner's own "no threats detected" summary,
+	// which keys on total_findings.
+	safe := result.TotalFindings == 0 && len(findings) == 0
+
+	return &ScanResult{Safe: safe, Findings: findings}, nil
 }
 
 // trimToA2AJSON strips leading non-JSON bytes by finding the first '{' or '['.

--- a/utils/scanner/a2a.go
+++ b/utils/scanner/a2a.go
@@ -30,8 +30,8 @@ type A2AConfig struct {
 }
 
 // A2ARunner invokes a2a-scanner to scan an Agent-to-Agent (A2A) protocol
-// AgentCard. It reads the a2a_data module stored on the record, writes the
-// card to a temporary file, and runs `a2a-scanner scan-card`.
+// AgentCard. It reads the a2a module's card_data stored on the record, writes
+// the card to a temporary file, and runs `a2a-scanner scan-card`.
 type A2ARunner struct {
 	cfg A2AConfig
 }
@@ -101,8 +101,11 @@ func (r *A2ARunner) Run(ctx context.Context, record *corev1.Record) (*ScanResult
 }
 
 // extractA2ACard decodes the record and returns the A2A AgentCard stored in
-// the a2a_data module's card_data field, if present. The bool return
-// indicates whether a card was found.
+// the a2a module's card_data field, if present. Per the OASF a2a_data schema
+// (https://schema.oasf.outshift.com/1.0.0/objects/a2a_data) the module's data
+// object holds card_data directly, so the lookup is data.card_data — not a
+// nested data.a2a_data.card_data. The bool return indicates whether a card was
+// found.
 func extractA2ACard(record *corev1.Record) (map[string]any, bool) {
 	if record == nil {
 		return nil, false
@@ -118,7 +121,7 @@ func extractA2ACard(record *corev1.Record) (map[string]any, bool) {
 	}
 
 	for _, mod := range decoded.GetV1().GetModules() {
-		if card := getNestedStructValue(mod.GetData(), "a2a_data", "card_data"); card != nil {
+		if card := getNestedStructValue(mod.GetData(), "card_data"); card != nil {
 			return card.AsMap(), true
 		}
 	}

--- a/utils/scanner/a2a_exec_test.go
+++ b/utils/scanner/a2a_exec_test.go
@@ -1,0 +1,214 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// These tests exercise A2ARunner.Run's happy path and runA2AScanner without a
+// real a2a-scanner binary. A small stand-in CLI (testdata/fakescanner) is built
+// into a temp dir and its path is used as CLIPath; the fake's behaviour is
+// driven through FAKE_A2A_* env vars, which reach the child because
+// buildA2AScannerEnv forwards the parent environment. Building the fake from
+// testdata (rather than re-execing the test binary) keeps its path out of the
+// os.Args taint chain, so the runner's exec call is not flagged by gosec.
+
+// fakeScannerBin builds testdata/fakescanner into the test's temp dir and
+// returns the binary path.
+func fakeScannerBin(t *testing.T) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "fakescanner")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	out, err := exec.CommandContext(t.Context(), "go", "build", "-o", bin, "./testdata/fakescanner").CombinedOutput() //nolint:gosec
+	if err != nil {
+		t.Fatalf("build fake scanner: %v: %s", err, out)
+	}
+
+	return bin
+}
+
+// a2aRecordWithCard builds a record whose a2a module carries a card_data object,
+// so extractA2ACard returns a card and Run proceeds to invoke the CLI.
+func a2aRecordWithCard(t *testing.T) *corev1.Record {
+	t.Helper()
+
+	data, err := structpb.NewStruct(map[string]any{
+		"schema_version": "1.0.0",
+		"name":           "burger_seller_agent",
+		"modules": []any{
+			map[string]any{
+				"name": "integration/a2a",
+				"data": map[string]any{
+					"card_data": map[string]any{
+						"name":    "burger_seller_agent",
+						"version": "1.0.0",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+
+	return &corev1.Record{Data: data}
+}
+
+func TestA2ARunner_Run_Safe(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	bin := fakeScannerBin(t)
+	// No FAKE_A2A_OUTPUT set: the fake emits its default is_safe=true payload.
+
+	r := NewA2ARunner(A2AConfig{CLIPath: bin})
+
+	got, err := r.Run(t.Context(), a2aRecordWithCard(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Skipped {
+		t.Fatalf("record with a card should not be skipped: %+v", got)
+	}
+
+	if !got.Safe {
+		t.Errorf("is_safe=true output should produce Safe=true, got %+v", got)
+	}
+
+	if len(got.Findings) != 0 {
+		t.Errorf("safe scan should have no findings, got %d", len(got.Findings))
+	}
+
+	wantAnalyzers := []string{"heuristic", "spec", "yara"}
+	if strings.Join(got.Analyzers, ",") != strings.Join(wantAnalyzers, ",") {
+		t.Errorf("Analyzers = %v, want %v", got.Analyzers, wantAnalyzers)
+	}
+
+	if got.Version != "9.9.9-test" {
+		t.Errorf("Version = %q, want %q (parsed from --version)", got.Version, "9.9.9-test")
+	}
+}
+
+func TestA2ARunner_Run_UnsafeWithFindings(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	t.Setenv("FAKE_A2A_OUTPUT", `{"is_safe":false,"findings":[`+
+		`{"rule_id":"A2A_DELEG","category":"delegation","severity":"HIGH","description":"unsafe delegation chain"}]}`)
+
+	r := NewA2ARunner(A2AConfig{CLIPath: fakeScannerBin(t)})
+
+	got, err := r.Run(t.Context(), a2aRecordWithCard(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Safe {
+		t.Error("is_safe=false output should produce Safe=false")
+	}
+
+	if len(got.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(got.Findings))
+	}
+
+	if got.Findings[0].Severity != SeverityError {
+		t.Errorf("HIGH severity should map to SeverityError, got %q", got.Findings[0].Severity)
+	}
+}
+
+func TestA2ARunner_Run_ScannerExitError(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	t.Setenv("FAKE_A2A_FAIL", "1")
+
+	r := NewA2ARunner(A2AConfig{CLIPath: fakeScannerBin(t)})
+
+	_, err := r.Run(t.Context(), a2aRecordWithCard(t))
+	if err == nil {
+		t.Fatal("a non-zero scanner exit should surface an error")
+	}
+
+	if !strings.Contains(err.Error(), "a2a-scanner") {
+		t.Errorf("error should be wrapped with a2a-scanner context, got %v", err)
+	}
+}
+
+func TestA2ARunner_Run_MissingOutputFile(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	t.Setenv("FAKE_A2A_NO_FILE", "1")
+
+	r := NewA2ARunner(A2AConfig{CLIPath: fakeScannerBin(t)})
+
+	_, err := r.Run(t.Context(), a2aRecordWithCard(t))
+	if err == nil {
+		t.Fatal("a scanner that writes no output file should surface a read error")
+	}
+}
+
+func TestA2ARunner_Run_InvalidScannerOutput(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	t.Setenv("FAKE_A2A_OUTPUT", "not valid json")
+
+	r := NewA2ARunner(A2AConfig{CLIPath: fakeScannerBin(t)})
+
+	_, err := r.Run(t.Context(), a2aRecordWithCard(t))
+	if err == nil {
+		t.Fatal("unparseable scanner output should surface an error")
+	}
+}
+
+// --- runA2AScanner directly ---
+
+func TestRunA2AScanner_WritesOutput(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	t.Setenv("FAKE_A2A_OUTPUT", `{"is_safe":true,"findings":[]}`)
+
+	bin := fakeScannerBin(t)
+	dir := t.TempDir()
+	cardPath := filepath.Join(dir, "card.json")
+	outputPath := filepath.Join(dir, "out.json")
+
+	if err := os.WriteFile(cardPath, []byte(`{"name":"x"}`), 0o600); err != nil {
+		t.Fatalf("write card: %v", err)
+	}
+
+	if err := runA2AScanner(t.Context(), bin, cardPath, outputPath); err != nil {
+		t.Fatalf("runA2AScanner returned error: %v", err)
+	}
+
+	body, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("output file not written: %v", err)
+	}
+
+	if !strings.Contains(string(body), "is_safe") {
+		t.Errorf("unexpected output body: %s", body)
+	}
+}
+
+func TestRunA2AScanner_ExitError(t *testing.T) {
+	// Not parallel: uses t.Setenv.
+	t.Setenv("FAKE_A2A_FAIL", "1")
+
+	bin := fakeScannerBin(t)
+	dir := t.TempDir()
+	cardPath := filepath.Join(dir, "card.json")
+
+	if err := os.WriteFile(cardPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write card: %v", err)
+	}
+
+	if err := runA2AScanner(t.Context(), bin, cardPath, filepath.Join(dir, "out.json")); err == nil {
+		t.Error("non-zero CLI exit should return an error")
+	}
+}

--- a/utils/scanner/a2a_exec_test.go
+++ b/utils/scanner/a2a_exec_test.go
@@ -71,7 +71,7 @@ func a2aRecordWithCard(t *testing.T) *corev1.Record {
 func TestA2ARunner_Run_Safe(t *testing.T) {
 	// Not parallel: uses t.Setenv.
 	bin := fakeScannerBin(t)
-	// No FAKE_A2A_OUTPUT set: the fake emits its default is_safe=true payload.
+	// No FAKE_A2A_OUTPUT set: the fake emits its default zero-finding payload.
 
 	r := NewA2ARunner(A2AConfig{CLIPath: bin})
 
@@ -85,7 +85,7 @@ func TestA2ARunner_Run_Safe(t *testing.T) {
 	}
 
 	if !got.Safe {
-		t.Errorf("is_safe=true output should produce Safe=true, got %+v", got)
+		t.Errorf("zero-finding output should produce Safe=true, got %+v", got)
 	}
 
 	if len(got.Findings) != 0 {
@@ -104,8 +104,9 @@ func TestA2ARunner_Run_Safe(t *testing.T) {
 
 func TestA2ARunner_Run_UnsafeWithFindings(t *testing.T) {
 	// Not parallel: uses t.Setenv.
-	t.Setenv("FAKE_A2A_OUTPUT", `{"is_safe":false,"findings":[`+
-		`{"rule_id":"A2A_DELEG","category":"delegation","severity":"HIGH","description":"unsafe delegation chain"}]}`)
+	t.Setenv("FAKE_A2A_OUTPUT", `{"status":"completed","findings":[`+
+		`{"threat_name":"unsafe_delegation","scanner_category":"delegation","severity":"HIGH","description":"unsafe delegation chain"}],`+
+		`"total_findings":1,"high_severity_count":1}`)
 
 	r := NewA2ARunner(A2AConfig{CLIPath: fakeScannerBin(t)})
 
@@ -115,7 +116,7 @@ func TestA2ARunner_Run_UnsafeWithFindings(t *testing.T) {
 	}
 
 	if got.Safe {
-		t.Error("is_safe=false output should produce Safe=false")
+		t.Error("output with findings should produce Safe=false")
 	}
 
 	if len(got.Findings) != 1 {
@@ -171,7 +172,7 @@ func TestA2ARunner_Run_InvalidScannerOutput(t *testing.T) {
 
 func TestRunA2AScanner_WritesOutput(t *testing.T) {
 	// Not parallel: uses t.Setenv.
-	t.Setenv("FAKE_A2A_OUTPUT", `{"is_safe":true,"findings":[]}`)
+	t.Setenv("FAKE_A2A_OUTPUT", `{"status":"completed","findings":[],"total_findings":0}`)
 
 	bin := fakeScannerBin(t)
 	dir := t.TempDir()
@@ -191,7 +192,7 @@ func TestRunA2AScanner_WritesOutput(t *testing.T) {
 		t.Fatalf("output file not written: %v", err)
 	}
 
-	if !strings.Contains(string(body), "is_safe") {
+	if !strings.Contains(string(body), "total_findings") {
 		t.Errorf("unexpected output body: %s", body)
 	}
 }

--- a/utils/scanner/a2a_test.go
+++ b/utils/scanner/a2a_test.go
@@ -205,7 +205,7 @@ func TestParseA2AOutput_EmptyBytes(t *testing.T) {
 func TestParseA2AOutput_SafeNoFindings(t *testing.T) {
 	t.Parallel()
 
-	raw := `{"is_safe":true,"findings":[]}`
+	raw := `{"status":"completed","findings":[],"total_findings":0,"high_severity_count":0}`
 
 	got, err := parseA2AOutput([]byte(raw))
 	if err != nil {
@@ -213,7 +213,7 @@ func TestParseA2AOutput_SafeNoFindings(t *testing.T) {
 	}
 
 	if !got.Safe || len(got.Findings) != 0 {
-		t.Errorf("safe object with no findings: want Safe=true, Findings=0; got %+v", got)
+		t.Errorf("zero-finding result: want Safe=true, Findings=0; got %+v", got)
 	}
 }
 
@@ -221,10 +221,12 @@ func TestParseA2AOutput_UnsafeWithFindings(t *testing.T) {
 	t.Parallel()
 
 	raw := `{
-		"is_safe": false,
+		"status": "completed",
 		"findings": [
-			{"rule_id":"A2A_RULE1","category":"delegation","severity":"HIGH","description":"unsafe delegation chain"}
-		]
+			{"threat_name":"unsafe_delegation","scanner_category":"delegation","severity":"HIGH","description":"unsafe delegation chain"}
+		],
+		"total_findings": 1,
+		"high_severity_count": 1
 	}`
 
 	got, err := parseA2AOutput([]byte(raw))
@@ -233,7 +235,7 @@ func TestParseA2AOutput_UnsafeWithFindings(t *testing.T) {
 	}
 
 	if got.Safe {
-		t.Error("is_safe=false should produce Safe=false")
+		t.Error("a result with findings should produce Safe=false")
 	}
 
 	if len(got.Findings) != 1 {
@@ -245,31 +247,78 @@ func TestParseA2AOutput_UnsafeWithFindings(t *testing.T) {
 		t.Errorf("HIGH severity should map to SeverityError, got %q", f.Severity)
 	}
 
-	for _, part := range []string{"A2A_RULE1", "delegation", "unsafe delegation chain"} {
+	for _, part := range []string{"unsafe_delegation", "delegation", "unsafe delegation chain"} {
 		if !strings.Contains(f.Message, part) {
 			t.Errorf("message %q should contain %q", f.Message, part)
 		}
 	}
 }
 
-func TestParseA2AOutput_TrustsScannerSafeVerdict(t *testing.T) {
+func TestParseA2AOutput_FindingsDeriveUnsafe(t *testing.T) {
 	t.Parallel()
 
-	raw := `{"is_safe":true,"findings":[
-		{"rule_id":"R1","category":"injection","severity":"CRITICAL","description":"critical"}
-	]}`
+	// a2a-scanner reports no is_safe flag: any finding must derive Safe=false.
+	// This finding also omits "description", exercising the summary fallback.
+	raw := `{"status":"completed","findings":[
+		{"threat_name":"prompt_injection","scanner_category":"injection","severity":"CRITICAL","summary":"injection detected"}
+	],"total_findings":1,"high_severity_count":1}`
 
 	got, err := parseA2AOutput([]byte(raw))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !got.Safe {
-		t.Error("is_safe=true should be trusted even when a CRITICAL finding is present")
+	if got.Safe {
+		t.Error("a result with findings must be Safe=false even without an is_safe flag")
 	}
 
 	if len(got.Findings) != 1 {
-		t.Errorf("finding must still be surfaced; got %d", len(got.Findings))
+		t.Fatalf("finding must be surfaced; got %d", len(got.Findings))
+	}
+
+	if got.Findings[0].Severity != SeverityError {
+		t.Errorf("CRITICAL severity should map to SeverityError, got %q", got.Findings[0].Severity)
+	}
+
+	if !strings.Contains(got.Findings[0].Message, "injection detected") {
+		t.Errorf("message should fall back to summary when description is empty, got %q", got.Findings[0].Message)
+	}
+}
+
+func TestParseA2AOutput_FindingsPresentButZeroCount_Unsafe(t *testing.T) {
+	t.Parallel()
+
+	// Defends the len(findings) clause of the safety conjunction: if the scanner
+	// ever reports findings without a matching total_findings count, the presence
+	// of a finding must still derive Safe=false.
+	raw := `{"status":"completed","findings":[
+		{"threat_name":"t","scanner_category":"c","severity":"HIGH","description":"d"}
+	],"total_findings":0}`
+
+	got, err := parseA2AOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Safe {
+		t.Error("a surfaced finding must force Safe=false even when total_findings is 0")
+	}
+}
+
+func TestParseA2AOutput_NonzeroCountNoFindings_Unsafe(t *testing.T) {
+	t.Parallel()
+
+	// Defends the TotalFindings clause: a non-zero count with an empty findings
+	// array must still derive Safe=false.
+	raw := `{"status":"completed","findings":[],"total_findings":2,"high_severity_count":1}`
+
+	got, err := parseA2AOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Safe {
+		t.Error("a non-zero total_findings must force Safe=false even with an empty findings array")
 	}
 }
 
@@ -285,7 +334,7 @@ func TestParseA2AOutput_InvalidJSON(t *testing.T) {
 func TestParseA2AOutput_LeadingTextStripped(t *testing.T) {
 	t.Parallel()
 
-	raw := "progress output\n" + `{"is_safe":true,"findings":[]}`
+	raw := "progress output\n" + `{"status":"completed","findings":[],"total_findings":0}`
 
 	got, err := parseA2AOutput([]byte(raw))
 	if err != nil {

--- a/utils/scanner/a2a_test.go
+++ b/utils/scanner/a2a_test.go
@@ -111,13 +111,11 @@ func TestExtractA2ACard_Found(t *testing.T) {
 			map[string]any{
 				"name": "integration/a2a",
 				"data": map[string]any{
-					"a2a_data": map[string]any{
-						"card_data": map[string]any{
-							"name":    "burger_seller_agent",
-							"version": "1.0.0",
-						},
-						"card_schema_version": "v1.0.0",
+					"card_data": map[string]any{
+						"name":    "burger_seller_agent",
+						"version": "1.0.0",
 					},
+					"card_schema_version": "v1.0.0",
 				},
 			},
 		},

--- a/utils/scanner/a2a_test.go
+++ b/utils/scanner/a2a_test.go
@@ -328,39 +328,6 @@ func TestTrimToA2AJSON_NoJSON(t *testing.T) {
 	}
 }
 
-// --- mapA2ASeverity ---
-
-func TestMapA2ASeverity(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		input string
-		want  FindingSeverity
-	}{
-		{"CRITICAL", SeverityError},
-		{"critical", SeverityError},
-		{"HIGH", SeverityError},
-		{"high", SeverityError},
-		{"MEDIUM", SeverityWarning},
-		{"medium", SeverityWarning},
-		{"LOW", SeverityInfo},
-		{"low", SeverityInfo},
-		{"INFO", SeverityInfo},
-		{"UNKNOWN", SeverityInfo},
-		{"", SeverityInfo},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			t.Parallel()
-
-			if got := mapA2ASeverity(tc.input); got != tc.want {
-				t.Errorf("mapA2ASeverity(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
 // --- buildA2AScannerEnv ---
 
 func TestBuildA2AScannerEnv_ContainsParentEnv(t *testing.T) {
@@ -375,40 +342,7 @@ func TestBuildA2AScannerEnv_ContainsParentEnv(t *testing.T) {
 }
 
 func TestBuildA2AScannerEnv_MapsAzureVars(t *testing.T) {
-	t.Setenv("AZURE_OPENAI_API_KEY", "test-key")
-	t.Setenv("AZURE_OPENAI_BASE_URL", "https://openai.example.com")
-	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
-	t.Setenv("AZURE_OPENAI_API_VERSION", "2024-08-01")
-
-	// Ensure A2A vars are absent so they get derived.
-	t.Setenv("A2A_SCANNER_LLM_API_KEY", "")
-	t.Setenv("A2A_SCANNER_LLM_BASE_URL", "")
-	t.Setenv("A2A_SCANNER_LLM_MODEL", "")
-	t.Setenv("A2A_SCANNER_LLM_API_VERSION", "")
-	t.Setenv("A2A_SCANNER_LLM_PROVIDER", "")
-
-	env := buildA2AScannerEnv()
-	envMap := make(map[string]string)
-
-	for _, e := range env {
-		if k, v, ok := splitEnvEntry(e); ok {
-			envMap[k] = v
-		}
-	}
-
-	cases := map[string]string{
-		"A2A_SCANNER_LLM_API_KEY":     "test-key",
-		"A2A_SCANNER_LLM_BASE_URL":    "https://openai.example.com",
-		"A2A_SCANNER_LLM_MODEL":       "azure/gpt-4o",
-		"A2A_SCANNER_LLM_API_VERSION": "2024-08-01",
-		"A2A_SCANNER_LLM_PROVIDER":    "openai-compatible",
-	}
-
-	for k, want := range cases {
-		if got := envMap[k]; got != want {
-			t.Errorf("env[%s] = %q, want %q", k, got, want)
-		}
-	}
+	testAzureEnvDerivation(t, "A2A_SCANNER", buildA2AScannerEnv)
 }
 
 func TestBuildA2AScannerEnv_ExistingA2AVarNotOverridden(t *testing.T) {

--- a/utils/scanner/a2a_test.go
+++ b/utils/scanner/a2a_test.go
@@ -1,0 +1,432 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package scanner
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// --- NewA2ARunner / Name ---
+
+func TestNewA2ARunner_DefaultCLIPath(t *testing.T) {
+	t.Parallel()
+
+	r := NewA2ARunner(A2AConfig{})
+	if r.cfg.CLIPath != DefaultA2ACLIPath {
+		t.Errorf("empty CLIPath should default to %q, got %q", DefaultA2ACLIPath, r.cfg.CLIPath)
+	}
+}
+
+func TestNewA2ARunner_CustomCLIPath(t *testing.T) {
+	t.Parallel()
+
+	r := NewA2ARunner(A2AConfig{CLIPath: "/opt/a2a-scanner"})
+	if r.cfg.CLIPath != "/opt/a2a-scanner" {
+		t.Errorf("custom CLIPath should be preserved, got %q", r.cfg.CLIPath)
+	}
+}
+
+func TestA2ARunner_Name(t *testing.T) {
+	t.Parallel()
+
+	r := NewA2ARunner(A2AConfig{})
+	if got := r.Name(); got != "a2a" {
+		t.Errorf("Name() = %q, want %q", got, "a2a")
+	}
+}
+
+// --- Run / no card found ---
+
+func TestA2ARunner_Run_NilRecord_Skipped(t *testing.T) {
+	t.Parallel()
+
+	r := NewA2ARunner(A2AConfig{})
+
+	got, err := r.Run(t.Context(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !got.Skipped || got.SkippedReason == "" {
+		t.Errorf("nil record should be skipped with a reason: %+v", got)
+	}
+}
+
+func TestA2ARunner_Run_NoA2AModule_Skipped(t *testing.T) {
+	t.Parallel()
+
+	r := NewA2ARunner(A2AConfig{})
+
+	data, _ := structpb.NewStruct(map[string]any{
+		"schema_version": "1.0.0",
+		"name":           "no-a2a-here",
+		"modules": []any{
+			map[string]any{"name": "integration/mcp", "data": map[string]any{"name": "x"}},
+		},
+	})
+
+	got, err := r.Run(t.Context(), &corev1.Record{Data: data})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !got.Skipped {
+		t.Error("record with no a2a_data module should be skipped")
+	}
+}
+
+// --- extractA2ACard ---
+
+func TestExtractA2ACard_NilRecord(t *testing.T) {
+	t.Parallel()
+
+	card, ok := extractA2ACard(nil)
+	if ok || card != nil {
+		t.Errorf("nil record should return (nil, false), got (%v, %v)", card, ok)
+	}
+}
+
+func TestExtractA2ACard_NoData(t *testing.T) {
+	t.Parallel()
+
+	card, ok := extractA2ACard(&corev1.Record{})
+	if ok || card != nil {
+		t.Errorf("record with no data should return (nil, false), got (%v, %v)", card, ok)
+	}
+}
+
+func TestExtractA2ACard_Found(t *testing.T) {
+	t.Parallel()
+
+	data, _ := structpb.NewStruct(map[string]any{
+		"schema_version": "1.0.0",
+		"name":           "burger_seller_agent",
+		"modules": []any{
+			map[string]any{
+				"name": "integration/a2a",
+				"data": map[string]any{
+					"a2a_data": map[string]any{
+						"card_data": map[string]any{
+							"name":    "burger_seller_agent",
+							"version": "1.0.0",
+						},
+						"card_schema_version": "v1.0.0",
+					},
+				},
+			},
+		},
+	})
+
+	card, ok := extractA2ACard(&corev1.Record{Data: data})
+	if !ok {
+		t.Fatal("expected a card to be found")
+	}
+
+	if card["name"] != "burger_seller_agent" {
+		t.Errorf("card[name] = %v, want burger_seller_agent", card["name"])
+	}
+}
+
+// --- getNestedStructValue ---
+
+func TestGetNestedStructValue_Nil(t *testing.T) {
+	t.Parallel()
+
+	if got := getNestedStructValue(nil, "a2a_data"); got != nil {
+		t.Errorf("nil struct should return nil, got %v", got)
+	}
+}
+
+func TestGetNestedStructValue_NoKeys(t *testing.T) {
+	t.Parallel()
+
+	s, _ := structpb.NewStruct(map[string]any{"a": 1})
+	if got := getNestedStructValue(s); got != s {
+		t.Errorf("no keys should return the input struct unchanged")
+	}
+}
+
+func TestGetNestedStructValue_MissingKey(t *testing.T) {
+	t.Parallel()
+
+	s, _ := structpb.NewStruct(map[string]any{"other": map[string]any{}})
+	if got := getNestedStructValue(s, "a2a_data"); got != nil {
+		t.Errorf("missing key should return nil, got %v", got)
+	}
+}
+
+func TestGetNestedStructValue_NotAStruct(t *testing.T) {
+	t.Parallel()
+
+	s, _ := structpb.NewStruct(map[string]any{"a2a_data": "not-a-struct"})
+	if got := getNestedStructValue(s, "a2a_data"); got != nil {
+		t.Errorf("non-struct value should return nil, got %v", got)
+	}
+}
+
+func TestGetNestedStructValue_Found(t *testing.T) {
+	t.Parallel()
+
+	s, _ := structpb.NewStruct(map[string]any{
+		"a2a_data": map[string]any{
+			"card_data": map[string]any{"name": "x"},
+		},
+	})
+
+	got := getNestedStructValue(s, "a2a_data", "card_data")
+	if got == nil {
+		t.Fatal("expected a struct value")
+	}
+
+	if got.AsMap()["name"] != "x" {
+		t.Errorf("card_data.name = %v, want x", got.AsMap()["name"])
+	}
+}
+
+// --- parseA2AOutput ---
+
+func TestParseA2AOutput_EmptyBytes(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseA2AOutput([]byte{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !got.Safe {
+		t.Error("empty input should produce Safe=true")
+	}
+}
+
+func TestParseA2AOutput_SafeNoFindings(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"is_safe":true,"findings":[]}`
+
+	got, err := parseA2AOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !got.Safe || len(got.Findings) != 0 {
+		t.Errorf("safe object with no findings: want Safe=true, Findings=0; got %+v", got)
+	}
+}
+
+func TestParseA2AOutput_UnsafeWithFindings(t *testing.T) {
+	t.Parallel()
+
+	raw := `{
+		"is_safe": false,
+		"findings": [
+			{"rule_id":"A2A_RULE1","category":"delegation","severity":"HIGH","description":"unsafe delegation chain"}
+		]
+	}`
+
+	got, err := parseA2AOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Safe {
+		t.Error("is_safe=false should produce Safe=false")
+	}
+
+	if len(got.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(got.Findings))
+	}
+
+	f := got.Findings[0]
+	if f.Severity != SeverityError {
+		t.Errorf("HIGH severity should map to SeverityError, got %q", f.Severity)
+	}
+
+	for _, part := range []string{"A2A_RULE1", "delegation", "unsafe delegation chain"} {
+		if !strings.Contains(f.Message, part) {
+			t.Errorf("message %q should contain %q", f.Message, part)
+		}
+	}
+}
+
+func TestParseA2AOutput_TrustsScannerSafeVerdict(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"is_safe":true,"findings":[
+		{"rule_id":"R1","category":"injection","severity":"CRITICAL","description":"critical"}
+	]}`
+
+	got, err := parseA2AOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !got.Safe {
+		t.Error("is_safe=true should be trusted even when a CRITICAL finding is present")
+	}
+
+	if len(got.Findings) != 1 {
+		t.Errorf("finding must still be surfaced; got %d", len(got.Findings))
+	}
+}
+
+func TestParseA2AOutput_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseA2AOutput([]byte(`not json`))
+	if err == nil {
+		t.Error("invalid JSON should return an error")
+	}
+}
+
+func TestParseA2AOutput_LeadingTextStripped(t *testing.T) {
+	t.Parallel()
+
+	raw := "progress output\n" + `{"is_safe":true,"findings":[]}`
+
+	got, err := parseA2AOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !got.Safe {
+		t.Error("leading non-JSON text should be stripped before parsing")
+	}
+}
+
+// --- trimToA2AJSON ---
+
+func TestTrimToA2AJSON_StartsWithObject(t *testing.T) {
+	t.Parallel()
+
+	in := []byte(`{"a":1}`)
+	if got := string(trimToA2AJSON(in)); got != string(in) {
+		t.Errorf("object JSON should be returned unchanged, got %q", got)
+	}
+}
+
+func TestTrimToA2AJSON_LeadingTextBeforeObject(t *testing.T) {
+	t.Parallel()
+
+	in := []byte("progress output\n{\"a\":1}")
+	want := `{"a":1}`
+
+	if got := string(trimToA2AJSON(in)); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestTrimToA2AJSON_NoJSON(t *testing.T) {
+	t.Parallel()
+
+	in := []byte("no json here")
+	if got := string(trimToA2AJSON(in)); got != string(in) {
+		t.Errorf("no JSON start should return input unchanged, got %q", got)
+	}
+}
+
+// --- mapA2ASeverity ---
+
+func TestMapA2ASeverity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  FindingSeverity
+	}{
+		{"CRITICAL", SeverityError},
+		{"critical", SeverityError},
+		{"HIGH", SeverityError},
+		{"high", SeverityError},
+		{"MEDIUM", SeverityWarning},
+		{"medium", SeverityWarning},
+		{"LOW", SeverityInfo},
+		{"low", SeverityInfo},
+		{"INFO", SeverityInfo},
+		{"UNKNOWN", SeverityInfo},
+		{"", SeverityInfo},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			if got := mapA2ASeverity(tc.input); got != tc.want {
+				t.Errorf("mapA2ASeverity(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- buildA2AScannerEnv ---
+
+func TestBuildA2AScannerEnv_ContainsParentEnv(t *testing.T) {
+	const marker = "TEST_BUILD_A2A_SCANNER_ENV_MARKER"
+	t.Setenv(marker, "present")
+
+	env := buildA2AScannerEnv()
+
+	if !slices.Contains(env, marker+"=present") {
+		t.Error("buildA2AScannerEnv should inherit the parent process environment")
+	}
+}
+
+func TestBuildA2AScannerEnv_MapsAzureVars(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_API_KEY", "test-key")
+	t.Setenv("AZURE_OPENAI_BASE_URL", "https://openai.example.com")
+	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
+	t.Setenv("AZURE_OPENAI_API_VERSION", "2024-08-01")
+
+	// Ensure A2A vars are absent so they get derived.
+	t.Setenv("A2A_SCANNER_LLM_API_KEY", "")
+	t.Setenv("A2A_SCANNER_LLM_BASE_URL", "")
+	t.Setenv("A2A_SCANNER_LLM_MODEL", "")
+	t.Setenv("A2A_SCANNER_LLM_API_VERSION", "")
+	t.Setenv("A2A_SCANNER_LLM_PROVIDER", "")
+
+	env := buildA2AScannerEnv()
+	envMap := make(map[string]string)
+
+	for _, e := range env {
+		if k, v, ok := splitEnvEntry(e); ok {
+			envMap[k] = v
+		}
+	}
+
+	cases := map[string]string{
+		"A2A_SCANNER_LLM_API_KEY":     "test-key",
+		"A2A_SCANNER_LLM_BASE_URL":    "https://openai.example.com",
+		"A2A_SCANNER_LLM_MODEL":       "azure/gpt-4o",
+		"A2A_SCANNER_LLM_API_VERSION": "2024-08-01",
+		"A2A_SCANNER_LLM_PROVIDER":    "openai-compatible",
+	}
+
+	for k, want := range cases {
+		if got := envMap[k]; got != want {
+			t.Errorf("env[%s] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestBuildA2AScannerEnv_ExistingA2AVarNotOverridden(t *testing.T) {
+	t.Setenv("AZURE_OPENAI_API_KEY", "azure-key")
+	t.Setenv("A2A_SCANNER_LLM_API_KEY", "already-set")
+
+	env := buildA2AScannerEnv()
+	envMap := make(map[string]string)
+
+	for _, e := range env {
+		if k, v, ok := splitEnvEntry(e); ok {
+			envMap[k] = v
+		}
+	}
+
+	if got := envMap["A2A_SCANNER_LLM_API_KEY"]; got != "already-set" {
+		t.Errorf("pre-existing A2A_SCANNER_LLM_API_KEY should not be overridden; got %q", got)
+	}
+}

--- a/utils/scanner/mcp.go
+++ b/utils/scanner/mcp.go
@@ -252,7 +252,7 @@ func parseMCPOutput(raw []byte) (*ScanResult, error) {
 		}
 
 		for analyzerName, ar := range r.Findings {
-			severity := mapMCPSeverity(ar.Severity)
+			severity := mapScannerSeverity(ar.Severity)
 			msg := fmt.Sprintf("[%s] %s: %s", analyzerName, r.ToolName, ar.ThreatSummary)
 
 			if len(ar.ThreatNames) > 0 {
@@ -274,15 +274,4 @@ func trimToJSON(raw []byte) []byte {
 	}
 
 	return raw
-}
-
-func mapMCPSeverity(s string) FindingSeverity {
-	switch strings.ToUpper(s) {
-	case "CRITICAL", "HIGH":
-		return SeverityError
-	case "MEDIUM":
-		return SeverityWarning
-	default:
-		return SeverityInfo
-	}
 }

--- a/utils/scanner/mcp_test.go
+++ b/utils/scanner/mcp_test.go
@@ -157,38 +157,6 @@ func TestParseMCPOutput_InvalidJSON(t *testing.T) {
 	}
 }
 
-// --- mapMCPSeverity ---
-
-func TestMapMCPSeverity(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		input string
-		want  FindingSeverity
-	}{
-		{"CRITICAL", SeverityError},
-		{"critical", SeverityError},
-		{"HIGH", SeverityError},
-		{"high", SeverityError},
-		{"MEDIUM", SeverityWarning},
-		{"medium", SeverityWarning},
-		{"LOW", SeverityInfo},
-		{"low", SeverityInfo},
-		{"UNKNOWN", SeverityInfo},
-		{"", SeverityInfo},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			t.Parallel()
-
-			if got := mapMCPSeverity(tc.input); got != tc.want {
-				t.Errorf("mapMCPSeverity(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
 // --- trimToJSON ---
 
 func TestTrimToJSON_AlreadyJSON(t *testing.T) {

--- a/utils/scanner/scanner.go
+++ b/utils/scanner/scanner.go
@@ -29,6 +29,20 @@ type Finding struct {
 	Message  string
 }
 
+// mapScannerSeverity converts a severity string reported by a scanner CLI to a
+// FindingSeverity. The mcp-scanner, skill-scanner, and a2a-scanner binaries all
+// use the same CRITICAL/HIGH/MEDIUM/LOW vocabulary.
+func mapScannerSeverity(s string) FindingSeverity {
+	switch strings.ToUpper(s) {
+	case "CRITICAL", "HIGH":
+		return SeverityError
+	case "MEDIUM":
+		return SeverityWarning
+	default:
+		return SeverityInfo
+	}
+}
+
 // ScanResult is the outcome of running a single runner against a record.
 type ScanResult struct {
 	Safe          bool

--- a/utils/scanner/scanner_test.go
+++ b/utils/scanner/scanner_test.go
@@ -12,6 +12,39 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// --- mapScannerSeverity ---
+
+func TestMapScannerSeverity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  FindingSeverity
+	}{
+		{"CRITICAL", SeverityError},
+		{"critical", SeverityError},
+		{"HIGH", SeverityError},
+		{"high", SeverityError},
+		{"MEDIUM", SeverityWarning},
+		{"medium", SeverityWarning},
+		{"LOW", SeverityInfo},
+		{"low", SeverityInfo},
+		{"INFO", SeverityInfo},
+		{"UNKNOWN", SeverityInfo},
+		{"", SeverityInfo},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			if got := mapScannerSeverity(tc.input); got != tc.want {
+				t.Errorf("mapScannerSeverity(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 // --- merge ---
 
 func TestMerge_Empty(t *testing.T) {

--- a/utils/scanner/skill.go
+++ b/utils/scanner/skill.go
@@ -195,7 +195,7 @@ func parseSkillOutput(raw []byte) (*ScanResult, error) {
 	for _, r := range results {
 		for _, f := range r.Findings {
 			findings = append(findings, Finding{
-				Severity: mapSkillSeverity(f.Severity),
+				Severity: mapScannerSeverity(f.Severity),
 				Message:  fmt.Sprintf("[%s] %s: %s", f.RuleID, f.Category, f.Description),
 			})
 		}
@@ -249,15 +249,4 @@ func parseSkillJSON(raw []byte) ([]skillScanResult, error) {
 	}
 
 	return []skillScanResult{result}, nil
-}
-
-func mapSkillSeverity(s string) FindingSeverity {
-	switch strings.ToUpper(s) {
-	case "CRITICAL", "HIGH":
-		return SeverityError
-	case "MEDIUM":
-		return SeverityWarning
-	default:
-		return SeverityInfo
-	}
 }

--- a/utils/scanner/skill_test.go
+++ b/utils/scanner/skill_test.go
@@ -225,39 +225,6 @@ func TestTrimToSkillJSON_NoJSON(t *testing.T) {
 	}
 }
 
-// --- mapSkillSeverity ---
-
-func TestMapSkillSeverity(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		input string
-		want  FindingSeverity
-	}{
-		{"CRITICAL", SeverityError},
-		{"critical", SeverityError},
-		{"HIGH", SeverityError},
-		{"high", SeverityError},
-		{"MEDIUM", SeverityWarning},
-		{"medium", SeverityWarning},
-		{"LOW", SeverityInfo},
-		{"low", SeverityInfo},
-		{"INFO", SeverityInfo},
-		{"UNKNOWN", SeverityInfo},
-		{"", SeverityInfo},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.input, func(t *testing.T) {
-			t.Parallel()
-
-			if got := mapSkillSeverity(tc.input); got != tc.want {
-				t.Errorf("mapSkillSeverity(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
 // --- skillArtifactBytes ---
 
 func TestSkillArtifactBytes_NilData(t *testing.T) {
@@ -416,19 +383,26 @@ func TestBuildSkillScannerEnv_ContainsParentEnv(t *testing.T) {
 }
 
 func TestBuildSkillScannerEnv_MapsAzureVars(t *testing.T) {
+	testAzureEnvDerivation(t, "SKILL_SCANNER", buildSkillScannerEnv)
+}
+
+// testAzureEnvDerivation verifies that build derives <prefix>_LLM_* values from
+// the AZURE_OPENAI_* environment when none are set explicitly. Shared by the
+// skill and a2a scanner env tests, which map the same variables.
+func testAzureEnvDerivation(t *testing.T, prefix string, build func() []string) {
+	t.Helper()
+
 	t.Setenv("AZURE_OPENAI_API_KEY", "test-key")
 	t.Setenv("AZURE_OPENAI_BASE_URL", "https://openai.example.com")
 	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
 	t.Setenv("AZURE_OPENAI_API_VERSION", "2024-08-01")
 
-	// Ensure SKILL vars are absent so they get derived.
-	t.Setenv("SKILL_SCANNER_LLM_API_KEY", "")
-	t.Setenv("SKILL_SCANNER_LLM_BASE_URL", "")
-	t.Setenv("SKILL_SCANNER_LLM_MODEL", "")
-	t.Setenv("SKILL_SCANNER_LLM_API_VERSION", "")
-	t.Setenv("SKILL_SCANNER_LLM_PROVIDER", "")
+	// Ensure scanner vars are absent so they get derived.
+	for _, suffix := range []string{"API_KEY", "BASE_URL", "MODEL", "API_VERSION", "PROVIDER"} {
+		t.Setenv(prefix+"_LLM_"+suffix, "")
+	}
 
-	env := buildSkillScannerEnv()
+	env := build()
 	envMap := make(map[string]string)
 
 	for _, e := range env {
@@ -438,11 +412,11 @@ func TestBuildSkillScannerEnv_MapsAzureVars(t *testing.T) {
 	}
 
 	cases := map[string]string{
-		"SKILL_SCANNER_LLM_API_KEY":     "test-key",
-		"SKILL_SCANNER_LLM_BASE_URL":    "https://openai.example.com",
-		"SKILL_SCANNER_LLM_MODEL":       "azure/gpt-4o",
-		"SKILL_SCANNER_LLM_API_VERSION": "2024-08-01",
-		"SKILL_SCANNER_LLM_PROVIDER":    "openai-compatible",
+		prefix + "_LLM_API_KEY":     "test-key",
+		prefix + "_LLM_BASE_URL":    "https://openai.example.com",
+		prefix + "_LLM_MODEL":       "azure/gpt-4o",
+		prefix + "_LLM_API_VERSION": "2024-08-01",
+		prefix + "_LLM_PROVIDER":    "openai-compatible",
 	}
 
 	for k, want := range cases {

--- a/utils/scanner/testdata/fakescanner/main.go
+++ b/utils/scanner/testdata/fakescanner/main.go
@@ -1,0 +1,56 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Command fakescanner is a test-only stand-in for the a2a-scanner binary. The
+// scanner tests build it into a temp dir and point A2ARunner.CLIPath at it, so
+// the runner's exec path (Run + runA2AScanner) can be exercised without the
+// real CLI installed. Behaviour is driven by env vars set by the test:
+//
+//	FAKE_A2A_FAIL=1     exit non-zero (simulate a scanner error)
+//	FAKE_A2A_NO_FILE=1  do not write the --output file (simulate missing output)
+//	FAKE_A2A_OUTPUT=... raw bytes to write to the --output file
+//
+// It lives under testdata/ so it is excluded from the module build, `go test`,
+// `go vet`, and golangci-lint (all of which skip testdata directories).
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	args := os.Args[1:]
+
+	if len(args) > 0 && args[0] == "--version" {
+		fmt.Fprintln(os.Stdout, "a2a-scanner 9.9.9-test")
+		os.Exit(0)
+	}
+
+	if os.Getenv("FAKE_A2A_FAIL") == "1" {
+		fmt.Fprintln(os.Stderr, "fake a2a-scanner: forced failure")
+		os.Exit(3)
+	}
+
+	outputPath := ""
+
+	for i, a := range args {
+		if a == "--output" && i+1 < len(args) {
+			outputPath = args[i+1]
+		}
+	}
+
+	if outputPath != "" && os.Getenv("FAKE_A2A_NO_FILE") != "1" {
+		body := os.Getenv("FAKE_A2A_OUTPUT")
+		if body == "" {
+			body = `{"is_safe": true, "findings": []}`
+		}
+
+		if err := os.WriteFile(outputPath, []byte(body), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(4)
+		}
+	}
+
+	os.Exit(0)
+}

--- a/utils/scanner/testdata/fakescanner/main.go
+++ b/utils/scanner/testdata/fakescanner/main.go
@@ -43,7 +43,7 @@ func main() {
 	if outputPath != "" && os.Getenv("FAKE_A2A_NO_FILE") != "1" {
 		body := os.Getenv("FAKE_A2A_OUTPUT")
 		if body == "" {
-			body = `{"is_safe": true, "findings": []}`
+			body = `{"status": "completed", "findings": [], "total_findings": 0, "high_severity_count": 0}`
 		}
 
 		if err := os.WriteFile(outputPath, []byte(body), 0o600); err != nil {


### PR DESCRIPTION
Adds an `A2ARunner` to `utils/scanner` alongside `MCPRunner` and `SkillRunner`. Fixes #1725.

Records that implement the Agent-to-Agent protocol expose an attack surface (inter-agent communication, delegation chains, capability negotiation) that neither mcp-scanner nor skill-scanner assesses. This runner closes that gap using the [a2a-scanner CLI](https://cisco-ai-defense.github.io/docs/a2a-scanner).

## How it works

- The runner fires when a record carries a module whose data holds a `card_data` object (the OASF a2a_data shape, with `card_data` directly under the module's `data`) — matching on data shape rather than module name, the same way the MCP runner keys on `mcp_data`. The AgentCard is written to a temp file and scanned with `a2a-scanner scan-card`.
- Analyzers: `heuristic`, `spec`, and `yara` run by default because they need no third-party credentials or live endpoint. `llm` and `endpoint` are opt-in follow-ups, mirroring how the MCP runner treats its llm/api analyzers.
- Results go through the existing plumbing: `ScanReport` referrer with `scanner_type = A2A` plus a `scan_reports` row. The `SCANNER_TYPE_A2A` enum and DB support were already in place; this adds the missing runner.
- Config follows the existing pattern: `A2ACLIPath` on the scan task, `scan.a2a_cli_path` env binding, sample daemon config, and a `deps:a2a-scanner` Taskfile target (uv package `cisco-ai-a2a-scanner`).
- Since this added a third copy of the severity switch and the Azure env test, the shared parts are now consolidated: one `mapScannerSeverity` used by all three runners, and a `testAzureEnvDerivation` helper shared by the skill/a2a env tests (goconst and dupl were flagging the copies).

## A note on output parsing

a2a-scanner's JSON output schema is not documented upstream. `parseA2AOutput` assumes the `is_safe`/`findings` shape that skill-scanner emits, and the struct doc comment flags this as the single place to adjust if the installed binary differs. Happy to update if a maintainer can share a sample raw output.

## Testing

Unit tests cover card extraction (validated against the repo's OASF record fixtures, including records with no A2A module), output parsing, severity mapping, env derivation, and skip behavior — mirroring the mcp/skill test suites. `go build ./... && go vet ./... && go test ./...` pass in the `utils` and `reconciler` modules.
