### PR TITLE
chore/add dir missing contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,5 @@ SPDX-License-Identifier: Apache-2.0
 2. Red Hat Inc.
 3. Modular
 4. Infosys
+5. Oracle Corp.
+6. Amazon Web Services (AWS)


### PR DESCRIPTION
- **docs: restore Modular and Infosys as legitimate contributors**
- **docs: map manual contributors to git history for dir**
