### PR TITLE
fix(reconciler): normalize remote directory URL into gRPC dial target

### DIFF
--- a/reconciler/tasks/regsync/credentials.go
+++ b/reconciler/tasks/regsync/credentials.go
@@ -105,8 +105,11 @@ func buildClientConfigForRemote(remoteDirectoryURL string, authnConfig authnconf
 		return cfg, nil
 	}
 
+	// Normalize the URL into a gRPC dial target (host:port). grpc.NewClient
+	// cannot parse HTTP-style URLs like "https://ads.outshift.io"; passing one
+	// through produces "name resolver error: produced zero addresses".
 	cfg := &client.Config{
-		ServerAddress: remoteDirectoryURL,
+		ServerAddress: canonicalServerAddress(remoteDirectoryURL),
 		AuthMode:      "insecure",
 	}
 

--- a/reconciler/tasks/regsync/credentials_test.go
+++ b/reconciler/tasks/regsync/credentials_test.go
@@ -137,7 +137,7 @@ func TestBuildClientConfigForRemote(t *testing.T) {
 			config:      "",
 			remote:      "http://localhost:8888",
 			authn:       authnconfig.Config{},
-			wantAddress: "http://localhost:8888",
+			wantAddress: "localhost:8888",
 			wantMode:    "insecure",
 		},
 		{
@@ -150,10 +150,23 @@ func TestBuildClientConfigForRemote(t *testing.T) {
 				SocketPath: "/run/spire/agent.sock",
 				Audiences:  []string{"directory"},
 			},
-			wantAddress: "http://localhost:8888",
+			wantAddress: "localhost:8888",
 			wantMode:    "jwt",
 			wantSocket:  "/run/spire/agent.sock",
 			wantAud:     "directory",
+		},
+		{
+			name:   "https url without context is normalized to host:port",
+			config: "",
+			remote: "https://ads.outshift.io",
+			authn: authnconfig.Config{
+				Enabled:    true,
+				Mode:       authnconfig.AuthModeX509,
+				SocketPath: "unix:///run/spire/agent-sockets/api.sock",
+			},
+			wantAddress: "ads.outshift.io:443",
+			wantMode:    "x509",
+			wantSocket:  "unix:///run/spire/agent-sockets/api.sock",
 		},
 		{
 			name: "matching context overrides authn config",


### PR DESCRIPTION
## Summary
`dirctl sync create https://ads.outshift.io` failed in the reconciler with:  worker failed: failed to negotiate credentials: failed to request registry credentials from https://ads.outshift.io/: rpc error: code = Unavailable desc = name resolver error: produced zero addresses

The regsync credential-negotiation fallback passed the raw `remote_directory_url`
(scheme included) directly to `grpc.NewClient`. gRPC expects a `host:port` dial
target, not an HTTP-style URL, so its name resolver produced zero addresses.

### Root cause

In `reconciler/tasks/regsync/credentials.go`, `buildClientConfigForRemote` takes
a fallback branch when the reconciler pod has no matching dirctl client context
(the typical headless-reconciler case). That branch set:

```go
cfg := &client.Config{
    ServerAddress: remoteDirectoryURL, // e.g. "https://ads.outshift.io"
    AuthMode:      "insecure",
}
```

### Fix
Normalize the fallback ServerAddress with the existing canonicalServerAddress():
```go
cfg := &client.Config{
    ServerAddress: canonicalServerAddress(remoteDirectoryURL), // -> "ads.outshift.io:443"
    AuthMode:      "insecure",
}
```
