### PR TITLE
feat(cli/importer): bump dir importer and upgrade to OASF 1.1.0

### DIFF
--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -31,10 +31,6 @@ on:
         description: "Force push even if record already exists"
         type: boolean
         default: false
-      scanner_enabled:
-        description: "Run security scanner on each MCP record"
-        type: boolean
-        default: true
       server_address:
         description: "Directory server address"
         type: string
@@ -72,7 +68,6 @@ jobs:
       server_address: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.server_address || 'ads.outshift.io:443' }}
       sign: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sign || 'true' }}
       force: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force || 'false' }}
-      scanner_enabled: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.scanner_enabled || 'false' }}
       debug: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug || 'false' }}
       sign_max_retries: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sign_max_retries || '3' }}
       sign_cleanup_on_failure: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.sign_cleanup_on_failure || 'true' }}
@@ -148,21 +143,6 @@ jobs:
           path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
           retention-days: 7
 
-      - name: Install mcp-scanner
-        if: ${{ needs.setup-matrix.outputs.scanner_enabled == 'true' && needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
-        run: |
-          task deps:mcp-scanner
-          mkdir -p .bin
-          install -m 755 "${HOME}/.local/bin/mcp-scanner" .bin/mcp-scanner
-
-      - name: Upload mcp-scanner artifact
-        if: ${{ needs.setup-matrix.outputs.scanner_enabled == 'true' && needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: mcp-scanner
-          path: .bin/mcp-scanner
-          retention-days: 7
-
   import-mcp:
     needs: [setup-matrix, build-dirctl]
     if: ${{ needs.setup-matrix.outputs.run_mcp_import == 'true' && needs.setup-matrix.outputs.mcp_matrix != '[]' }}
@@ -181,7 +161,6 @@ jobs:
       SERVER_ADDRESS: ${{ needs.setup-matrix.outputs.server_address }}
       SIGN: ${{ needs.setup-matrix.outputs.sign }}
       FORCE: ${{ needs.setup-matrix.outputs.force }}
-      SCANNER_ENABLED: ${{ needs.setup-matrix.outputs.scanner_enabled }}
       DEBUG: ${{ needs.setup-matrix.outputs.debug }}
       SIGN_MAX_RETRIES: ${{ needs.setup-matrix.outputs.sign_max_retries }}
       SIGN_CLEANUP_ON_FAILURE: ${{ needs.setup-matrix.outputs.sign_cleanup_on_failure }}
@@ -202,17 +181,6 @@ jobs:
           echo "${GITHUB_WORKSPACE}/.bin" >> "${GITHUB_PATH}"
           echo "dirctl_path=${GITHUB_WORKSPACE}/.bin/dirctl" >> "${GITHUB_OUTPUT}"
 
-      - name: Download mcp-scanner
-        if: ${{ env.SCANNER_ENABLED == 'true' }}
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: mcp-scanner
-          path: .bin
-
-      - name: Prepare mcp-scanner
-        if: ${{ env.SCANNER_ENABLED == 'true' }}
-        run: chmod +x .bin/mcp-scanner
-
       - name: Create Import Config
         env:
           DIRCTL_PATH: ${{ steps.setup-dirctl.outputs.dirctl_path }}
@@ -222,23 +190,18 @@ jobs:
           url: https://registry.modelcontextprotocol.io/v0.1
 
           enricher:
-            requests_per_minute: ${RATE_LIMIT}
-            tool_host:
-              model: azure:gpt-4o
-              max_steps: 10
-              mcp_servers:
-                dir-mcp-server:
-                  command: ${DIRCTL_PATH}
-                  args: [mcp, serve]
-                  env:
-                    OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
-                    DIRECTORY_CLIENT_AUTH_MODE: insecure
-
-          scanner:
-            enabled: ${SCANNER_ENABLED}
-            cli_path: ${GITHUB_WORKSPACE}/.bin/mcp-scanner
-            timeout: 5m
-            fail_on_error: true
+            llm:
+              requests_per_minute: ${RATE_LIMIT}
+              tool_host:
+                model: azure:gpt-4o
+                max_steps: 10
+                mcp_servers:
+                  dir-mcp-server:
+                    command: ${DIRCTL_PATH}
+                    args: [mcp, serve]
+                    env:
+                      OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
+                      DIRECTORY_CLIENT_AUTH_MODE: insecure
           EOF
 
       - name: Fetch Directory OIDC token
@@ -447,17 +410,18 @@ jobs:
           ${AUTHORS_YAML}
 
           enricher:
-            requests_per_minute: ${RATE_LIMIT}
-            tool_host:
-              model: azure:gpt-4o
-              max_steps: 10
-              mcp_servers:
-                dir-mcp-server:
-                  command: ${DIRCTL_PATH}
-                  args: [mcp, serve]
-                  env:
-                    OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
-                    DIRECTORY_CLIENT_AUTH_MODE: insecure
+            llm:
+              requests_per_minute: ${RATE_LIMIT}
+              tool_host:
+                model: azure:gpt-4o
+                max_steps: 10
+                mcp_servers:
+                  dir-mcp-server:
+                    command: ${DIRCTL_PATH}
+                    args: [mcp, serve]
+                    env:
+                      OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
+                      DIRECTORY_CLIENT_AUTH_MODE: insecure
           EOF
 
       - name: Fetch Directory OIDC token

--- a/api/go.mod
+++ b/api/go.mod
@@ -6,7 +6,7 @@ require (
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260703134920-dbfa1736bef5.1
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260703134941-ebce38fee5a5.1
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5
+	github.com/agntcy/oasf-sdk/pkg v1.1.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/opencontainers/go-digest v1.0.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -6,8 +6,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-202604152011
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 h1:xUBFl8T0CJb0SPZDcNXlBpYGu1v7dvPa0RPouHkPGIw=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.1.0 h1:Z2CfQ+XIjoHvlw2P0jcTRs59nbgVpjdnSVGGxmJTIEo=
+github.com/agntcy/oasf-sdk/pkg v1.1.0/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/cli/cmd/import/config.go
+++ b/cli/cmd/import/config.go
@@ -14,6 +14,8 @@ import (
 	enricherconfig "github.com/agntcy/dir-importer/enricher/config"
 	"github.com/agntcy/dir-importer/enricher/toolhost"
 	scannerconfig "github.com/agntcy/dir-importer/scanner/config"
+	internalextractor "github.com/agntcy/dir/cli/internal/extractor"
+	sdk "github.com/agntcy/oasf-sdk/pkg/extractor"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 )
@@ -36,13 +38,29 @@ type importFileConfig struct {
 }
 
 type enricherFileConfig struct {
+	LLM       *llmEnricherFileConfig       `yaml:"llm"`
+	Static    *staticEnricherFileConfig    `yaml:"static"`
+	Extractor *extractorEnricherFileConfig `yaml:"extractor"`
+}
+
+// extractorEnricherFileConfig configures the local OASF extractor enricher.
+// Both fields are optional: when absent the extractor uses the config saved by
+// `dirctl init`; explicit values override it.
+type extractorEnricherFileConfig struct {
+	OASFUrl  string `yaml:"oasf_url"`
+	AssetDir string `yaml:"asset_dir"`
+}
+
+type llmEnricherFileConfig struct {
 	ToolHost              *toolHostFileConfig `yaml:"tool_host"`
 	SkillsPromptTemplate  string              `yaml:"skills_prompt_template"`
 	DomainsPromptTemplate string              `yaml:"domains_prompt_template"`
 	RequestsPerMinute     int                 `yaml:"requests_per_minute"`
-	SkipEnricher          bool                `yaml:"skip_enricher"`
-	Skills                []taxonomyEntry     `yaml:"skills"`
-	Domains               []taxonomyEntry     `yaml:"domains"`
+}
+
+type staticEnricherFileConfig struct {
+	Skills  []taxonomyEntry `yaml:"skills"`
+	Domains []taxonomyEntry `yaml:"domains"`
 }
 
 type toolHostFileConfig struct {
@@ -90,9 +108,8 @@ func (d *yamlDuration) UnmarshalYAML(value *yaml.Node) error {
 //nolint:nestif
 func (o *options) loadConfig(flags *pflag.FlagSet) error {
 	o.Scanner = defaultScannerConfig()
-	o.Enricher.RequestsPerMinute = enricherconfig.DefaultRequestsPerMinute
 
-	fileHasToolHost := false
+	fileHasEnricher := false
 
 	if o.ConfigFile != "" {
 		fc, err := parseConfigFile(o.ConfigFile)
@@ -100,7 +117,7 @@ func (o *options) loadConfig(flags *pflag.FlagSet) error {
 			return err
 		}
 
-		fileHasToolHost = fc.Enricher.ToolHost != nil
+		fileHasEnricher = fc.Enricher.LLM != nil || fc.Enricher.Static != nil || fc.Enricher.Extractor != nil
 
 		// The flags share storage with the config.Config fields, so applying the
 		// file config below overwrites any flag value. Snapshot the explicitly-set
@@ -129,6 +146,21 @@ func (o *options) loadConfig(flags *pflag.FlagSet) error {
 		if flagFilters != nil {
 			o.Filters = flagFilters
 		}
+
+		// Extractor enricher needs a live SDK instance; load it after all file
+		// config is applied and flags are restored.
+		if fc.Enricher.Extractor != nil {
+			sdkExt, loadErr := loadExtractorFromConfig(fc.Enricher.Extractor)
+			if loadErr != nil {
+				return fmt.Errorf("extractor enricher: %w", loadErr)
+			}
+
+			o.Enricher = enricherconfig.Config{
+				Extractor: &enricherconfig.ExtractorConfig{
+					Extractor: &oasfExtractorAdapter{ext: sdkExt},
+				},
+			}
+		}
 	}
 
 	// --type binds to a plain string (TypeFlag); map it onto the typed field,
@@ -137,11 +169,15 @@ func (o *options) loadConfig(flags *pflag.FlagSet) error {
 		o.Type = config.ImportType(o.TypeFlag)
 	}
 
-	// Enricher tool host: an inline enricher.tool_host in the file wins;
-	// otherwise fall back to the built-in default. Not needed when enrichment is
-	// skipped.
-	if !o.Enricher.SkipEnricher && !fileHasToolHost {
-		o.Enricher.ToolHost = defaultToolHostConfig()
+	// Default to LLM enrichment with the built-in tool host when no enricher
+	// method was provided via the config file.
+	if !fileHasEnricher {
+		o.Enricher = enricherconfig.Config{
+			LLM: &enricherconfig.LLMConfig{
+				ToolHost:          defaultToolHostConfig(),
+				RequestsPerMinute: enricherconfig.DefaultRequestsPerMinute,
+			},
+		}
 	}
 
 	return nil
@@ -154,9 +190,6 @@ func parseConfigFile(path string) (importFileConfig, error) {
 		Scanner: scannerFileConfig{
 			Timeout: yamlDuration(scannerconfig.DefaultTimeout),
 			CLIPath: scannerconfig.DefaultCLIPath,
-		},
-		Enricher: enricherFileConfig{
-			RequestsPerMinute: enricherconfig.DefaultRequestsPerMinute,
 		},
 	}
 
@@ -215,30 +248,39 @@ func applyFileConfig(fc importFileConfig, cfg *config.Config) {
 		FailOnWarning: fc.Scanner.FailOnWarning,
 	}
 
-	cfg.Enricher.RequestsPerMinute = fc.Enricher.RequestsPerMinute
+	if fc.Enricher.LLM != nil {
+		llm := fc.Enricher.LLM
+		llmCfg := &enricherconfig.LLMConfig{
+			RequestsPerMinute:     llm.RequestsPerMinute,
+			SkillsPromptTemplate:  llm.SkillsPromptTemplate,
+			DomainsPromptTemplate: llm.DomainsPromptTemplate,
+		}
 
-	if fc.Enricher.SkillsPromptTemplate != "" {
-		cfg.Enricher.SkillsPromptTemplate = fc.Enricher.SkillsPromptTemplate
-	}
+		if llmCfg.RequestsPerMinute == 0 {
+			llmCfg.RequestsPerMinute = enricherconfig.DefaultRequestsPerMinute
+		}
 
-	if fc.Enricher.DomainsPromptTemplate != "" {
-		cfg.Enricher.DomainsPromptTemplate = fc.Enricher.DomainsPromptTemplate
-	}
+		if llm.ToolHost != nil {
+			llmCfg.ToolHost = toToolHostConfig(*llm.ToolHost)
+		} else {
+			llmCfg.ToolHost = defaultToolHostConfig()
+		}
 
-	cfg.Enricher.SkipEnricher = fc.Enricher.SkipEnricher
+		cfg.Enricher = enricherconfig.Config{LLM: llmCfg}
+	} else if fc.Enricher.Static != nil {
+		staticCfg := &enricherconfig.StaticConfig{}
 
-	for _, s := range fc.Enricher.Skills {
-		cfg.Enricher.Skills = append(cfg.Enricher.Skills,
-			typesv1.Skill_builder{Name: s.Name, Id: s.ID}.Build())
-	}
+		for _, s := range fc.Enricher.Static.Skills {
+			staticCfg.Skills = append(staticCfg.Skills,
+				typesv1.Skill_builder{Name: s.Name, Id: s.ID}.Build())
+		}
 
-	for _, d := range fc.Enricher.Domains {
-		cfg.Enricher.Domains = append(cfg.Enricher.Domains,
-			typesv1.Domain_builder{Name: d.Name, Id: d.ID}.Build())
-	}
+		for _, d := range fc.Enricher.Static.Domains {
+			staticCfg.Domains = append(staticCfg.Domains,
+				typesv1.Domain_builder{Name: d.Name, Id: d.ID}.Build())
+		}
 
-	if fc.Enricher.ToolHost != nil {
-		cfg.Enricher.ToolHost = toToolHostConfig(*fc.Enricher.ToolHost)
+		cfg.Enricher = enricherconfig.Config{Static: staticCfg}
 	}
 }
 
@@ -268,6 +310,30 @@ func defaultScannerConfig() scannerconfig.Config {
 		FailOnError:   scannerconfig.DefaultFailOnError,
 		FailOnWarning: scannerconfig.DefaultFailOnWarning,
 	}
+}
+
+// loadExtractorFromConfig loads the local OASF extractor for the extractor enricher.
+// When both OASFUrl and AssetDir are empty it defers to the config saved by
+// `dirctl init`; explicit values override the saved config.
+func loadExtractorFromConfig(fc *extractorEnricherFileConfig) (*sdk.Extractor, error) {
+	if fc.OASFUrl == "" && fc.AssetDir == "" {
+		ext, err := internalextractor.LoadConfigured()
+		if err != nil {
+			return nil, fmt.Errorf("load configured extractor: %w", err)
+		}
+
+		return ext, nil
+	}
+
+	ext, err := internalextractor.Load(internalextractor.Config{
+		OASFURL:  fc.OASFUrl,
+		AssetDir: fc.AssetDir,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load extractor: %w", err)
+	}
+
+	return ext, nil
 }
 
 // defaultToolHostConfig is the built-in enricher tool host used when neither the

--- a/cli/cmd/import/config.go
+++ b/cli/cmd/import/config.go
@@ -7,13 +7,11 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"time"
 
 	typesv1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1"
 	"github.com/agntcy/dir-importer/config"
 	enricherconfig "github.com/agntcy/dir-importer/enricher/config"
 	"github.com/agntcy/dir-importer/enricher/toolhost"
-	scannerconfig "github.com/agntcy/dir-importer/scanner/config"
 	internalextractor "github.com/agntcy/dir/cli/internal/extractor"
 	sdk "github.com/agntcy/oasf-sdk/pkg/extractor"
 	"github.com/spf13/pflag"
@@ -34,7 +32,6 @@ type importFileConfig struct {
 	Debug     bool               `yaml:"debug"`
 	Authors   []string           `yaml:"authors"`
 	Enricher  enricherFileConfig `yaml:"enricher"`
-	Scanner   scannerFileConfig  `yaml:"scanner"`
 }
 
 type enricherFileConfig struct {
@@ -75,31 +72,9 @@ type mcpServerFileConfig struct {
 	Env     map[string]any `yaml:"env"`
 }
 
-type scannerFileConfig struct {
-	Enabled       bool         `yaml:"enabled"`
-	Timeout       yamlDuration `yaml:"timeout"`
-	CLIPath       string       `yaml:"cli_path"`
-	FailOnError   bool         `yaml:"fail_on_error"`
-	FailOnWarning bool         `yaml:"fail_on_warning"`
-}
-
 type taxonomyEntry struct {
 	Name string `yaml:"name"`
 	ID   uint32 `yaml:"id"`
-}
-
-// yamlDuration allows duration strings ("5m", "30s") in YAML config files.
-type yamlDuration time.Duration
-
-func (d *yamlDuration) UnmarshalYAML(value *yaml.Node) error {
-	v, err := time.ParseDuration(value.Value)
-	if err != nil {
-		return fmt.Errorf("invalid duration %q: %w", value.Value, err)
-	}
-
-	*d = yamlDuration(v)
-
-	return nil
 }
 
 // loadConfig populates the importer config (o.Config) from the optional --config
@@ -107,8 +82,6 @@ func (d *yamlDuration) UnmarshalYAML(value *yaml.Node) error {
 //
 //nolint:nestif
 func (o *options) loadConfig(flags *pflag.FlagSet) error {
-	o.Scanner = defaultScannerConfig()
-
 	fileHasEnricher := false
 
 	if o.ConfigFile != "" {
@@ -186,12 +159,7 @@ func (o *options) loadConfig(flags *pflag.FlagSet) error {
 // parseConfigFile reads and decodes the YAML config file into importFileConfig.
 // Non-zero defaults are pre-seeded so unmentioned fields retain their defaults.
 func parseConfigFile(path string) (importFileConfig, error) {
-	fc := importFileConfig{
-		Scanner: scannerFileConfig{
-			Timeout: yamlDuration(scannerconfig.DefaultTimeout),
-			CLIPath: scannerconfig.DefaultCLIPath,
-		},
-	}
+	var fc importFileConfig
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -238,14 +206,6 @@ func applyFileConfig(fc importFileConfig, cfg *config.Config) {
 
 	if len(fc.Authors) > 0 {
 		cfg.Authors = fc.Authors
-	}
-
-	cfg.Scanner = scannerconfig.Config{
-		Enabled:       fc.Scanner.Enabled,
-		Timeout:       time.Duration(fc.Scanner.Timeout),
-		CLIPath:       fc.Scanner.CLIPath,
-		FailOnError:   fc.Scanner.FailOnError,
-		FailOnWarning: fc.Scanner.FailOnWarning,
 	}
 
 	if fc.Enricher.LLM != nil {
@@ -299,16 +259,6 @@ func toToolHostConfig(fc toolHostFileConfig) toolhost.Config {
 		Model:      fc.Model,
 		MaxSteps:   fc.MaxSteps,
 		MCPServers: servers,
-	}
-}
-
-func defaultScannerConfig() scannerconfig.Config {
-	return scannerconfig.Config{
-		Enabled:       scannerconfig.DefaultScannerEnabled,
-		Timeout:       scannerconfig.DefaultTimeout,
-		CLIPath:       scannerconfig.DefaultCLIPath,
-		FailOnError:   scannerconfig.DefaultFailOnError,
-		FailOnWarning: scannerconfig.DefaultFailOnWarning,
 	}
 }
 

--- a/cli/cmd/import/config_test.go
+++ b/cli/cmd/import/config_test.go
@@ -7,10 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	enricherconfig "github.com/agntcy/dir-importer/enricher/config"
-	scannerconfig "github.com/agntcy/dir-importer/scanner/config"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,8 +66,6 @@ func TestLoadConfigDefaultsWithoutFile(t *testing.T) {
 
 	require.NoError(t, o.loadConfig(flags))
 
-	assert.Equal(t, scannerconfig.DefaultTimeout, o.Scanner.Timeout)
-	assert.Equal(t, scannerconfig.DefaultScannerEnabled, o.Scanner.Enabled)
 	require.NotNil(t, o.Enricher.LLM)
 	assert.Equal(t, enricherconfig.DefaultRequestsPerMinute, o.Enricher.LLM.RequestsPerMinute)
 	assert.Equal(t, "azure:gpt-4o", o.Enricher.LLM.ToolHost.Model)
@@ -82,11 +78,6 @@ url: https://registry.example.com/v0.1
 filters:
   search: analytics
 limit: 100
-scanner:
-  enabled: true
-  timeout: 30s
-  cli_path: /usr/local/bin/mcp-scanner
-  fail_on_error: true
 enricher:
   llm:
     requests_per_minute: 7
@@ -108,10 +99,6 @@ enricher:
 	assert.Equal(t, "https://registry.example.com/v0.1", o.RegistryURL)
 	assert.Equal(t, map[string]string{"search": "analytics"}, o.Filters)
 	assert.Equal(t, 100, o.Limit)
-	assert.True(t, o.Scanner.Enabled)
-	assert.Equal(t, 30*time.Second, o.Scanner.Timeout)
-	assert.Equal(t, "/usr/local/bin/mcp-scanner", o.Scanner.CLIPath)
-	assert.True(t, o.Scanner.FailOnError)
 	require.NotNil(t, o.Enricher.LLM)
 	assert.Equal(t, 7, o.Enricher.LLM.RequestsPerMinute)
 	assert.Equal(t, 12, o.Enricher.LLM.ToolHost.MaxSteps)

--- a/cli/cmd/import/config_test.go
+++ b/cli/cmd/import/config_test.go
@@ -70,9 +70,9 @@ func TestLoadConfigDefaultsWithoutFile(t *testing.T) {
 
 	assert.Equal(t, scannerconfig.DefaultTimeout, o.Scanner.Timeout)
 	assert.Equal(t, scannerconfig.DefaultScannerEnabled, o.Scanner.Enabled)
-	assert.Equal(t, enricherconfig.DefaultRequestsPerMinute, o.Enricher.RequestsPerMinute)
-	// tool-host falls back to the embedded default enricher.json.
-	assert.Equal(t, "azure:gpt-4o", o.Enricher.ToolHost.Model)
+	require.NotNil(t, o.Enricher.LLM)
+	assert.Equal(t, enricherconfig.DefaultRequestsPerMinute, o.Enricher.LLM.RequestsPerMinute)
+	assert.Equal(t, "azure:gpt-4o", o.Enricher.LLM.ToolHost.Model)
 }
 
 func TestLoadConfigFromFile(t *testing.T) {
@@ -88,16 +88,17 @@ scanner:
   cli_path: /usr/local/bin/mcp-scanner
   fail_on_error: true
 enricher:
-  requests_per_minute: 7
-  tool_host:
-    model: azure:gpt-4o
-    max_steps: 12
-    mcp_servers:
-      dir-mcp-server:
-        command: dirctl
-        args: [mcp, serve]
-        env:
-          OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
+  llm:
+    requests_per_minute: 7
+    tool_host:
+      model: azure:gpt-4o
+      max_steps: 12
+      mcp_servers:
+        dir-mcp-server:
+          command: dirctl
+          args: [mcp, serve]
+          env:
+            OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
 `)
 
 	o, flags := newTestOptions(t, "--config", path)
@@ -111,8 +112,9 @@ enricher:
 	assert.Equal(t, 30*time.Second, o.Scanner.Timeout)
 	assert.Equal(t, "/usr/local/bin/mcp-scanner", o.Scanner.CLIPath)
 	assert.True(t, o.Scanner.FailOnError)
-	assert.Equal(t, 7, o.Enricher.RequestsPerMinute)
-	assert.Equal(t, 12, o.Enricher.ToolHost.MaxSteps)
+	require.NotNil(t, o.Enricher.LLM)
+	assert.Equal(t, 7, o.Enricher.LLM.RequestsPerMinute)
+	assert.Equal(t, 12, o.Enricher.LLM.ToolHost.MaxSteps)
 }
 
 // TestSignIsFlagOnly verifies that signing is driven by flags and that a sign:
@@ -143,21 +145,23 @@ func TestToolHostEnvKeysPreserveCase(t *testing.T) {
 type: mcp-registry
 url: https://registry.example.com/v0.1
 enricher:
-  tool_host:
-    model: azure:gpt-4o
-    mcp_servers:
-      dir-mcp-server:
-        command: dirctl
-        args: [mcp, serve]
-        env:
-          OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
-          DIRECTORY_CLIENT_AUTH_MODE: insecure
+  llm:
+    tool_host:
+      model: azure:gpt-4o
+      mcp_servers:
+        dir-mcp-server:
+          command: dirctl
+          args: [mcp, serve]
+          env:
+            OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
+            DIRECTORY_CLIENT_AUTH_MODE: insecure
 `)
 
 	o, flags := newTestOptions(t, "--config", path)
 	require.NoError(t, o.loadConfig(flags))
 
-	server, ok := o.Enricher.ToolHost.MCPServers["dir-mcp-server"]
+	require.NotNil(t, o.Enricher.LLM)
+	server, ok := o.Enricher.LLM.ToolHost.MCPServers["dir-mcp-server"]
 	require.True(t, ok)
 	assert.Equal(t, "https://schema.oasf.outshift.com", server.Env["OASF_API_VALIDATION_SCHEMA_URL"])
 	assert.Equal(t, "insecure", server.Env["DIRECTORY_CLIENT_AUTH_MODE"])
@@ -191,32 +195,31 @@ filters:
 	assert.Equal(t, map[string]string{"search": "devtools"}, o.Filters)
 }
 
-func TestLoadConfigSkipEnricher(t *testing.T) {
+func TestLoadConfigStaticEnricher(t *testing.T) {
 	path := writeConfig(t, `
 type: mcp-registry
 url: https://registry.example.com/v0.1
 enricher:
-  skip_enricher: true
-  skills:
-    - name: natural_language_processing/text_completion
-      id: 10201
-  domains:
-    - name: technology
-      id: 1
+  static:
+    skills:
+      - name: natural_language_processing/text_completion
+        id: 10201
+    domains:
+      - name: technology
+        id: 1
 `)
 
 	o, flags := newTestOptions(t, "--config", path)
 	require.NoError(t, o.loadConfig(flags))
 
-	assert.True(t, o.Enricher.SkipEnricher)
-	require.Len(t, o.Enricher.Skills, 1)
-	assert.Equal(t, "natural_language_processing/text_completion", o.Enricher.Skills[0].GetName())
-	assert.Equal(t, uint32(10201), o.Enricher.Skills[0].GetId())
-	require.Len(t, o.Enricher.Domains, 1)
-	assert.Equal(t, "technology", o.Enricher.Domains[0].GetName())
-	assert.Equal(t, uint32(1), o.Enricher.Domains[0].GetId())
+	require.NotNil(t, o.Enricher.Static)
+	require.Len(t, o.Enricher.Static.Skills, 1)
+	assert.Equal(t, "natural_language_processing/text_completion", o.Enricher.Static.Skills[0].GetName())
+	assert.Equal(t, uint32(10201), o.Enricher.Static.Skills[0].GetId())
+	require.Len(t, o.Enricher.Static.Domains, 1)
+	assert.Equal(t, "technology", o.Enricher.Static.Domains[0].GetName())
+	assert.Equal(t, uint32(1), o.Enricher.Static.Domains[0].GetId())
 
-	// Skipping enrichment must not require a tool host, and the config must validate.
 	require.NoError(t, o.Enricher.Validate())
 }
 
@@ -226,9 +229,10 @@ func TestReferenceConfigIsValid(t *testing.T) {
 	require.NoError(t, o.loadConfig(flags))
 
 	assert.Equal(t, "mcp-registry", string(o.Type))
-	assert.Equal(t, "azure:gpt-4o", o.Enricher.ToolHost.Model)
+	require.NotNil(t, o.Enricher.LLM)
+	assert.Equal(t, "azure:gpt-4o", o.Enricher.LLM.ToolHost.Model)
 
-	server, ok := o.Enricher.ToolHost.MCPServers["dir-mcp-server"]
+	server, ok := o.Enricher.LLM.ToolHost.MCPServers["dir-mcp-server"]
 	require.True(t, ok)
 	assert.Equal(t, "https://schema.oasf.outshift.com", server.Env["OASF_API_VALIDATION_SCHEMA_URL"])
 }

--- a/cli/cmd/import/extractor_adapter.go
+++ b/cli/cmd/import/extractor_adapter.go
@@ -1,0 +1,37 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package importcmd
+
+import (
+	"context"
+	"fmt"
+
+	enricherconfig "github.com/agntcy/dir-importer/enricher/config"
+	sdk "github.com/agntcy/oasf-sdk/pkg/extractor"
+)
+
+// oasfExtractorAdapter adapts *sdk.Extractor to enricherconfig.RecordExtractor so
+// the import pipeline can use the local OASF extractor for in-process enrichment.
+type oasfExtractorAdapter struct {
+	ext *sdk.Extractor
+}
+
+func (a *oasfExtractorAdapter) Extract(ctx context.Context, text string) (enricherconfig.ExtractResult, error) {
+	result, err := a.ext.Extract(ctx, text)
+	if err != nil {
+		return enricherconfig.ExtractResult{}, fmt.Errorf("extract taxonomy: %w", err)
+	}
+
+	skills := make([]enricherconfig.TaxonomyClass, len(result.Skills))
+	for i, s := range result.Skills {
+		skills[i] = enricherconfig.TaxonomyClass{ID: uint32(s.ID), Name: s.Name} //nolint:gosec
+	}
+
+	domains := make([]enricherconfig.TaxonomyClass, len(result.Domains))
+	for i, d := range result.Domains {
+		domains[i] = enricherconfig.TaxonomyClass{ID: uint32(d.ID), Name: d.Name} //nolint:gosec
+	}
+
+	return enricherconfig.ExtractResult{Skills: skills, Domains: domains}, nil
+}

--- a/cli/cmd/import/extractor_adapter.go
+++ b/cli/cmd/import/extractor_adapter.go
@@ -18,7 +18,10 @@ type oasfExtractorAdapter struct {
 }
 
 func (a *oasfExtractorAdapter) Extract(ctx context.Context, text string) (enricherconfig.ExtractResult, error) {
-	result, err := a.ext.Extract(ctx, text)
+	// Latest() restricts results to classes present in the newest provisioned OASF version,
+	// preventing stale classes from older versions (e.g. 0.8.0) from being assigned to records
+	// that will be validated against the current schema.
+	result, err := a.ext.Extract(ctx, text, sdk.Latest())
 	if err != nil {
 		return enricherconfig.ExtractResult{}, fmt.Errorf("extract taxonomy: %w", err)
 	}

--- a/cli/cmd/import/import.config.yaml
+++ b/cli/cmd/import/import.config.yaml
@@ -54,13 +54,6 @@ enricher:
   #   oasf_url: https://schema.oasf.outshift.com
   #   asset_dir: ~/.agntcy/oasf-sdk/extractor
 
-scanner:
-  enabled: true
-  timeout: 5m
-  cli_path: /usr/local/bin/mcp-scanner
-  fail_on_error: true
-  fail_on_warning: false
-
 output_dir: ./import-out
 dry_run: false
 force: false

--- a/cli/cmd/import/import.config.yaml
+++ b/cli/cmd/import/import.config.yaml
@@ -21,30 +21,38 @@ limit: 100                    # 0 = no limit
 #   - "ACME Corp"
 
 enricher:
-  tool_host:
-    model: azure:gpt-4o
-    max_steps: 10
-    mcp_servers:
-      dir-mcp-server:
-        command: dirctl
-        args: [mcp, serve]
-        env:
-          OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
-          DIRECTORY_CLIENT_AUTH_MODE: insecure
-  # skills_prompt_template: ./prompts/skills.md
-  # domains_prompt_template: ./prompts/domains.md
-  requests_per_minute: 5
+  # Choose one of: llm (default) or static.
+  llm:
+    tool_host:
+      model: azure:gpt-4o
+      max_steps: 10
+      mcp_servers:
+        dir-mcp-server:
+          command: dirctl
+          args: [mcp, serve]
+          env:
+            OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
+            DIRECTORY_CLIENT_AUTH_MODE: insecure
+    # skills_prompt_template: ./prompts/skills.md
+    # domains_prompt_template: ./prompts/domains.md
+    requests_per_minute: 5
 
-  # Skip LLM-based enrichment entirely and tag every imported record with the
-  # static skills/domains below (each entry needs a name and/or numeric id).
-  # When skip_enricher is true, the tool_host above is not required.
-  # skip_enricher: false
-  # skills:
-  #   - name: language_processing/language_generation/dialogue_generation
-  #     id: 10304
-  # domains:
-  #   - name: technology/software_engineering
-  #     id: 102
+  # Replace the "llm:" block above with "static:" to stamp every imported
+  # record with a fixed set of skills/domains (no LLM or local model needed).
+  # static:
+  #   skills:
+  #     - name: language_processing/language_generation/dialogue_generation
+  #       id: 10304
+  #   domains:
+  #     - name: technology/software_engineering
+  #       id: 102
+
+  # Or use "extractor:" for in-process, LLM-free enrichment using the local
+  # OASF taxonomy model (requires `dirctl init` to have been run first).
+  # Both fields are optional — omit them to use the config saved by dirctl init.
+  # extractor:
+  #   oasf_url: https://schema.oasf.outshift.com
+  #   asset_dir: ~/.agntcy/oasf-sdk/extractor
 
 scanner:
   enabled: true

--- a/cli/cmd/import/import.go
+++ b/cli/cmd/import/import.go
@@ -117,20 +117,6 @@ func printSummary(cmd *cobra.Command, result *types.ImportResult) {
 		}
 	}
 
-	if len(result.ScannerFindings) > 0 {
-		presenter.Printf(cmd, "\n=== Scanner findings ===\n")
-
-		for i, msg := range result.ScannerFindings {
-			if i < maxErrors {
-				presenter.Printf(cmd, "  - %s\n", msg)
-			}
-		}
-
-		if len(result.ScannerFindings) > maxErrors {
-			presenter.Printf(cmd, "  ... and %d more\n", len(result.ScannerFindings)-maxErrors)
-		}
-	}
-
 	if opts.DryRun {
 		presenter.Printf(cmd, "\nNote: This was a dry run. No records were actually imported.\n")
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260703134941-ebce38fee5a5.1
-	github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5
+	github.com/agntcy/dir-importer v1.5.0
 	github.com/agntcy/dir-mcp v1.3.2
 	github.com/agntcy/dir-runtime/discovery v1.3.2
 	github.com/agntcy/dir-runtime/server v1.3.2

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260703134941-ebce38fee5a5.1
-	github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400
+	github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5
 	github.com/agntcy/dir-mcp v1.3.2
 	github.com/agntcy/dir-runtime/discovery v1.3.2
 	github.com/agntcy/dir-runtime/server v1.3.2
@@ -30,7 +30,7 @@ require (
 	github.com/agntcy/dir/reconciler v1.5.0
 	github.com/agntcy/dir/server v1.5.0
 	github.com/agntcy/dir/utils v1.6.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7
+	github.com/agntcy/oasf-sdk/pkg v1.1.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/ipfs/go-cid v0.6.1
 	github.com/libp2p/go-libp2p v0.48.0

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260703134941-ebce38fee5a5.1
-	github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281
+	github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400
 	github.com/agntcy/dir-mcp v1.3.2
 	github.com/agntcy/dir-runtime/discovery v1.3.2
 	github.com/agntcy/dir-runtime/server v1.3.2

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260703134941-ebce38fee5a5.1
-	github.com/agntcy/dir-importer v1.4.2-0.20260713172338-b92ad73bc0dd
+	github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281
 	github.com/agntcy/dir-mcp v1.3.2
 	github.com/agntcy/dir-runtime/discovery v1.3.2
 	github.com/agntcy/dir-runtime/server v1.3.2
@@ -508,7 +508,7 @@ require (
 	github.com/libp2p/go-reuseport v0.4.0 // indirect
 	github.com/libp2p/go-yamux/v5 v5.1.0 // indirect
 	github.com/libp2p/zeroconf/v2 v2.2.0 // indirect
-	github.com/mark3labs/mcp-go v0.54.1 // indirect
+	github.com/mark3labs/mcp-go v0.56.0 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/miekg/dns v1.1.72 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -200,6 +200,8 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281 h1:x2ikF1DWCKjT7NCwQMP7PZ86Fx34WyGvM969/egC0yk=
 github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281/go.mod h1:+sNVLiYPRTfac7/pKJq4UtF8lYXYOhq8JFAp5F78Brw=
+github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400 h1:7ptXH8lLd7dGFxKDbHngm23Bj0DK+TGrJKhW4190ZiY=
+github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400/go.mod h1:NsyBBP2WAPI5ukJov1kWPd/LbzdH+RYCvclGiAAI810=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.2-0.20260713172338-b92ad73bc0dd h1:z88/qXfr5KNBULyunJ/hUAPLTJgNxrNdrL//gTQ3HHE=
-github.com/agntcy/dir-importer v1.4.2-0.20260713172338-b92ad73bc0dd/go.mod h1:emTmHmARlhxAF9giWVukFW5Yvx63QZbpPBUEoqrA8xA=
+github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281 h1:x2ikF1DWCKjT7NCwQMP7PZ86Fx34WyGvM969/egC0yk=
+github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281/go.mod h1:+sNVLiYPRTfac7/pKJq4UtF8lYXYOhq8JFAp5F78Brw=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=
@@ -1190,8 +1190,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/marcopolo/simnet v0.0.4 h1:50Kx4hS9kFGSRIbrt9xUS3NJX33EyPqHVmpXvaKLqrY=
 github.com/marcopolo/simnet v0.0.4/go.mod h1:tfQF1u2DmaB6WHODMtQaLtClEf3a296CKQLq5gAsIS0=
-github.com/mark3labs/mcp-go v0.54.1 h1:Ap/ptEB9FtWzFKM8NDsTA7QDxerQOC06eZigrTldVj0=
-github.com/mark3labs/mcp-go v0.54.1/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
+github.com/mark3labs/mcp-go v0.56.0 h1:7aCj2wODCskMi08f923ADG+EfELZBdiKILny415cIS8=
+github.com/mark3labs/mcp-go v0.56.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/masahiro331/go-disk v0.0.0-20260423015231-f7a470ebd472 h1:QAY4If99Ee10TUP4mdcB6Qlm036ayfYruTLjvlaczbs=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5 h1:M5hapq0lyarTAb5L3/yeiHy7JNqSBId8VrZ9JFPMSfc=
-github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5/go.mod h1:kGy+Gwbc+i9pL0/Ky1JPzKZcDWQKXAOVkXUCTFUtn4c=
+github.com/agntcy/dir-importer v1.5.0 h1:mOlafWmj2xbMcFL44iW5s8lA08w2bnd4/ysC68M92mQ=
+github.com/agntcy/dir-importer v1.5.0/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -198,10 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281 h1:x2ikF1DWCKjT7NCwQMP7PZ86Fx34WyGvM969/egC0yk=
-github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281/go.mod h1:+sNVLiYPRTfac7/pKJq4UtF8lYXYOhq8JFAp5F78Brw=
-github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400 h1:7ptXH8lLd7dGFxKDbHngm23Bj0DK+TGrJKhW4190ZiY=
-github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400/go.mod h1:NsyBBP2WAPI5ukJov1kWPd/LbzdH+RYCvclGiAAI810=
+github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5 h1:M5hapq0lyarTAb5L3/yeiHy7JNqSBId8VrZ9JFPMSfc=
+github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5/go.mod h1:kGy+Gwbc+i9pL0/Ky1JPzKZcDWQKXAOVkXUCTFUtn4c=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=
@@ -212,8 +210,8 @@ github.com/agntcy/dir-runtime/store v1.3.2 h1:hFT7/YCAV0jxeyS4GGOo9uC+i79L9Mgiq+
 github.com/agntcy/dir-runtime/store v1.3.2/go.mod h1:ODt3giBEmOiI3gwARZawtF/iIGnU9WD3pjDowCWJkdY=
 github.com/agntcy/dir-runtime/utils v1.3.2 h1:dRpcEKHp6svEOf+3g/mayDWNgvxSHwa+T2/4h2WrLY8=
 github.com/agntcy/dir-runtime/utils v1.3.2/go.mod h1:kPyp84+ER5CTtZkzVVJijNDx3VoYXXaM9ltufmNeyxg=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7 h1:+BEhjN06hqeIC8WZu3Bh8UZ6ZVChhYUWPjGL1So98Ho=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
+github.com/agntcy/oasf-sdk/pkg v1.1.0 h1:Z2CfQ+XIjoHvlw2P0jcTRs59nbgVpjdnSVGGxmJTIEo=
+github.com/agntcy/oasf-sdk/pkg v1.1.0/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/client/go.mod
+++ b/client/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ThalesIgnite/crypto11 v1.6.0 // indirect
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v1.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -47,8 +47,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ThalesGroup/crypto11 v1.6.2 h1:X+JsrOlKanaIlHgwV/3MJ/cFivbEaQ8kpXRPoiC2T+c=
 github.com/ThalesGroup/crypto11 v1.6.2/go.mod h1:fQ61t02lJdXD2HrG7upt/VRlDECsipwtqpPcZJEjBKg=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 h1:xUBFl8T0CJb0SPZDcNXlBpYGu1v7dvPa0RPouHkPGIw=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.1.0 h1:Z2CfQ+XIjoHvlw2P0jcTRs59nbgVpjdnSVGGxmJTIEo=
+github.com/agntcy/oasf-sdk/pkg v1.1.0/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go-v2 v1.41.9 h1:/rYeyO2+HrMztAmxAq9++XJtFMqSIpSsNA0yDGALYq4=

--- a/reconciler/go.mod
+++ b/reconciler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/agntcy/dir/client v1.6.0
 	github.com/agntcy/dir/server v1.5.0
 	github.com/agntcy/dir/utils v1.6.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5
+	github.com/agntcy/oasf-sdk/pkg v1.1.0
 	github.com/csirmazbendeguz/regclient v0.0.0-20260429082137-82ab6d426079
 	github.com/sigstore/sigstore v1.10.8
 	github.com/spf13/viper v1.21.0

--- a/reconciler/go.sum
+++ b/reconciler/go.sum
@@ -51,8 +51,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ThalesGroup/crypto11 v1.6.2 h1:X+JsrOlKanaIlHgwV/3MJ/cFivbEaQ8kpXRPoiC2T+c=
 github.com/ThalesGroup/crypto11 v1.6.2/go.mod h1:fQ61t02lJdXD2HrG7upt/VRlDECsipwtqpPcZJEjBKg=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 h1:xUBFl8T0CJb0SPZDcNXlBpYGu1v7dvPa0RPouHkPGIw=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.1.0 h1:Z2CfQ+XIjoHvlw2P0jcTRs59nbgVpjdnSVGGxmJTIEo=
+github.com/agntcy/oasf-sdk/pkg v1.1.0/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/server/go.mod
+++ b/server/go.mod
@@ -18,7 +18,7 @@ require (
 	buf.build/go/protovalidate v1.2.0
 	github.com/agntcy/dir/api v1.6.0
 	github.com/agntcy/dir/utils v1.6.0
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5
+	github.com/agntcy/oasf-sdk/pkg v1.1.0
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3

--- a/server/go.sum
+++ b/server/go.sum
@@ -60,8 +60,8 @@ github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 h1:xUBFl8T0CJb0SPZDcNXlBpYGu1v7dvPa0RPouHkPGIw=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.1.0 h1:Z2CfQ+XIjoHvlw2P0jcTRs59nbgVpjdnSVGGxmJTIEo=
+github.com/agntcy/oasf-sdk/pkg v1.1.0/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=

--- a/tests/e2e/local/01_storage_test.go
+++ b/tests/e2e/local/01_storage_test.go
@@ -72,6 +72,20 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests using a local single no
 			expectedModule:  "integration/mcp",
 			shouldFailPush:  false,
 		},
+		{
+			name:              "OASF_1.1.0_Record",
+			fileName:          "oasf_1.1.0_record_test.json",
+			jsonData:          testdata.ExpectedRecordV110JSON,
+			expectedAgentName: "code_review_agent",
+			expectedSkillIDs:  []string{"10101", "10102"},
+			expectedSkillNames: []string{
+				"language_processing/language_understanding/contextual_comprehension",
+				"language_processing/language_understanding/semantic_understanding",
+			},
+			expectedLocator: "container_image:https://ghcr.io/agntcy/code-review-agent",
+			expectedModule:  "integration/mcp",
+			shouldFailPush:  false,
+		},
 	}
 
 	// Test each OASF version (V1, V2, V3) to identify JSON marshal/unmarshal issues

--- a/tests/e2e/local/10_export_test.go
+++ b/tests/e2e/local/10_export_test.go
@@ -14,6 +14,7 @@ import (
 	typesv1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1"
 	importer "github.com/agntcy/dir-importer"
 	importerconfig "github.com/agntcy/dir-importer/config"
+	enricherconfig "github.com/agntcy/dir-importer/enricher/config"
 	"github.com/agntcy/dir-importer/factory"
 	"github.com/agntcy/dir-importer/types"
 	"github.com/agntcy/dir/tests/e2e/shared/testdata"
@@ -22,15 +23,18 @@ import (
 	"github.com/onsi/gomega"
 )
 
-// importerWithStaticEnricher wraps importer.New, forcing the built-in static
-// enricher (SkipEnricher) so that e2e tests can import records without an LLM.
+// importerWithStaticEnricher wraps importer.New, forcing the static enricher so
+// that e2e tests can import records without an LLM or local model.
 func importerWithStaticEnricher(ctx context.Context, client importerconfig.ClientInterface, cfg importerconfig.Config) (types.Importer, error) {
-	cfg.Enricher.SkipEnricher = true
-	cfg.Enricher.Skills = []*typesv1.Skill{
-		{Name: "language_processing/language_understanding/contextual_comprehension", Id: 10101},
-	}
-	cfg.Enricher.Domains = []*typesv1.Domain{
-		{Name: "technology/software_engineering", Id: 102},
+	cfg.Enricher = enricherconfig.Config{
+		Static: &enricherconfig.StaticConfig{
+			Skills: []*typesv1.Skill{
+				{Name: "language_processing/language_understanding/contextual_comprehension", Id: 10101},
+			},
+			Domains: []*typesv1.Domain{
+				{Name: "technology/software_engineering", Id: 102},
+			},
+		},
 	}
 
 	return importer.New(ctx, client, cfg) //nolint:wrapcheck

--- a/tests/e2e/shared/testdata/embed.go
+++ b/tests/e2e/shared/testdata/embed.go
@@ -26,6 +26,9 @@ var ExpectedRecordV070SyncV5JSON []byte
 //go:embed record_100.json
 var ExpectedRecordV100JSON []byte
 
+//go:embed record_110.json
+var ExpectedRecordV110JSON []byte
+
 //go:embed record_070_name_resolution.json
 var ExpectedRecordV070NameResolutionJSON []byte
 

--- a/tests/e2e/shared/testdata/record_110.json
+++ b/tests/e2e/shared/testdata/record_110.json
@@ -1,0 +1,57 @@
+{
+  "name": "code_review_agent",
+  "schema_version": "1.1.0",
+  "version": "1.0.0",
+  "description": "Agent that performs automated code reviews and provides feedback",
+  "authors": [
+    "Example Organization"
+  ],
+  "created_at": "2025-01-01T00:00:00Z",
+  "skills": [
+    {
+      "name": "language_processing/language_understanding/contextual_comprehension",
+      "id": 10101
+    },
+    {
+      "name": "language_processing/language_understanding/semantic_understanding",
+      "id": 10102
+    }
+  ],
+  "locators": [
+    {
+      "type": "container_image",
+      "urls": [
+        "https://ghcr.io/agntcy/code-review-agent"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "id": 202,
+      "name": "integration/mcp",
+      "data": {
+        "name": "code-review-mcp-server",
+        "connections": [
+          {
+            "type": "stdio",
+            "command": "docker",
+            "args": [
+              "run",
+              "-i",
+              "--rm",
+              "ghcr.io/agntcy/code-review-mcp-server"
+            ],
+            "env_vars": [
+              {
+                "name": "CODE_REVIEW_API_KEY",
+                "default_value": "",
+                "description": "API key for the code review service",
+                "required": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281
+	github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400
 	github.com/agntcy/dir/api v1.6.0
 	github.com/agntcy/dir/cli v1.5.0
 	github.com/agntcy/dir/client v1.6.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400
+	github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5
 	github.com/agntcy/dir/api v1.6.0
 	github.com/agntcy/dir/cli v1.5.0
 	github.com/agntcy/dir/client v1.6.0
@@ -110,7 +110,7 @@ require (
 	github.com/agntcy/dir/reconciler v1.5.0 // indirect
 	github.com/agntcy/dir/server v1.5.0
 	github.com/agntcy/dir/utils v1.6.0 // indirect
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7 // indirect
+	github.com/agntcy/oasf-sdk/pkg v1.1.0 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/anchore/go-struct-converter v0.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5
+	github.com/agntcy/dir-importer v1.5.0
 	github.com/agntcy/dir/api v1.6.0
 	github.com/agntcy/dir/cli v1.5.0
 	github.com/agntcy/dir/client v1.6.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.4.2-0.20260713172338-b92ad73bc0dd
+	github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281
 	github.com/agntcy/dir/api v1.6.0
 	github.com/agntcy/dir/cli v1.5.0
 	github.com/agntcy/dir/client v1.6.0
@@ -380,7 +380,7 @@ require (
 	github.com/libp2p/zeroconf/v2 v2.2.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lunixbochs/struc v0.0.0-20241101090106-8d528fa2c543 // indirect
-	github.com/mark3labs/mcp-go v0.54.1 // indirect
+	github.com/mark3labs/mcp-go v0.56.0 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/masahiro331/go-disk v0.0.0-20260423015231-f7a470ebd472 // indirect
 	github.com/masahiro331/go-ebs-file v0.0.0-20260422020928-9d24e29aac27 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.2-0.20260713172338-b92ad73bc0dd h1:z88/qXfr5KNBULyunJ/hUAPLTJgNxrNdrL//gTQ3HHE=
-github.com/agntcy/dir-importer v1.4.2-0.20260713172338-b92ad73bc0dd/go.mod h1:emTmHmARlhxAF9giWVukFW5Yvx63QZbpPBUEoqrA8xA=
+github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281 h1:x2ikF1DWCKjT7NCwQMP7PZ86Fx34WyGvM969/egC0yk=
+github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281/go.mod h1:+sNVLiYPRTfac7/pKJq4UtF8lYXYOhq8JFAp5F78Brw=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=
@@ -1199,8 +1199,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/marcopolo/simnet v0.0.4 h1:50Kx4hS9kFGSRIbrt9xUS3NJX33EyPqHVmpXvaKLqrY=
 github.com/marcopolo/simnet v0.0.4/go.mod h1:tfQF1u2DmaB6WHODMtQaLtClEf3a296CKQLq5gAsIS0=
-github.com/mark3labs/mcp-go v0.54.1 h1:Ap/ptEB9FtWzFKM8NDsTA7QDxerQOC06eZigrTldVj0=
-github.com/mark3labs/mcp-go v0.54.1/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
+github.com/mark3labs/mcp-go v0.56.0 h1:7aCj2wODCskMi08f923ADG+EfELZBdiKILny415cIS8=
+github.com/mark3labs/mcp-go v0.56.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -200,6 +200,8 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281 h1:x2ikF1DWCKjT7NCwQMP7PZ86Fx34WyGvM969/egC0yk=
 github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281/go.mod h1:+sNVLiYPRTfac7/pKJq4UtF8lYXYOhq8JFAp5F78Brw=
+github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400 h1:7ptXH8lLd7dGFxKDbHngm23Bj0DK+TGrJKhW4190ZiY=
+github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400/go.mod h1:NsyBBP2WAPI5ukJov1kWPd/LbzdH+RYCvclGiAAI810=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5 h1:M5hapq0lyarTAb5L3/yeiHy7JNqSBId8VrZ9JFPMSfc=
-github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5/go.mod h1:kGy+Gwbc+i9pL0/Ky1JPzKZcDWQKXAOVkXUCTFUtn4c=
+github.com/agntcy/dir-importer v1.5.0 h1:mOlafWmj2xbMcFL44iW5s8lA08w2bnd4/ysC68M92mQ=
+github.com/agntcy/dir-importer v1.5.0/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -198,10 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281 h1:x2ikF1DWCKjT7NCwQMP7PZ86Fx34WyGvM969/egC0yk=
-github.com/agntcy/dir-importer v1.4.2-0.20260714100437-8f334cfdc281/go.mod h1:+sNVLiYPRTfac7/pKJq4UtF8lYXYOhq8JFAp5F78Brw=
-github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400 h1:7ptXH8lLd7dGFxKDbHngm23Bj0DK+TGrJKhW4190ZiY=
-github.com/agntcy/dir-importer v1.4.2-0.20260714104042-e546d560a400/go.mod h1:NsyBBP2WAPI5ukJov1kWPd/LbzdH+RYCvclGiAAI810=
+github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5 h1:M5hapq0lyarTAb5L3/yeiHy7JNqSBId8VrZ9JFPMSfc=
+github.com/agntcy/dir-importer v1.4.2-0.20260714135757-70c2faf1c4b5/go.mod h1:kGy+Gwbc+i9pL0/Ky1JPzKZcDWQKXAOVkXUCTFUtn4c=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=
@@ -212,8 +210,8 @@ github.com/agntcy/dir-runtime/store v1.3.2 h1:hFT7/YCAV0jxeyS4GGOo9uC+i79L9Mgiq+
 github.com/agntcy/dir-runtime/store v1.3.2/go.mod h1:ODt3giBEmOiI3gwARZawtF/iIGnU9WD3pjDowCWJkdY=
 github.com/agntcy/dir-runtime/utils v1.3.2 h1:dRpcEKHp6svEOf+3g/mayDWNgvxSHwa+T2/4h2WrLY8=
 github.com/agntcy/dir-runtime/utils v1.3.2/go.mod h1:kPyp84+ER5CTtZkzVVJijNDx3VoYXXaM9ltufmNeyxg=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7 h1:+BEhjN06hqeIC8WZu3Bh8UZ6ZVChhYUWPjGL1So98Ho=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260702111004-a058446d13b7/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
+github.com/agntcy/oasf-sdk/pkg v1.1.0 h1:Z2CfQ+XIjoHvlw2P0jcTRs59nbgVpjdnSVGGxmJTIEo=
+github.com/agntcy/oasf-sdk/pkg v1.1.0/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -16,7 +16,7 @@ require (
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260703134920-dbfa1736bef5.1 // indirect
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
-	github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 // indirect
+	github.com/agntcy/oasf-sdk/pkg v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect

--- a/utils/go.sum
+++ b/utils/go.sum
@@ -6,8 +6,8 @@ buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-202604152011
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1/go.mod h1:tvtbpgaVXZX4g6Pn+AnzFycuRK3MOz5HJfEGeEllXYM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5 h1:xUBFl8T0CJb0SPZDcNXlBpYGu1v7dvPa0RPouHkPGIw=
-github.com/agntcy/oasf-sdk/pkg v1.0.6-0.20260629100853-cc016581c7f5/go.mod h1:6dii5LpZlAPNhko78tvD2LOhJ2qwOXDy95aSjrsJbgg=
+github.com/agntcy/oasf-sdk/pkg v1.1.0 h1:Z2CfQ+XIjoHvlw2P0jcTRs59nbgVpjdnSVGGxmJTIEo=
+github.com/agntcy/oasf-sdk/pkg v1.1.0/go.mod h1:MAWceG+fNkVjgWbfrQOp64h6f5dbJbd1InP93fiMEiQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=


### PR DESCRIPTION
Tracks the latest `dir-importer` main branch across the `cli` and `tests` modules, adapting the import command to three breaking API changes introduced upstream: the enricher config was restructured from a flat struct into three mutually exclusive sub-configs (`LLM`, `Static`, `Extractor`), the scanner pipeline was removed entirely, and `ImportResult.ScannerFindings` was dropped. The reference YAML config (`import.config.yaml`) is updated to reflect the new `enricher.llm` / `enricher.static` / `enricher.extractor` structure.

Importer pipeline working with llm enricher ✅  https://github.com/agntcy/dir/actions/runs/29348727603/job/87139971523
Static enricher working in e2e test ✅ 
Extractor enricher manually tested ✅  