### PR TITLE
chore/fix morgan redhat

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,5 +11,5 @@ SPDX-License-Identifier: Apache-2.0
 2. Red Hat Inc.
 3. Modular
 4. Infosys
-5. Oracle Corp.
-6. Amazon Web Services (AWS)
+
+


### PR DESCRIPTION
- **docs: map manual contributors to git history for dir**
- **docs: remove Oracle and AWS; Morgan is Red Hat**
