### PR TITLE
feat(dir): provide oci address in discovery response

### DIFF
--- a/cli/cmd/sync/sync.go
+++ b/cli/cmd/sync/sync.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	routingv1 "github.com/agntcy/dir/api/routing/v1"
 	storev1 "github.com/agntcy/dir/api/store/v1"
@@ -334,36 +335,66 @@ func parseSearchOutput(input io.Reader) ([]*routingv1.SearchResponse, error) {
 	return searchResponses, nil
 }
 
-// PeerSyncInfo holds sync information for a peer (grouped by API address).
+// PeerSyncInfo holds sync information for a peer resolved from routing addresses.
 type PeerSyncInfo struct {
+	// APIAddress is the value of the /dir/ multiaddr (e.g. "host:443"), if present.
 	APIAddress string
-	CIDs       []string
+	// OCIRegistry is the registry host[:port] parsed from the /oci/ multiaddr.
+	OCIRegistry string
+	// OCIRepository is the repository path component of the /oci/ multiaddr, if any.
+	OCIRepository string
+	CIDs          []string
 }
 
+// groupResultsByAPIAddress groups search results by peer, parsing /dir/ and /oci/
+// multiaddrs so callers can choose the right sync strategy per peer.
 func groupResultsByAPIAddress(results []*routingv1.SearchResponse) map[string]PeerSyncInfo {
 	peerResults := make(map[string]PeerSyncInfo)
 
 	for _, result := range results {
-		// Get the first API address if available
-		var apiAddress string
-		if result.GetPeer() != nil && len(result.GetPeer().GetAddrs()) > 0 {
-			apiAddress = result.GetPeer().GetAddrs()[0]
+		peer := result.GetPeer()
+		if peer == nil {
+			continue
 		}
 
-		// Skip results without API address
-		if apiAddress == "" {
+		var dirAddr, ociRegistry, ociRepo string
+
+		for _, addr := range peer.GetAddrs() {
+			switch {
+			case strings.HasPrefix(addr, "/dir/"):
+				dirAddr = strings.TrimPrefix(addr, "/dir/")
+			case strings.HasPrefix(addr, "/oci/"):
+				raw := strings.TrimPrefix(addr, "/oci/")
+				if idx := strings.LastIndex(raw, "/"); idx != -1 {
+					ociRegistry = raw[:idx]
+					ociRepo = raw[idx+1:]
+				} else {
+					ociRegistry = raw
+				}
+			}
+		}
+
+		// Use dir address as key when present; fall back to oci registry.
+		key := dirAddr
+		if key == "" {
+			key = ociRegistry
+		}
+
+		if key == "" {
 			continue
 		}
 
 		cid := result.GetRecordRef().GetCid()
 
-		if existing, exists := peerResults[apiAddress]; exists {
+		if existing, exists := peerResults[key]; exists {
 			existing.CIDs = append(existing.CIDs, cid)
-			peerResults[apiAddress] = existing
+			peerResults[key] = existing
 		} else {
-			peerResults[apiAddress] = PeerSyncInfo{
-				APIAddress: apiAddress,
-				CIDs:       []string{cid},
+			peerResults[key] = PeerSyncInfo{
+				APIAddress:    dirAddr,
+				OCIRegistry:   ociRegistry,
+				OCIRepository: ociRepo,
+				CIDs:          []string{cid},
 			}
 		}
 	}
@@ -372,36 +403,42 @@ func groupResultsByAPIAddress(results []*routingv1.SearchResponse) map[string]Pe
 }
 
 func createSyncOperations(cmd *cobra.Command, peerResults map[string]PeerSyncInfo) error {
-	client, ok := ctxUtils.GetClientFromContext(cmd.Context())
+	dirClient, ok := ctxUtils.GetClientFromContext(cmd.Context())
 	if !ok {
 		return errors.New("failed to get client from context")
 	}
 
-	totalSyncs := 0
-	totalCIDs := 0
-
 	syncIDs := make([]any, 0, len(peerResults))
 
-	for apiAddress, syncInfo := range peerResults {
-		if syncInfo.APIAddress == "" {
-			presenter.PrintSmartf(cmd, "WARNING: No API address found for peer\n")
-			presenter.PrintSmartf(cmd, "Skipping sync for this peer\n")
+	for _, syncInfo := range peerResults {
+		var (
+			syncID string
+			err    error
+		)
+
+		switch {
+		case syncInfo.APIAddress != "":
+			// /dir/ available (possibly alongside /oci/): prefer credential negotiation.
+			syncID, err = dirClient.CreateSync(cmd.Context(), syncInfo.APIAddress, syncInfo.CIDs, nil)
+		case syncInfo.OCIRegistry != "":
+			// Only /oci/ available: direct OCI pull.
+			syncID, err = dirClient.CreateSync(cmd.Context(), "", syncInfo.CIDs, &client.CreateSyncOptions{
+				RemoteRegistryURL: syncInfo.OCIRegistry,
+				RepositoryName:    syncInfo.OCIRepository,
+			})
+		default:
+			presenter.PrintSmartf(cmd, "WARNING: No usable address found for peer, skipping\n")
 
 			continue
 		}
 
-		// Create sync operation
-		syncID, err := client.CreateSync(cmd.Context(), syncInfo.APIAddress, syncInfo.CIDs, nil)
 		if err != nil {
-			presenter.PrintSmartf(cmd, "ERROR: Failed to create sync for peer %s: %v\n", apiAddress, err)
+			presenter.PrintSmartf(cmd, "ERROR: Failed to create sync: %v\n", err)
 
 			continue
 		}
 
 		syncIDs = append(syncIDs, syncID)
-
-		totalSyncs++
-		totalCIDs += len(syncInfo.CIDs)
 	}
 
 	return presenter.PrintMessage(cmd, "sync IDs", "Sync IDs created", syncIDs)

--- a/cli/cmd/sync/sync_test.go
+++ b/cli/cmd/sync/sync_test.go
@@ -155,7 +155,7 @@ func TestGroupResultsByAPIAddress_SingleResult(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid1"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://api1.example.com"},
+				Addrs: []string{"/dir/http://api1.example.com"},
 			},
 		},
 	}
@@ -175,21 +175,21 @@ func TestGroupResultsByAPIAddress_MultipleSamePeer(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid1"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://api1.example.com"},
+				Addrs: []string{"/dir/http://api1.example.com"},
 			},
 		},
 		{
 			RecordRef: &corev1.RecordRef{Cid: "cid2"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://api1.example.com"},
+				Addrs: []string{"/dir/http://api1.example.com"},
 			},
 		},
 		{
 			RecordRef: &corev1.RecordRef{Cid: "cid3"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://api1.example.com"},
+				Addrs: []string{"/dir/http://api1.example.com"},
 			},
 		},
 	}
@@ -209,21 +209,21 @@ func TestGroupResultsByAPIAddress_MultipleDifferentPeers(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid1"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://api1.example.com"},
+				Addrs: []string{"/dir/http://api1.example.com"},
 			},
 		},
 		{
 			RecordRef: &corev1.RecordRef{Cid: "cid2"},
 			Peer: &routingv1.Peer{
 				Id:    "peer2",
-				Addrs: []string{"http://api2.example.com"},
+				Addrs: []string{"/dir/http://api2.example.com"},
 			},
 		},
 		{
 			RecordRef: &corev1.RecordRef{Cid: "cid3"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://api1.example.com"},
+				Addrs: []string{"/dir/http://api1.example.com"},
 			},
 		},
 	}
@@ -259,7 +259,7 @@ func TestGroupResultsByAPIAddress_NoPeerInfo(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid3"},
 			Peer: &routingv1.Peer{
 				Id:    "peer2",
-				Addrs: []string{"http://api1.example.com"},
+				Addrs: []string{"/dir/http://api1.example.com"},
 			},
 		},
 	}
@@ -272,25 +272,27 @@ func TestGroupResultsByAPIAddress_NoPeerInfo(t *testing.T) {
 	assert.Equal(t, []string{"cid3"}, grouped["http://api1.example.com"].CIDs)
 }
 
-// TestGroupResultsByAPIAddress_MultipleAddresses tests using first address only.
+// TestGroupResultsByAPIAddress_MultipleAddresses tests address classification with /dir/ and /oci/ addrs.
 func TestGroupResultsByAPIAddress_MultipleAddresses(t *testing.T) {
 	results := []*routingv1.SearchResponse{
 		{
 			RecordRef: &corev1.RecordRef{Cid: "cid1"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://api1.example.com", "http://api2.example.com", "http://api3.example.com"},
+				Addrs: []string{"/dir/api1.example.com:443", "/oci/https://registry.example.com:5000/myrepo"},
 			},
 		},
 	}
 
 	grouped := groupResultsByAPIAddress(results)
 
-	// Should use the first address
+	// /dir/ address is preferred as the map key
 	assert.Len(t, grouped, 1)
-	assert.Contains(t, grouped, "http://api1.example.com")
-	assert.NotContains(t, grouped, "http://api2.example.com")
-	assert.NotContains(t, grouped, "http://api3.example.com")
+	assert.Contains(t, grouped, "api1.example.com:443")
+	info := grouped["api1.example.com:443"]
+	assert.Equal(t, "api1.example.com:443", info.APIAddress)
+	assert.Equal(t, "https://registry.example.com:5000", info.OCIRegistry)
+	assert.Equal(t, "myrepo", info.OCIRepository)
 }
 
 // TestGroupResultsByAPIAddress_MixedScenario tests complex real-world scenario.
@@ -301,14 +303,14 @@ func TestGroupResultsByAPIAddress_MixedScenario(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid1"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://peer1.com"},
+				Addrs: []string{"/dir/http://peer1.com"},
 			},
 		},
 		{
 			RecordRef: &corev1.RecordRef{Cid: "cid2"},
 			Peer: &routingv1.Peer{
 				Id:    "peer1",
-				Addrs: []string{"http://peer1.com"},
+				Addrs: []string{"/dir/http://peer1.com"},
 			},
 		},
 		// Peer 2 - single CID
@@ -316,7 +318,7 @@ func TestGroupResultsByAPIAddress_MixedScenario(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid3"},
 			Peer: &routingv1.Peer{
 				Id:    "peer2",
-				Addrs: []string{"http://peer2.com"},
+				Addrs: []string{"/dir/http://peer2.com"},
 			},
 		},
 		// No peer info - should be skipped
@@ -329,7 +331,7 @@ func TestGroupResultsByAPIAddress_MixedScenario(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid5"},
 			Peer: &routingv1.Peer{
 				Id:    "peer3",
-				Addrs: []string{"http://peer3.com"},
+				Addrs: []string{"/dir/http://peer3.com"},
 			},
 		},
 	}
@@ -397,7 +399,7 @@ func TestGroupResultsByAPIAddress_LargeDataset(t *testing.T) {
 			RecordRef: &corev1.RecordRef{Cid: "cid" + strings.Repeat("a", i)},
 			Peer: &routingv1.Peer{
 				Id:    "peer" + strings.Repeat("a", peerNum),
-				Addrs: []string{"http://peer" + strings.Repeat("a", peerNum) + ".com"},
+				Addrs: []string{"/dir/http://peer" + strings.Repeat("a", peerNum) + ".com"},
 			},
 		}
 	}
@@ -579,7 +581,7 @@ func TestGroupResultsByAPIAddress_EdgeCases(t *testing.T) {
 				{
 					RecordRef: &corev1.RecordRef{Cid: ""},
 					Peer: &routingv1.Peer{
-						Addrs: []string{"http://api.example.com"},
+						Addrs: []string{"/dir/http://api.example.com"},
 					},
 				},
 			},
@@ -591,7 +593,7 @@ func TestGroupResultsByAPIAddress_EdgeCases(t *testing.T) {
 				{
 					RecordRef: nil,
 					Peer: &routingv1.Peer{
-						Addrs: []string{"http://api.example.com"},
+						Addrs: []string{"/dir/http://api.example.com"},
 					},
 				},
 			},

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -498,6 +498,9 @@ func LoadConfig(opts ...ConfigOption) (*Config, error) {
 	_ = v.BindEnv("routing.directory_api_address")
 	v.SetDefault("routing.directory_api_address", "")
 
+	_ = v.BindEnv("routing.directory_oci_address")
+	v.SetDefault("routing.directory_oci_address", "")
+
 	_ = v.BindEnv("routing.bootstrap_peers")
 	v.SetDefault("routing.bootstrap_peers", strings.Join(routing.DefaultBootstrapPeers, ","))
 

--- a/server/routing/config/config.go
+++ b/server/routing/config/config.go
@@ -39,6 +39,13 @@ type Config struct {
 	// Address to use for sync operations
 	DirectoryAPIAddress string `json:"directory_api_address,omitempty" mapstructure:"directory_api_address"`
 
+	// DirectoryOCIAddress is this node's OCI registry endpoint advertised to
+	// peers (as an "/oci/<addr>" host multiaddr) so remote peers can pull record
+	// content directly from this node's registry. Optional; empty means not
+	// advertised. Independent of store.oci.registry_address — set the publicly
+	// reachable registry endpoint here.
+	DirectoryOCIAddress string `json:"directory_oci_address,omitempty" mapstructure:"directory_oci_address"`
+
 	// Peers to use for bootstrapping.
 	// We can choose between public and private peers.
 	BootstrapPeers []string `json:"bootstrap_peers,omitempty" mapstructure:"bootstrap_peers"`

--- a/server/routing/internal/p2p/host.go
+++ b/server/routing/internal/p2p/host.go
@@ -5,6 +5,7 @@ package p2p
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -13,6 +14,60 @@ import (
 	libp2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	ma "github.com/multiformats/go-multiaddr"
 )
+
+// EncodeAppAddr percent-encodes an application address (e.g. "ghcr.io/org/repo")
+// into a single multiaddr path segment, escaping "/" so it does not collide with
+// the multiaddr component separator. This mirrors the multiaddr /http-path
+// convention (RFC 3986 segment-nz encoding); the binary form is length-prefixed
+// so no encoding is needed there.
+func EncodeAppAddr(addr string) string {
+	return url.PathEscape(addr)
+}
+
+// DecodeAppAddr reverses EncodeAppAddr. On malformed input it returns the value
+// unchanged (best effort) so callers always get a usable string.
+func DecodeAppAddr(seg string) string {
+	decoded, err := url.PathUnescape(seg)
+	if err != nil {
+		return seg
+	}
+
+	return decoded
+}
+
+// buildAppAddrs constructs the advertised /dir/ and /oci/ host multiaddrs from
+// the configured (URL-form) addresses, skipping empty or invalid values.
+func buildAppAddrs(dirAPIAddr, ociAddr string) []ma.Multiaddr {
+	var out []ma.Multiaddr
+
+	if a := newAppAddr(DirProtocol, dirAPIAddr); a != nil {
+		out = append(out, a)
+	}
+
+	if a := newAppAddr(OciProtocol, ociAddr); a != nil {
+		out = append(out, a)
+	}
+
+	return out
+}
+
+// newAppAddr builds a "/<proto>/<percent-encoded addr>" multiaddr, or returns
+// nil (logging once) when the address is empty or cannot be represented.
+func newAppAddr(proto, addr string) ma.Multiaddr {
+	if addr == "" {
+		return nil
+	}
+
+	m, err := ma.NewMultiaddr("/" + proto + "/" + EncodeAppAddr(addr))
+	if err != nil {
+		logger.Warn("Ignoring invalid routing address; not advertised",
+			"protocol", proto, "value", addr, "error", err)
+
+		return nil
+	}
+
+	return m
+}
 
 const (
 	DirProtocol     = "dir"
@@ -76,25 +131,18 @@ func newHost(listenAddr, dirAPIAddr, ociAddr string, key crypto.PrivKey, enableR
 		return nil, fmt.Errorf("failed to create p2p host connection manager: %w", err)
 	}
 
+	// Precompute the advertised Directory API (/dir/) and OCI registry (/oci/)
+	// multiaddrs once; the AddrsFactory below runs on every address query. Values
+	// are percent-encoded so URL-form addresses (e.g. "ghcr.io/org/repo") survive
+	// the multiaddr separator. Invalid values are logged once and skipped.
+	appAddrs := buildAppAddrs(dirAPIAddr, ociAddr)
+
 	hostOpts := []libp2p.Option{
-		// Advertise the Directory API (/dir/) and OCI registry (/oci/) endpoints
-		// as host multiaddrs so peers learn them via identify. Each is optional;
-		// only non-empty values are appended.
+		// Advertise the app-level endpoints as host multiaddrs so peers learn
+		// them via identify.
 		libp2p.AddrsFactory(
 			func(addrs []ma.Multiaddr) []ma.Multiaddr {
-				if dirAPIAddr != "" {
-					if a, err := ma.NewMultiaddr("/" + DirProtocol + "/" + dirAPIAddr); err == nil {
-						addrs = append(addrs, a)
-					}
-				}
-
-				if ociAddr != "" {
-					if a, err := ma.NewMultiaddr("/" + OciProtocol + "/" + ociAddr); err == nil {
-						addrs = append(addrs, a)
-					}
-				}
-
-				return addrs
+				return append(addrs, appAddrs...)
 			},
 		),
 		// Use the keypair we generated

--- a/server/routing/internal/p2p/host.go
+++ b/server/routing/internal/p2p/host.go
@@ -17,16 +17,31 @@ import (
 const (
 	DirProtocol     = "dir"
 	DirProtocolCode = 65535
+	OciProtocol     = "oci"
+	OciProtocolCode = 65534
 )
 
-// Add dir protocol to the host.
-//
-//nolint:mnd
+// Register the custom /dir/ and /oci/ multiaddr protocols so a node's Directory
+// API and OCI registry endpoints can be carried as host multiaddrs and
+// propagated to other peers via libp2p identify.
 func init() {
+	if err := addStringProtocol(DirProtocol, DirProtocolCode); err != nil {
+		panic(err)
+	}
+
+	if err := addStringProtocol(OciProtocol, OciProtocolCode); err != nil {
+		panic(err)
+	}
+}
+
+// addStringProtocol registers a length-prefixed string multiaddr protocol,
+// letting an application-level address (e.g. host:port) ride along as a host
+// multiaddr component such as "/dir/<addr>" or "/oci/<addr>".
+func addStringProtocol(name string, code int) error {
 	err := ma.AddProtocol(ma.Protocol{
-		Name:  DirProtocol,
-		Code:  DirProtocolCode,
-		VCode: ma.CodeToVarint(DirProtocolCode),
+		Name:  name,
+		Code:  code,
+		VCode: ma.CodeToVarint(code),
 		Size:  ma.LengthPrefixedVarSize,
 		Transcoder: ma.NewTranscoderFromFunctions(
 			// String to bytes encoder
@@ -42,12 +57,14 @@ func init() {
 		),
 	})
 	if err != nil {
-		panic(fmt.Errorf("failed to add dir protocol: %w", err))
+		return fmt.Errorf("failed to add %q multiaddr protocol: %w", name, err)
 	}
+
+	return nil
 }
 
 // newHost creates a new host libp2p host.
-func newHost(listenAddr, dirAPIAddr string, key crypto.PrivKey, enableRelayService, forceReachabilityPrivate, forceReachabilityPublic bool) (host.Host, error) {
+func newHost(listenAddr, dirAPIAddr, ociAddr string, key crypto.PrivKey, enableRelayService, forceReachabilityPrivate, forceReachabilityPublic bool) (host.Host, error) {
 	// Create connection manager to limit and manage peer connections.
 	// This prevents resource exhaustion and enables smart peer pruning based on priority.
 	connMgr, err := connmgr.NewConnManager(
@@ -60,14 +77,21 @@ func newHost(listenAddr, dirAPIAddr string, key crypto.PrivKey, enableRelayServi
 	}
 
 	hostOpts := []libp2p.Option{
-		// Add directory API address to the host address factory
+		// Advertise the Directory API (/dir/) and OCI registry (/oci/) endpoints
+		// as host multiaddrs so peers learn them via identify. Each is optional;
+		// only non-empty values are appended.
 		libp2p.AddrsFactory(
 			func(addrs []ma.Multiaddr) []ma.Multiaddr {
-				// Only add the dir address if dirAPIAddr is not empty
 				if dirAPIAddr != "" {
-					dirAddr := ma.StringCast("/dir/" + dirAPIAddr)
+					if a, err := ma.NewMultiaddr("/" + DirProtocol + "/" + dirAPIAddr); err == nil {
+						addrs = append(addrs, a)
+					}
+				}
 
-					return append(addrs, dirAddr)
+				if ociAddr != "" {
+					if a, err := ma.NewMultiaddr("/" + OciProtocol + "/" + ociAddr); err == nil {
+						addrs = append(addrs, a)
+					}
 				}
 
 				return addrs

--- a/server/routing/internal/p2p/options.go
+++ b/server/routing/internal/p2p/options.go
@@ -25,6 +25,7 @@ type options struct {
 	Key                      crypto.PrivKey
 	ListenAddress            string
 	DirectoryAPIAddress      string
+	DirectoryOCIAddress      string
 	BootstrapPeers           []peer.AddrInfo
 	RefreshInterval          time.Duration
 	Randevous                string
@@ -104,6 +105,18 @@ func WithListenAddress(addr string) Option {
 func WithDirectoryAPIAddress(addr string) Option {
 	return func(opts *options) error {
 		opts.DirectoryAPIAddress = addr
+
+		return nil
+	}
+}
+
+// WithDirectoryOCIAddress sets the OCI registry endpoint this node advertises to
+// peers (as an "/oci/<addr>" host multiaddr), so remote peers can pull record
+// content directly from this node's registry. Optional; empty means not
+// advertised.
+func WithDirectoryOCIAddress(addr string) Option {
+	return func(opts *options) error {
+		opts.DirectoryOCIAddress = addr
 
 		return nil
 	}

--- a/server/routing/internal/p2p/server.go
+++ b/server/routing/internal/p2p/server.go
@@ -124,7 +124,7 @@ func start(ctx context.Context, opts *options) <-chan status {
 		defer cancel()
 
 		// Create host
-		host, err := newHost(opts.ListenAddress, opts.DirectoryAPIAddress, opts.Key, opts.RelayService, opts.ForceReachabilityPrivate, opts.ForceReachabilityPublic)
+		host, err := newHost(opts.ListenAddress, opts.DirectoryAPIAddress, opts.DirectoryOCIAddress, opts.Key, opts.RelayService, opts.ForceReachabilityPrivate, opts.ForceReachabilityPublic)
 		if err != nil {
 			statusCh <- status{Err: err}
 

--- a/server/routing/routing_remote.go
+++ b/server/routing/routing_remote.go
@@ -180,6 +180,7 @@ func newRemote(parentCtx context.Context,
 	server, err := p2p.New(parentCtx,
 		p2p.WithListenAddress(opts.Config().Routing.ListenAddress),
 		p2p.WithDirectoryAPIAddress(opts.Config().Routing.DirectoryAPIAddress),
+		p2p.WithDirectoryOCIAddress(opts.Config().Routing.DirectoryOCIAddress),
 		p2p.WithBootstrapAddrs(opts.Config().Routing.BootstrapPeers),
 		p2p.WithRefreshInterval(refreshInterval),
 		p2p.WithRandevous(ProtocolRendezvous), // enable libp2p auto-discovery
@@ -514,20 +515,36 @@ func (r *routeRemote) getRemoteRecordLabels(ctx context.Context, cid, peerID str
 	return labelList
 }
 
-// createPeerInfo creates a Peer message from a PeerID string.
+// createPeerInfo creates a Peer message from a PeerID string, advertising the
+// peer's Directory API (/dir/) and OCI registry (/oci/) endpoints when known.
+// Addresses are returned in prefixed multiaddr form (e.g. "/dir/host:443",
+// "/oci/host:5000") so the consumer can tell them apart. Missing endpoints are
+// omitted (the slice may be empty).
 func (r *routeRemote) createPeerInfo(ctx context.Context, peerID string) *routingv1.Peer {
-	dirAPIAddr := r.getDirectoryAPIAddress(ctx, peerID)
+	addrs := make([]string, 0, 2) //nolint:mnd // dir + oci
+
+	if v := r.getPeerProtocolAddress(ctx, peerID, p2p.DirProtocolCode); v != "" {
+		addrs = append(addrs, "/"+p2p.DirProtocol+"/"+v)
+	}
+
+	if v := r.getPeerProtocolAddress(ctx, peerID, p2p.OciProtocolCode); v != "" {
+		addrs = append(addrs, "/"+p2p.OciProtocol+"/"+v)
+	}
 
 	return &routingv1.Peer{
 		Id:    peerID,
-		Addrs: []string{dirAPIAddr},
+		Addrs: addrs,
 	}
 }
 
-func (r *routeRemote) getDirectoryAPIAddress(ctx context.Context, peerID string) string {
+// getPeerProtocolAddress returns the value of the given custom multiaddr
+// protocol (e.g. DirProtocolCode, OciProtocolCode) advertised by the peer,
+// checking the datastore cache first and falling back to the live peerstore.
+// Returns "" if the peer advertises no such address.
+func (r *routeRemote) getPeerProtocolAddress(ctx context.Context, peerID string, code int) string {
 	// Try datastore cache first (fast path)
-	if dirAddr := r.getDirectoryAPIAddressFromDatastore(ctx, peerID); dirAddr != "" {
-		return dirAddr
+	if addr := r.getPeerProtocolAddressFromDatastore(ctx, peerID, code); addr != "" {
+		return addr
 	}
 
 	// Fallback: Try live peerstore (handles mDNS and DHT without addresses)
@@ -540,35 +557,19 @@ func (r *routeRemote) getDirectoryAPIAddress(ctx context.Context, peerID string)
 
 	peerstoreAddrs := r.server.Host().Peerstore().Addrs(pid)
 	if len(peerstoreAddrs) == 0 {
-		remoteLogger.Warn("No Directory API address found for peer",
-			"peerID", peerID,
-			"note", "Peer might be discovered via mDNS or DHT without /dir/ configuration")
-
 		return ""
 	}
 
-	remoteLogger.Debug("Trying peerstore addresses for /dir/ protocol",
-		"peerID", peerID,
-		"addrs", len(peerstoreAddrs))
-
-	if dirAddr := extractDirProtocol(peerstoreAddrs, peerID); dirAddr != "" {
-		return dirAddr
-	}
-
-	remoteLogger.Warn("No /dir/ protocol found in peerstore addresses",
-		"peerID", peerID)
-
-	return ""
+	return extractProtocolValue(peerstoreAddrs, code)
 }
 
-// getDirectoryAPIAddressFromDatastore checks datastore cache for peer addresses.
-func (r *routeRemote) getDirectoryAPIAddressFromDatastore(ctx context.Context, peerID string) string {
+// getPeerProtocolAddressFromDatastore checks the datastore cache for the peer's
+// advertised value of the given multiaddr protocol code.
+func (r *routeRemote) getPeerProtocolAddressFromDatastore(ctx context.Context, peerID string, code int) string {
 	key := datastore.NewKey("peer_addrs/" + peerID)
 
 	addresses, err := r.dstore.Get(ctx, key)
 	if err != nil {
-		remoteLogger.Debug("No cached peer addresses in datastore", "peerID", peerID)
-
 		return ""
 	}
 
@@ -579,7 +580,7 @@ func (r *routeRemote) getDirectoryAPIAddressFromDatastore(ctx context.Context, p
 		return ""
 	}
 
-	return extractDirProtocol(multiaddrs, peerID)
+	return extractProtocolValue(multiaddrs, code)
 }
 
 // storePeerAddresses stores peer addresses in datastore for later retrieval.
@@ -626,27 +627,12 @@ func (r *routeRemote) storePeerAddresses(ctx context.Context, peerIDStr string, 
 	remoteLogger.Debug("Stored peer addresses", "peerID", peerIDStr, "count", len(peerAddrs))
 }
 
-// extractDirProtocol extracts the /dir/ protocol value from a list of multiaddrs.
-// Returns empty string if no /dir/ protocol is found.
-func extractDirProtocol(multiaddrs []ma.Multiaddr, peerID string) string {
+// extractProtocolValue returns the value of the given multiaddr protocol code
+// from the first address that carries it, or "" if none do.
+func extractProtocolValue(multiaddrs []ma.Multiaddr, code int) string {
 	for _, addr := range multiaddrs {
-		protocols := addr.Protocols()
-		for _, protocol := range protocols {
-			if protocol.Code == p2p.DirProtocolCode {
-				value, err := addr.ValueForProtocol(p2p.DirProtocolCode)
-				if err != nil {
-					remoteLogger.Debug("Failed to extract /dir/ protocol value",
-						"peerID", peerID,
-						"addr", addr.String(),
-						"error", err)
-				} else {
-					remoteLogger.Debug("Found Directory API address",
-						"peerID", peerID,
-						"dirAddress", value)
-
-					return value
-				}
-			}
+		if value, err := addr.ValueForProtocol(code); err == nil && value != "" {
+			return value
 		}
 	}
 

--- a/server/routing/routing_remote.go
+++ b/server/routing/routing_remote.go
@@ -628,11 +628,13 @@ func (r *routeRemote) storePeerAddresses(ctx context.Context, peerIDStr string, 
 }
 
 // extractProtocolValue returns the value of the given multiaddr protocol code
-// from the first address that carries it, or "" if none do.
+// from the first address that carries it, or "" if none do. The stored value is
+// percent-encoded (see p2p.EncodeAppAddr), so it is decoded back to its original
+// URL form before returning.
 func extractProtocolValue(multiaddrs []ma.Multiaddr, code int) string {
 	for _, addr := range multiaddrs {
 		if value, err := addr.ValueForProtocol(code); err == nil && value != "" {
-			return value
+			return p2p.DecodeAppAddr(value)
 		}
 	}
 


### PR DESCRIPTION
Register an `/oci/` multiaddr protocol alongside `/dir/` and add a `directory_oci_address` routing config that is advertised via identify. Routing search now returns both `/dir/` and `/oci/` prefixed addresses in `peer.addrs` so consumers can locate a peer's Directory API and OCI registry.