### PR TITLE
fix(dir): increase db connection pool

### DIFF
--- a/server/database/database.go
+++ b/server/database/database.go
@@ -25,8 +25,9 @@ var logger = logging.Logger("database")
 type DB string
 
 const (
-	SQLite   DB = "sqlite"
-	Postgres DB = "postgres"
+	SQLite              DB = "sqlite"
+	Postgres            DB = "postgres"
+	defaultMaxIdleConns    = 10
 )
 
 func New(cfg config.Config) (types.DatabaseAPI, error) {
@@ -92,6 +93,10 @@ func newSQLite(cfg config.SQLiteConfig) (*gormdb.DB, error) {
 		return nil, fmt.Errorf("failed to connect to SQLite database: %w", err)
 	}
 
+	if err := configureSQLPool(db); err != nil {
+		return nil, fmt.Errorf("failed to configure SQLite connection pool: %w", err)
+	}
+
 	// SQLite does not enforce foreign keys by default; enable for CASCADE support.
 	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
 		return nil, fmt.Errorf("failed to enable SQLite foreign keys: %w", err)
@@ -144,7 +149,27 @@ func NewPostgresGormDb(cfg config.PostgresConfig) (*gorm.DB, error) {
 	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
 		host, port, cfg.Username, cfg.Password, database, sslMode)
 
-	return gorm.Open(postgres.Open(dsn), &gorm.Config{ //nolint:wrapcheck
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: newCustomLogger(),
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open PostgreSQL database: %w", err)
+	}
+
+	if err := configureSQLPool(db); err != nil {
+		return nil, fmt.Errorf("failed to configure PostgreSQL connection pool: %w", err)
+	}
+
+	return db, nil
+}
+
+func configureSQLPool(db *gorm.DB) error {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return fmt.Errorf("get sql.DB: %w", err)
+	}
+
+	sqlDB.SetMaxIdleConns(defaultMaxIdleConns)
+
+	return nil
 }


### PR DESCRIPTION
We're seeing slow queries reported by GORM in the reconciler logs:

```sql
2026/07/20 12:28:00 /build/server/database/gorm/scan.go:71 SLOW SQL >= 200ms
[283.626ms] [rows:19] SELECT * FROM "records" WHERE NOT EXISTS (
			SELECT 1 FROM scan_reports sr
			WHERE sr.record_cid = records.record_cid
			AND sr.updated_at >= '2026-07-13 12:28:00.641'
```

I confirmed the queries are not actually slow. I checked the queries with `EXPLAIN ANALYZE` and they are less than 1 milisecond (we don't have a lot of data)

I noticed the "slow" query is always the first query in the task. So I have good reason to believe they're slow because they're not re-using connections from the connection pool efficiently

This PR increases the connection pool - it will keep 10 connections warm even if they're idle (it was 2 by default). This should help with query execution times and reduce noise in the logs about slow queries
