### PR TITLE
fix(tests): revert OASF schema version from 1.1.0 back to 1.0.0

### DIFF
--- a/cli/cmd/import/config.go
+++ b/cli/cmd/import/config.go
@@ -21,17 +21,18 @@ import (
 // importFileConfig mirrors the YAML config file with explicit yaml tags.
 // Fields intentionally absent: sign.* (CLI-only) and output_cids (CLI-only).
 type importFileConfig struct {
-	Type      string             `yaml:"type"`
-	URL       string             `yaml:"url"`
-	FilePath  string             `yaml:"file_path"`
-	Filters   map[string]string  `yaml:"filters"`
-	Limit     int                `yaml:"limit"`
-	DryRun    bool               `yaml:"dry_run"`
-	OutputDir string             `yaml:"output_dir"`
-	Force     bool               `yaml:"force"`
-	Debug     bool               `yaml:"debug"`
-	Authors   []string           `yaml:"authors"`
-	Enricher  enricherFileConfig `yaml:"enricher"`
+	Type          string             `yaml:"type"`
+	URL           string             `yaml:"url"`
+	FilePath      string             `yaml:"file_path"`
+	Filters       map[string]string  `yaml:"filters"`
+	Limit         int                `yaml:"limit"`
+	DryRun        bool               `yaml:"dry_run"`
+	OutputDir     string             `yaml:"output_dir"`
+	Force         bool               `yaml:"force"`
+	Debug         bool               `yaml:"debug"`
+	Authors       []string           `yaml:"authors"`
+	SchemaVersion string             `yaml:"schema_version"`
+	Enricher      enricherFileConfig `yaml:"enricher"`
 }
 
 type enricherFileConfig struct {
@@ -206,6 +207,10 @@ func applyFileConfig(fc importFileConfig, cfg *config.Config) {
 
 	if len(fc.Authors) > 0 {
 		cfg.Authors = fc.Authors
+	}
+
+	if fc.SchemaVersion != "" {
+		cfg.SchemaVersion = fc.SchemaVersion
 	}
 
 	if fc.Enricher.LLM != nil {

--- a/cli/cmd/import/import.config.yaml
+++ b/cli/cmd/import/import.config.yaml
@@ -41,11 +41,11 @@ enricher:
   # record with a fixed set of skills/domains (no LLM or local model needed).
   # static:
   #   skills:
-  #     - name: language_processing/language_generation/dialogue_generation
+  #     - name: natural_language_processing/natural_language_generation/dialogue_generation
   #       id: 10304
   #   domains:
-  #     - name: technology/software_engineering
-  #       id: 102
+  #     - name: technology/software_engineering/apis_integration
+  #       id: 10204
 
   # Or use "extractor:" for in-process, LLM-free enrichment using the local
   # OASF taxonomy model (requires `dirctl init` to have been run first).
@@ -53,6 +53,8 @@ enricher:
   # extractor:
   #   oasf_url: https://schema.oasf.outshift.com
   #   asset_dir: ~/.agntcy/oasf-sdk/extractor
+
+schema_version: "1.0.0"
 
 output_dir: ./import-out
 dry_run: false

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260703134941-ebce38fee5a5.1
-	github.com/agntcy/dir-importer v1.5.0
+	github.com/agntcy/dir-importer v1.5.1-0.20260715144405-f5000b6658e5
 	github.com/agntcy/dir-mcp v1.3.2
 	github.com/agntcy/dir-runtime/discovery v1.3.2
 	github.com/agntcy/dir-runtime/server v1.3.2

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.5.0 h1:mOlafWmj2xbMcFL44iW5s8lA08w2bnd4/ysC68M92mQ=
-github.com/agntcy/dir-importer v1.5.0/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
+github.com/agntcy/dir-importer v1.5.1-0.20260715144405-f5000b6658e5 h1:B2P+ZxpWFirINjY6EvWg/kYYWr5NObmiofU026QkYeU=
+github.com/agntcy/dir-importer v1.5.1-0.20260715144405-f5000b6658e5/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=

--- a/server/skill/skill.go
+++ b/server/skill/skill.go
@@ -23,27 +23,27 @@ var DirSkill string
 
 const (
 	RecordName    = "org.agntcy/directory"
-	SchemaVersion = "1.1.0"
+	SchemaVersion = "1.0.0"
 
 	MCPModuleName         = "integration/mcp"
 	AgentSkillsModuleName = "core/language_model/agentskills"
 	MCPServerName         = "agntcy-dir-mcp"
 
-	// OASF taxonomy IDs (verified against the 1.1.0 JSON schema). Mismatching
+	// OASF taxonomy IDs (verified against the 1.0.0 JSON schema). Mismatching
 	// these is a hard validation error, missing them is only a warning.
 	skillContextualComprehensionID uint32 = 10101
 	agentSkillsModuleID            uint32 = 10302
 	mcpModuleID                    uint32 = 202
-	domainSoftwareEngineeringID    uint32 = 102
+	domainAPIsIntegrationID        uint32 = 10204
 
 	// Used when the binary lacks an ldflags-stamped version (e.g. `go run`).
 	fallbackVersion = "0.0.0-dev"
 
 	// OASF requires `skills` to be non-empty; pick the closest taxonomy
 	// node for an instructional record.
-	skillContextualComprehensionName = "language_processing/language_understanding/contextual_comprehension"
+	skillContextualComprehensionName = "natural_language_processing/natural_language_understanding/contextual_comprehension"
 
-	domainSoftwareEngineeringName = "technology/software_engineering"
+	domainAPIsIntegrationName = "technology/software_engineering/apis_integration"
 )
 
 // RecordVersion returns the record's `version`, stripping the commit suffix
@@ -88,7 +88,7 @@ func BuildRecord(now time.Time) (*corev1.Record, error) {
 			{Name: skillContextualComprehensionName, Id: skillContextualComprehensionID},
 		},
 		Domains: []*typesv1.Domain{
-			{Name: domainSoftwareEngineeringName, Id: domainSoftwareEngineeringID},
+			{Name: domainAPIsIntegrationName, Id: domainAPIsIntegrationID},
 		},
 		Modules: []*typesv1.Module{skillModule, mcpModule},
 	}), nil

--- a/tests/e2e/local/01_storage_test.go
+++ b/tests/e2e/local/01_storage_test.go
@@ -72,20 +72,21 @@ var _ = ginkgo.Describe("Running dirctl end-to-end tests using a local single no
 			expectedModule:  "integration/mcp",
 			shouldFailPush:  false,
 		},
-		{
-			name:              "OASF_1.1.0_Record",
-			fileName:          "oasf_1.1.0_record_test.json",
-			jsonData:          testdata.ExpectedRecordV110JSON,
-			expectedAgentName: "code_review_agent",
-			expectedSkillIDs:  []string{"10101", "10102"},
-			expectedSkillNames: []string{
-				"language_processing/language_understanding/contextual_comprehension",
-				"language_processing/language_understanding/semantic_understanding",
-			},
-			expectedLocator: "container_image:https://ghcr.io/agntcy/code-review-agent",
-			expectedModule:  "integration/mcp",
-			shouldFailPush:  false,
-		},
+		// TODO: Revert when OASF 1.1.0 schema is available
+		// {
+		// 	name:              "OASF_1.1.0_Record",
+		// 	fileName:          "oasf_1.1.0_record_test.json",
+		// 	jsonData:          testdata.ExpectedRecordV110JSON,
+		// 	expectedAgentName: "code_review_agent",
+		// 	expectedSkillIDs:  []string{"10101", "10102"},
+		// 	expectedSkillNames: []string{
+		// 		"language_processing/language_understanding/contextual_comprehension",
+		// 		"language_processing/language_understanding/semantic_understanding",
+		// 	},
+		// 	expectedLocator: "container_image:https://ghcr.io/agntcy/code-review-agent",
+		// 	expectedModule:  "integration/mcp",
+		// 	shouldFailPush:  false,
+		// },
 	}
 
 	// Test each OASF version (V1, V2, V3) to identify JSON marshal/unmarshal issues

--- a/tests/e2e/local/10_export_test.go
+++ b/tests/e2e/local/10_export_test.go
@@ -29,7 +29,7 @@ func importerWithStaticEnricher(ctx context.Context, client importerconfig.Clien
 	cfg.Enricher = enricherconfig.Config{
 		Static: &enricherconfig.StaticConfig{
 			Skills: []*typesv1.Skill{
-				{Name: "language_processing/language_understanding/contextual_comprehension", Id: 10101},
+				{Name: "natural_language_processing/natural_language_understanding/contextual_comprehension", Id: 10101},
 			},
 			Domains: []*typesv1.Domain{
 				{Name: "technology/software_engineering", Id: 102},

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.5.0
+	github.com/agntcy/dir-importer v1.5.1-0.20260715144405-f5000b6658e5
 	github.com/agntcy/dir/api v1.6.0
 	github.com/agntcy/dir/cli v1.5.0
 	github.com/agntcy/dir/client v1.6.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.5.0 h1:mOlafWmj2xbMcFL44iW5s8lA08w2bnd4/ysC68M92mQ=
-github.com/agntcy/dir-importer v1.5.0/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
+github.com/agntcy/dir-importer v1.5.1-0.20260715144405-f5000b6658e5 h1:B2P+ZxpWFirINjY6EvWg/kYYWr5NObmiofU026QkYeU=
+github.com/agntcy/dir-importer v1.5.1-0.20260715144405-f5000b6658e5/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
 github.com/agntcy/dir-mcp v1.3.2 h1:wZYJ/RiN+gAw2p0FLOgadCatKvubLpw7THO+ZOXNem0=
 github.com/agntcy/dir-mcp v1.3.2/go.mod h1:GPHHhPgbrfJwMxzjjchYHftZPaPSWVUM41UB4DDZsQA=
 github.com/agntcy/dir-runtime/discovery v1.3.2 h1:/flBeZSEUGzxGPeYHvfq0x9dv9S8gzb+ItRgYkz6GVs=

--- a/tests/integration/server/push_test.go
+++ b/tests/integration/server/push_test.go
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("Push", func() {
 		gomega.Expect(annotations["org.agntcy.dir/cid"]).To(gomega.Equal(cid))
 		gomega.Expect(annotations["org.agntcy.dir/created-at"]).To(gomega.Equal(record.CreatedAt))
 		gomega.Expect(annotations["org.agntcy.dir/name"]).To(gomega.Equal(record.Name))
-		gomega.Expect(annotations["org.agntcy.dir/oasf-version"]).To(gomega.Equal("1.1.0"))
+		gomega.Expect(annotations["org.agntcy.dir/oasf-version"]).To(gomega.Equal("1.0.0"))
 		gomega.Expect(annotations["org.agntcy.dir/schema-version"]).To(gomega.Equal(record.SchemaVersion))
 		gomega.Expect(annotations["org.agntcy.dir/type"]).To(gomega.Equal("record"))
 		gomega.Expect(annotations["org.agntcy.dir/version"]).To(gomega.Equal(record.Version))

--- a/tests/integration/server/testenv/docker-compose.yml
+++ b/tests/integration/server/testenv/docker-compose.yml
@@ -28,10 +28,8 @@ services:
       retries: 60
       start_period: 10s
   oasf:
-    # Pin to the released 1.1.0 schema image. Using `latest` tracks the moving
-    # `1.1.0-dev` pre-release schema, which drifts from the 1.1.0 test data
-    # (e.g. skill ID/name reassignments) and breaks validation in these tests.
-    image: ghcr.io/agntcy/oasf-server:v1.1.0
+    # Pin to the released 1.0.0 schema image.
+    image: ghcr.io/agntcy/oasf-server:v1.0.4
     ports:
       - 8092:8080
     deploy:

--- a/tests/test_utils/gofakeit.go
+++ b/tests/test_utils/gofakeit.go
@@ -24,7 +24,7 @@ var GofakeitGenericLookups = map[string]gofakeit.Info{
 
 func InitGofakeit() {
 	AddFuncLookups(GofakeitGenericLookups)
-	AddFuncLookups(GofakeitOASF110Lookups)
+	AddFuncLookups(GofakeitOASF100Lookups)
 }
 
 func AddFuncLookups(lookups map[string]gofakeit.Info) {

--- a/tests/test_utils/oasf_110.go
+++ b/tests/test_utils/oasf_110.go
@@ -56,19 +56,19 @@ var modules = []Module{
 }
 
 var skills = []Skill{
-	{Id: 101, Name: "language_processing/language_understanding"},                            //nolint:mnd
-	{Id: 10101, Name: "language_processing/language_understanding/contextual_comprehension"}, //nolint:mnd
-	{Id: 10102, Name: "language_processing/language_understanding/semantic_understanding"},   //nolint:mnd
-	{Id: 10103, Name: "language_processing/language_understanding/entity_recognition"},       //nolint:mnd
-	{Id: 20103, Name: "computer_vision/image_analysis/image_segmentation"},                   //nolint:mnd
-	{Id: 1504, Name: "reasoning_planning/strategic_planning"},                                //nolint:mnd
+	{Id: 101, Name: "natural_language_processing/natural_language_understanding"},                            //nolint:mnd
+	{Id: 10101, Name: "natural_language_processing/natural_language_understanding/contextual_comprehension"}, //nolint:mnd
+	{Id: 10102, Name: "natural_language_processing/natural_language_understanding/semantic_understanding"},   //nolint:mnd
+	{Id: 108, Name: "natural_language_processing/ethical_interaction"},                                       //nolint:mnd
+	{Id: 201, Name: "images_computer_vision/image_segmentation"},                                             //nolint:mnd
+	{Id: 1504, Name: "advanced_reasoning_planning/hypothesis_generation"},                                    //nolint:mnd
 }
 
-var GofakeitOASF110Lookups = map[string]gofakeit.Info{
-	"oasf110skills": {
-		Display:     "OASF110Skills",
+var GofakeitOASF100Lookups = map[string]gofakeit.Info{
+	"oasf100skills": {
+		Display:     "OASF100Skills",
 		Category:    "oasf",
-		Description: "OASF 1.1.0 skills (a slice of 1 to 5 skills)",
+		Description: "OASF 1.0.0 skills (a slice of 1 to 5 skills)",
 		Output:      "Skills",
 		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
 			skillsCopy := make(Skills, len(skills))
@@ -80,10 +80,10 @@ var GofakeitOASF110Lookups = map[string]gofakeit.Info{
 			return skillsCopy[:n], nil
 		},
 	},
-	"oasf110modules": {
-		Display:     "OASF110Modules",
+	"oasf100modules": {
+		Display:     "OASF100Modules",
 		Category:    "oasf",
-		Description: "OASF 1.1.0 modules (a slice of 1 to 2 modules)",
+		Description: "OASF 1.0.0 modules (a slice of 1 to 2 modules)",
 		Output:      "Modules",
 		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
 			modulesCopy := make(Modules, len(modules))
@@ -95,20 +95,20 @@ var GofakeitOASF110Lookups = map[string]gofakeit.Info{
 			return modulesCopy[:n], nil
 		},
 	},
-	"oasf110recordname": {
-		Display:     "OASF110RecordName",
+	"oasf100recordname": {
+		Display:     "OASF100RecordName",
 		Category:    "oasf",
-		Description: "OASF 1.1.0 record name",
+		Description: "OASF 1.0.0 record name",
 		Example:     "Marketing Strategy Agent",
 		Output:      "string",
 		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
 			return fmt.Sprintf("%s Agent", gofakeit.JobTitle()), nil
 		},
 	},
-	"oasf110authors": {
-		Display:     "OASF110Authors",
+	"oasf100authors": {
+		Display:     "OASF100Authors",
 		Category:    "oasf",
-		Description: "OASF 1.1.0 authors",
+		Description: "OASF 1.0.0 authors",
 		Output:      "[]string",
 		Generate: func(f *gofakeit.Faker, m *gofakeit.MapParams, info *gofakeit.Info) (any, error) {
 			n := f.Number(1, 5) //nolint:mnd
@@ -126,8 +126,8 @@ var GofakeitOASF110Lookups = map[string]gofakeit.Info{
 	},
 }
 
-// Skill represents an OASF 1.1.0 Skill category
-// https://schema.oasf.outshift.com/1.1.0/skill_categories
+// Skill represents an OASF 1.0.0 Skill category
+// https://schema.oasf.outshift.com/1.0.0/skill_categories
 type Skill struct {
 	Id   int    `json:"id"`
 	Name string `json:"name"`
@@ -137,15 +137,15 @@ type Skill struct {
 // (Gofakeit doesn't work with anonymous slices).
 type Skills []Skill
 
-// Locator represents an OASF 1.1.0 Locator object
-// https://schema.oasf.outshift.com/1.1.0/objects/locator
+// Locator represents an OASF 1.0.0 Locator object
+// https://schema.oasf.outshift.com/1.0.0/objects/locator
 type Locator struct {
 	LocatorType string   `fake:"{randomstring:[binary,container_image,helm_chart,package,source_code,unspecified,url]}" json:"type"`
 	Urls        []string `fake:"{url}"                                                                                  json:"urls"`
 }
 
-// Module represents an OASF 1.1.0 Module category
-// https://schema.oasf.outshift.com/1.1.0/module_categories
+// Module represents an OASF 1.0.0 Module category
+// https://schema.oasf.outshift.com/1.0.0/module_categories
 type Module struct {
 	Name string `json:"name"`
 	Data any    `json:"data"`
@@ -155,15 +155,15 @@ type Module struct {
 // (Gofakeit doesn't work with anonymous slices).
 type Modules []Module
 
-// MCPData represents an OASF 1.1.0 MCP Data object
-// https://schema.oasf.outshift.com/1.1.0/objects/mcp_data
+// MCPData represents an OASF 1.0.0 MCP Data object
+// https://schema.oasf.outshift.com/1.0.0/objects/mcp_data
 type MCPData struct {
 	Name        string                `json:"name"`
 	Connections []MCPServerConnection `json:"connections"`
 }
 
-// MCPServerConnection represents an OASF 1.1.0 MCP Server Connection object
-// https://schema.oasf.outshift.com/1.1.0/objects/mcp_server_connection
+// MCPServerConnection represents an OASF 1.0.0 MCP Server Connection object
+// https://schema.oasf.outshift.com/1.0.0/objects/mcp_server_connection
 type MCPServerConnection struct {
 	Type    string                `fake:"{randomstring:[sse,stdio,streamable-http]}" json:"type"`
 	Args    []string              `json:"args"`
@@ -173,8 +173,8 @@ type MCPServerConnection struct {
 	Url     string                `json:"url,omitempty"`
 }
 
-// EnvironmentVariable represents an OASF 1.1.0 Environment Variable object
-// https://schema.oasf.outshift.com/1.1.0/objects/env_var
+// EnvironmentVariable represents an OASF 1.0.0 Environment Variable object
+// https://schema.oasf.outshift.com/1.0.0/objects/env_var
 type EnvironmentVariable struct {
 	Name         string `json:"name"`
 	Description  string `json:"description"`
@@ -182,25 +182,25 @@ type EnvironmentVariable struct {
 	Required     bool   `json:"required"`
 }
 
-// A2AData represents an OASF 1.1.0 A2A Data object
-// https://schema.oasf.outshift.com/1.1.0/objects/a2a_data
+// A2AData represents an OASF 1.0.0 A2A Data object
+// https://schema.oasf.outshift.com/1.0.0/objects/a2a_data
 type A2AData struct {
 	CardData          any    `json:"card_data"`
 	CardSchemaVersion string `fake:"{appversion}" json:"card_schema_version"`
 }
 
-// Record represents an OASF 1.1.0 Record object
-// https://schema.oasf.outshift.com/1.1.0/objects/record
+// Record represents an OASF 1.0.0 Record object
+// https://schema.oasf.outshift.com/1.0.0/objects/record
 type Record struct {
-	Name          string    `fake:"{oasf110recordname}"  json:"name"`
-	SchemaVersion string    `fake:"1.1.0"                json:"schema_version"`
+	Name          string    `fake:"{oasf100recordname}"  json:"name"`
+	SchemaVersion string    `fake:"1.0.0"                json:"schema_version"`
 	Version       string    `fake:"{appversion}"         json:"version"`
 	Description   string    `fake:"{productdescription}" json:"description"`
-	Authors       []string  `fake:"{oasf110authors}"     json:"authors"`
+	Authors       []string  `fake:"{oasf100authors}"     json:"authors"`
 	CreatedAt     string    `fake:"{pastdaterfc3339}"    json:"created_at"`
-	Skills        Skills    `fake:"{oasf110skills}"      json:"skills"`
+	Skills        Skills    `fake:"{oasf100skills}"      json:"skills"`
 	Locators      []Locator `fakesize:"1"                json:"locators"`
-	Modules       Modules   `fake:"{oasf110modules}"     json:"modules"`
+	Modules       Modules   `fake:"{oasf100modules}"     json:"modules"`
 }
 
 func FakeRecord() *Record {


### PR DESCRIPTION
The OASF 1.1.0 schema deployment at `schema.oasf.outshift.com` was reverted, causing the `/api/1.1.0/validate/...` endpoint to return 404 and breaking any push of a record with `schema_version: "1.1.0"`. This PR undoes the schema bump introduced in #1785 and #1806, restoring all OASF references — skill taxonomy names, domain IDs, test fixtures, the OASF server image tag, and the self-describing DIR skill record — to their 1.0.0 equivalents.