### PR TITLE
chore(docs): fix front-page Discord widget link

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -176,7 +176,7 @@ Need a skill, MCP server, or A2A partner? Your agent searches the Directory, wir
   <div class="dir-community-social">
     <a
       class="dir-community-card"
-      href="https://discord.gg/7dhMdJuc"
+      href="https://discord.gg/FbEnSHXD34"
       target="_blank"
       rel="noopener noreferrer"
     >


### PR DESCRIPTION
Fixes the Discord URL used by the front-page Community widget.

- old: https://discord.gg/7dhMdJuc
- new: https://discord.gg/FbEnSHXD34