### PR TITLE
feat(search): add --schema-version flag to NL search for OASF version scoping

### DIFF
--- a/cli/cmd/routing/nlsearch.go
+++ b/cli/cmd/routing/nlsearch.go
@@ -36,7 +36,12 @@ func runNLRoutingSearch(cmd *cobra.Command, query string) error {
 		return fmt.Errorf("natural-language search requires the OASF extractor — run `dirctl init` to set it up: %w", err)
 	}
 
-	signals, err := nlsearch.DecomposeWithMinScore(cmd.Context(), query, ext, routingMinScore)
+	var queryOpts []sdk.QueryOption
+	if len(searchOpts.SchemaVersions) > 0 {
+		queryOpts = append(queryOpts, sdk.Versions(searchOpts.SchemaVersions...))
+	}
+
+	signals, err := nlsearch.DecomposeWithMinScore(cmd.Context(), query, ext, routingMinScore, queryOpts...)
 	if err != nil {
 		return fmt.Errorf("decompose query: %w", err)
 	}

--- a/cli/cmd/routing/search.go
+++ b/cli/cmd/routing/search.go
@@ -74,13 +74,14 @@ Usage examples:
 
 // Search command options.
 var searchOpts struct {
-	Skills   []string
-	Locators []string
-	Domains  []string
-	Modules  []string
-	Limit    uint32
-	MinScore uint32
-	Verbose  bool
+	Skills         []string
+	Locators       []string
+	Domains        []string
+	Modules        []string
+	SchemaVersions []string
+	Limit          uint32
+	MinScore       uint32
+	Verbose        bool
 }
 
 const (
@@ -97,6 +98,7 @@ func init() {
 	searchCmd.Flags().Uint32Var(&searchOpts.Limit, "limit", defaultSearchLimit, "Maximum number of results to return")
 	searchCmd.Flags().Uint32Var(&searchOpts.MinScore, "min-score", defaultMinScore, "Minimum match score (number of queries that must match)")
 	searchCmd.Flags().BoolVar(&searchOpts.Verbose, "verbose", false, "Print extracted signals and per-signal details to stderr")
+	searchCmd.Flags().StringArrayVar(&searchOpts.SchemaVersions, "schema-version", nil, "Restrict NL search to specific OASF schema version(s), e.g. --schema-version 1.0.0 (repeatable; default: all provisioned versions)")
 
 	presenter.AddOutputFlags(searchCmd)
 }

--- a/cli/cmd/search/filters.go
+++ b/cli/cmd/search/filters.go
@@ -65,7 +65,7 @@ func registerFilterFlags(flags *pflag.FlagSet, f *Filters) {
 	flags.StringArrayVar(&f.Authors, "author", nil,
 		"Search for records with specific author (e.g., --author 'john*')")
 	flags.StringArrayVar(&f.SchemaVersions, "schema-version", nil,
-		"Search for records with specific schema version (e.g., --schema-version '0.8.*')")
+		"Filter records by OASF schema version (e.g., --schema-version '0.8.*'); in natural-language search mode, also restricts the extractor to that taxonomy version (repeatable)")
 	flags.StringArrayVar(&f.ModuleIDs, "module-id", nil,
 		"Search for records with specific module ID (e.g., --module-id '201')")
 	flags.BoolVar(&f.Verified, "verified", false,

--- a/cli/cmd/search/nlsearch.go
+++ b/cli/cmd/search/nlsearch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/agntcy/dir/cli/internal/nlsearch"
 	"github.com/agntcy/dir/cli/presenter"
 	"github.com/agntcy/dir/client"
+	sdk "github.com/agntcy/oasf-sdk/pkg/extractor"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +49,12 @@ func runNLSearch(cmd *cobra.Command, query string, c *client.Client) error {
 		return fmt.Errorf("natural-language search requires the OASF extractor — run `dirctl init` to set it up: %w", err)
 	}
 
-	signals, err := nlsearch.Decompose(cmd.Context(), query, ext)
+	var queryOpts []sdk.QueryOption
+	if len(opts.Filters.SchemaVersions) > 0 {
+		queryOpts = append(queryOpts, sdk.Versions(opts.Filters.SchemaVersions...))
+	}
+
+	signals, err := nlsearch.Decompose(cmd.Context(), query, ext, queryOpts...)
 	if err != nil {
 		return fmt.Errorf("decompose query: %w", err)
 	}

--- a/cli/internal/nlsearch/decompose.go
+++ b/cli/internal/nlsearch/decompose.go
@@ -63,14 +63,16 @@ const DefaultMinTaxonomyScore = 0.3
 
 // Decompose extracts search signals from free-form text using the provisioned
 // OASF extractor, applying DefaultMinTaxonomyScore to filter weak matches.
-func Decompose(ctx context.Context, text string, ext *sdk.Extractor) ([]Signal, error) {
-	return DecomposeWithMinScore(ctx, text, ext, DefaultMinTaxonomyScore)
+// Optional sdk.QueryOption values (e.g. sdk.Versions("1.0.0")) are forwarded
+// to the extractor to restrict which OASF versions are searched.
+func Decompose(ctx context.Context, text string, ext *sdk.Extractor, queryOpts ...sdk.QueryOption) ([]Signal, error) {
+	return DecomposeWithMinScore(ctx, text, ext, DefaultMinTaxonomyScore, queryOpts...)
 }
 
 // DecomposeWithMinScore is like Decompose but uses the given minScore threshold
 // instead of DefaultMinTaxonomyScore.
-func DecomposeWithMinScore(ctx context.Context, text string, ext *sdk.Extractor, minScore float64) ([]Signal, error) {
-	res, err := ext.Extract(ctx, text)
+func DecomposeWithMinScore(ctx context.Context, text string, ext *sdk.Extractor, minScore float64, queryOpts ...sdk.QueryOption) ([]Signal, error) {
+	res, err := ext.Extract(ctx, text, queryOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("extract signals from %q: %w", text, err)
 	}


### PR DESCRIPTION
Records published against OASF 1.0.0 use different skill taxonomy names than records enriched with 1.1.0, so after re-provisioning the extractor with the new schema, natural-language queries generate only 1.1.0 signals and miss older records. This PR adds a `--schema-version` flag to both `dirctl search` and `dirctl routing search` that pins the OASF taxonomy version(s) used during query decomposition, letting operators bridge the gap while older records are re-enriched.

- `Decompose` and `DecomposeWithMinScore` accept variadic `sdk.QueryOption` arguments and forward them to `ext.Extract`, keeping existing callers (routing NL search) unchanged with no extra arguments.
- When `--schema-version` is omitted the behavior is identical to before — the extractor defaults to `ScopeAll` and covers every provisioned version.