### PR TITLE
docs(dir): document NL search, a2a-scanner, and extractor enrichment

### DIFF
--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -91,7 +91,7 @@ Guided first-run setup for a new environment — run it once after installing
 `dirctl`. It provisions the **OASF taxonomy extractor**: a small
 sentence-transformer model (`all-MiniLM-L6-v2`, ~89 MB) plus the OASF taxonomy,
 downloaded to a local asset directory. Those assets power local, **LLM-free**
-record enrichment (and, in future, free-text search) that runs in-process — no
+record enrichment and natural language search that runs in-process — no
 Python, no external inference service, no LLM API. The chosen OASF endpoint and
 asset directory are saved to the `dirctl` config so other commands load the
 provisioned assets automatically.

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -810,12 +810,51 @@ See the [MCP Registry API docs](https://registry.modelcontextprotocol.io/docs#/o
 
 ### Enrichment
 
-By default, the import command automatically enriches records using an LLM to map them to appropriate OASF skills and domains. The enrichment pipeline is built into `dirctl`: it runs an LLM with tool-calling support against the OASF schema tools exposed by `dirctl mcp serve`, so no external tooling is required. LLM enrichment can be skipped by specifying skills and domains explicitly in the config file (see **Skip enrichment** below).
+The import command enriches records by mapping them to OASF skills and domains. Three enrichment methods are available, configured under the `enricher` key in the `--config` YAML file. When no config file is provided, LLM enrichment is used by default (azure:gpt-4o, 2 RPM).
+
+#### Extractor enrichment (LLM-free, recommended)
+
+Uses the local OASF sentence-transformer model provisioned by `dirctl init` to classify records in-process — no API key, no external service, no LLM runtime. This is the fastest option and works offline.
+
+**Requires:** `dirctl init` to have been run at least once to provision the model assets.
+
+```yaml
+enricher:
+  extractor: {}           # uses assets provisioned by dirctl init
+```
+
+To override the default asset location:
+
+```yaml
+enricher:
+  extractor:
+    oasf_url: https://schema.oasf.outshift.com   # optional
+    asset_dir: /path/to/custom/assets             # optional
+```
+
+#### Static enrichment
+
+Assigns the same fixed skills and domains to every imported record. No LLM or model assets required.
+
+```yaml
+enricher:
+  static:
+    skills:
+      - name: natural_language_processing/text_completion
+        id: 10201
+    domains:
+      - name: technology
+        id: 1
+```
+
+#### LLM enrichment
+
+Runs an LLM with tool-calling support against the OASF schema tools exposed by `dirctl mcp serve`. Produces the most semantically accurate skill and domain assignments but requires LLM credentials or a local runtime.
 
 **Requirements:**
 
 - `dirctl` binary (includes the built-in MCP server with `agntcy_oasf_get_schema_skills` and `agntcy_oasf_get_schema_domains` tools)
-- An LLM model with tool-calling support (GPT-4o, Claude, or compatible Ollama models)
+- An LLM with tool-calling support (GPT-4o, Claude, or compatible Ollama models)
 
 **How it works:**
 
@@ -824,43 +863,25 @@ By default, the import command automatically enriches records using an LLM to ma
 3. The LLM uses the `agntcy_oasf_get_schema_domains` tool to browse available OASF domains
 4. Based on the record description and capabilities, the LLM selects appropriate skills and domains
 
-**Configuration via `--config`:**
-
-Enrichment is configured under the `enricher` key in the `--config` YAML file. A built-in default (azure:gpt-4o, 2 RPM) is used when no config file is provided. The YAML below shows all available options:
-
 ```yaml
 enricher:
-  requests_per_minute: 5          # LLM API calls per minute (rate limit)
-  tool_host:
-    model: azure:gpt-4o
-    max_steps: 10
-    mcp_servers:
-      dir-mcp-server:
-        command: dirctl
-        args: [mcp, serve]
-        env:
-          OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
-          DIRECTORY_CLIENT_AUTH_MODE: insecure
-  skills_prompt_template: ./prompts/skills.md    # optional custom prompt
-  domains_prompt_template: ./prompts/domains.md  # optional custom prompt
+  llm:
+    requests_per_minute: 5
+    tool_host:
+      model: azure:gpt-4o
+      max_steps: 10
+      mcp_servers:
+        dir-mcp-server:
+          command: dirctl
+          args: [mcp, serve]
+          env:
+            OASF_API_VALIDATION_SCHEMA_URL: https://schema.oasf.outshift.com
+            DIRECTORY_CLIENT_AUTH_MODE: insecure
+    skills_prompt_template: ./prompts/skills.md    # optional custom prompt
+    domains_prompt_template: ./prompts/domains.md  # optional custom prompt
 ```
 
 See `cli/cmd/import/import.config.yaml` in the repository for a fully annotated reference configuration.
-
-**Skip enrichment** (static taxonomy):
-
-To bypass LLM enrichment and tag every record with fixed skills and domains, set `skip_enricher: true` — no `tool_host` or LLM credentials are required:
-
-```yaml
-enricher:
-  skip_enricher: true
-  skills:
-    - name: natural_language_processing/text_completion
-      id: 10201
-  domains:
-    - name: technology
-      id: 1
-```
 
 **Recommended LLM providers:**
 

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -1286,7 +1286,7 @@ Omit the positional argument and use filter flags to query specific fields. All 
 
 ### Security Scanning
 
-The Directory reconciler automatically runs security scanners against records and stores the results as OCI referrers. Scan results are indexed in the local database so they can be queried as search filters. Two scanners are supported: [mcp-scanner](https://cisco-ai-defense.github.io/docs/mcp-scanner) for MCP server source code and [skill-scanner](https://cisco-ai-defense.github.io/docs/skill-scanner) for agent skill bundles.
+The Directory reconciler automatically runs security scanners against records and stores the results as OCI referrers. Scan results are indexed in the local database so they can be queried as search filters. Three scanners are supported: [mcp-scanner](https://cisco-ai-defense.github.io/docs/mcp-scanner) for MCP server source code, [skill-scanner](https://cisco-ai-defense.github.io/docs/skill-scanner) for agent skill bundles, and [a2a-scanner](https://github.com/cisco-ai-defense/a2a-scanner) for A2A AgentCards.
 
 **Pull scan reports for a record:**
 
@@ -1298,7 +1298,7 @@ The response includes a `scanReports` array. Each entry covers one scanner type 
 
 | Field | Description |
 |-------|-------------|
-| `scanner_type` | Scanner that produced this report (`SCANNER_TYPE_MCP`, `SCANNER_TYPE_SKILL`) |
+| `scanner_type` | Scanner that produced this report (`SCANNER_TYPE_MCP`, `SCANNER_TYPE_SKILL`, `SCANNER_TYPE_A2A`) |
 | `scanner_version` | Version of the scanner binary |
 | `scanned_at` | RFC 3339 timestamp of when the scan ran |
 | `is_safe` | `true` if the scanner found no security issues |
@@ -1321,7 +1321,7 @@ dirctl search --name "cisco.com/*" --safe
 dirctl search --safe --scan-severity MEDIUM
 ```
 
-A record appears in `--safe` results only when at least one scanner has run and no scanner has reported `is_safe=false`. Records where all scanners were skipped (no source repo, no skill bundle) are not included.
+A record appears in `--safe` results only when at least one scanner has run and no scanner has reported `is_safe=false`. Records where all scanners were skipped (no source repo, no skill bundle, no A2A AgentCard) are not included.
 
 ### Name Verification
 

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -1073,47 +1073,87 @@ The following flags are available:
     dirctl routing list --skill "AI" --limit 5
     ```
 
-### `dirctl routing search [flags]`
+### `dirctl routing search [query] [flags]`
 
-Discovers records from other peers across the network.
+Discovers records from other peers across the DHT network. Two modes are available:
 
-The following flags are available:
+| Mode | Invocation | Requires |
+|------|-----------|----------|
+| **Natural-language** | `dirctl routing search "free-text query"` | `dirctl init` (OASF extractor) |
+| **Structured** | `dirctl routing search --skill "..." --domain "..."` | None |
 
-- `--skill <skill>` - Search by skill (repeatable)
-- `--locator <type>` - Search by locator type (repeatable)
-- `--domain <domain>` - Search by domain (repeatable)
-- `--module <module>` - Search by module name (repeatable)
-- `--limit <number>` - Maximum results to return
-- `--min-score <score>` - Minimum match score threshold
+#### Natural-language routing search
 
-The output includes the following:
+Pass a free-text phrase as a positional argument. The OASF extractor decomposes the phrase into skill and domain signals. Keyword signals are dropped because the DHT only indexes skills, domains, locators, and modules — there is no name or description index at the routing layer.
 
-- Record CID and provider peer information
-- Match score showing query relevance
-- Specific queries that matched
-- Peer connection details
+Each signal is queried against the DHT independently; the discovered window of results is then reordered by match score, best-first. This is not a global top-N: only the records returned within `--limit` are reordered.
+
+```bash
+dirctl routing search "Github MCP server that manages issues"
+dirctl routing search "real-time fraud detection for banking"
+```
+
+Use `--schema-version` to restrict NL extraction to a specific OASF schema version:
+
+```bash
+dirctl routing search "code review agent" --schema-version 1.0.0
+```
+
+Use `--verbose` to print the extracted signals to stderr:
+
+```bash
+dirctl routing search "fraud detection for banking" --verbose
+# stderr output:
+# [nl-routing-search] signals extracted (2 usable of 3 total):
+#   RECORD_QUERY_TYPE_SKILL   fraud_detection
+#   RECORD_QUERY_TYPE_DOMAIN  finance
+# (keyword signal "banking" dropped — no DHT equivalent)
+```
+
+#### Structured routing search
+
+Omit the positional argument and use filter flags. All flags are repeatable and combined with OR logic: a record matches if it satisfies at least `--min-score` of the specified queries.
+
+**Flags:**
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--skill` | Search by skill name (repeatable) | — |
+| `--domain` | Search by domain name (repeatable) | — |
+| `--locator` | Search by locator type (repeatable) | — |
+| `--module` | Search by module path (repeatable) | — |
+| `--limit` | Maximum results to return | `10` |
+| `--min-score` | Minimum number of queries that must match | `1` |
+| `--schema-version` | Restrict NL extraction to specific OASF schema version(s) (repeatable; NL mode only) | all versions |
+| `--verbose` | Print extracted NL signals and per-signal details to stderr (NL mode only) | `false` |
+
+**Output includes** record CID, provider peer information, match score, and the specific queries that matched.
 
 ??? example
 
     ```bash
-    # Search for AI records across the network
+    # Natural-language search across the network
+    dirctl routing search "Github MCP server that manages issues"
+
+    # Structured: search for AI records
     dirctl routing search --skill "AI"
 
-    # Search with multiple criteria
+    # Structured: search with multiple criteria (record must match at least 2)
     dirctl routing search --skill "AI" --skill "ML" --min-score 2
 
-    # Search by locator type
+    # Structured: search by locator type
     dirctl routing search --locator "docker-image"
 
-    # Search by module
+    # Structured: search by module
     dirctl routing search --module "runtime/framework"
 
-    # Advanced search with scoring
+    # Structured: combined filters
     dirctl routing search --skill "web-development" --limit 10 --min-score 1
     dirctl routing search --domain "finance" --module "validation" --min-score 2
-    ```
 
-**Output includes:**
+    # Pipe results into sync
+    dirctl routing search --skill "AI" --output json | dirctl sync create --stdin
+    ```
 
 ### `dirctl routing info`
 
@@ -1135,11 +1175,52 @@ The output includes the following:
 
 ## Search & Discovery
 
-### `dirctl search [flags]`
+### `dirctl search [query] [flags]`
 
-Search the local index using structured filter flags.
+Search for records in the local index. Two modes are available depending on whether a positional argument is provided:
 
-**Filter flags** (all repeatable):
+| Mode | Invocation | Requires |
+|------|-----------|----------|
+| **Natural-language** | `dirctl search "free-text query"` | `dirctl init` (OASF extractor) |
+| **Structured** | `dirctl search --name "..." --skill "..."` | None |
+
+#### Natural-language search
+
+Pass a free-text phrase as a positional argument. The OASF extractor (provisioned by [`dirctl init`](#dirctl-init-flags)) decomposes the phrase into typed signals — skill names, domain names, and keywords. Each signal is queried against the index independently and concurrently; results are ranked by how many signals matched, with the best-matching records returned first.
+
+```bash
+dirctl search "Github MCP server that manages issues"
+dirctl search "real-time fraud detection for banking" --format record
+dirctl search "code review assistant" --limit 5 --format record
+```
+
+If the extractor has not been provisioned, the command fails with a prompt to run `dirctl init`.
+
+Use `--verbose` to print signal decomposition and per-signal hit counts to stderr — useful for understanding why a query returns particular results:
+
+```bash
+dirctl search "fraud detection for banking" --verbose
+# stderr output:
+# [nl-search] signals extracted (3):
+#   skill     fraud_detection                                       score=0.91
+#   domain    finance                                               score=0.87
+#   keyword   banking                                               score=0.74
+# [nl-search] per-signal hits:
+#   skill     fraud_detection                                       → 12 CIDs
+#   domain    finance                                               → 31 CIDs
+#   keyword   banking                                               → 8 CIDs
+# [nl-search] ranked results (36 unique, 3 signals):
+#   sha256:abc...  hits=3/3  signals=[skill:fraud_detection, domain:finance, keyword:banking]
+#   ...
+```
+
+> **Note:** `--sort` is ignored in NL mode — results are always ranked by signal-hit-count.
+
+#### Structured search
+
+Omit the positional argument and use filter flags to query specific fields. All filter flags are repeatable and combinable.
+
+**Filter flags:**
 
 | Flag | Description |
 |------|-------------|
@@ -1160,13 +1241,15 @@ Search the local index using structured filter flags.
 | `--safe` | Only records where all security scanners reported `is_safe=true` |
 | `--scan-severity` | Only records whose highest scan severity meets or exceeds a threshold (`NONE`, `INFO`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`) |
 
-**Other flags:**
+**Output and pagination flags:**
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--format` | Output format: `cid` or `record` | `cid` |
+| `--sort` | Result ordering for structured search: `relevance`, `popularity`, or `recency` | `recency` |
 | `--limit` | Maximum results | `100` |
 | `--offset` | Pagination offset | `0` |
+| `--verbose` | Print NL signal decomposition and per-signal hit counts to stderr (NL mode only) | `false` |
 
 ??? example
 
@@ -1186,6 +1269,12 @@ Search the local index using structured filter flags.
       --skill "Text Completion" \
       --locator docker-image \
       --format record
+
+    # Sort by most recently published
+    dirctl search --skill "code-review" --sort recency
+
+    # Sort by most popular (pull frequency)
+    dirctl search --domain finance --sort popularity
 
     # Security scan filters
     dirctl search --safe

--- a/docs/content/dir/dir-component-import.md
+++ b/docs/content/dir/dir-component-import.md
@@ -24,27 +24,29 @@ LLM-powered skill and domain mapping to ensure consistency with the OASF schema.
 ### Translation and enrichment
 
 Records are transformed from external registry data into OASF-compliant format, which
-directly impacts how records are indexed and discovered across the network. Three methods are
+directly impacts how records are indexed and discovered across the network. Four methods are
 available:
 
 - **Basic translation** uses [OASF-SDK basic translation](https://docs.agntcy.org/oasf/translation/)
   with rule-based mapping. It is fast and deterministic but produces a record without any
   skills or domains, requiring manual or LLM-based enrichment afterwards.
-- **Static enrichment** assigns fixed skills and domains to every record by setting
-  `skip_enricher: true` in the `--config` file and listing the taxonomy entries explicitly.
-  No LLM or API credentials are required.
-- **Local LLM enrichment** runs an LLM locally for intelligent skill and domain mapping,
-  requiring a local LLM runtime.
-- **Remote LLM enrichment** uses external LLM services for skill and domain mapping,
-  requiring API credentials.
+- **Static enrichment** assigns fixed skills and domains to every record by listing the
+  taxonomy entries explicitly in the `--config` file. No LLM or API credentials are required.
+- **Extractor enrichment** uses the local OASF sentence-transformer model provisioned by
+  `dirctl init` to classify each record into OASF skills and domains automatically — no LLM,
+  no API key, no external service. This is the fastest and most accessible enrichment path for
+  users who have already run `dirctl init`. Enable it by setting `enricher.extractor: {}`
+  in the `--config` file.
+- **LLM enrichment** uses an LLM with tool-calling support (local via Ollama or remote via
+  Azure OpenAI and compatible providers) for intelligent skill and domain mapping. This is the
+  default when no `--config` file is provided (azure:gpt-4o, 2 RPM). Requires API credentials
+  or a running local LLM runtime.
 
-LLM enrichment runs automatically by default (azure:gpt-4o, 2 RPM) and can be customised or
-skipped entirely via the `--config` YAML file. Both LLM methods require access to an LLM with
-tool-calling support and the corresponding provider credentials (for example, Azure OpenAI, or
-a local model via Ollama). The enrichment pipeline is built into `dirctl` — it runs the OASF
-schema tools exposed by `dirctl mcp serve` against the model.
+The enrichment pipeline is built into `dirctl` — LLM enrichment runs the OASF schema tools
+exposed by `dirctl mcp serve` against the model, while extractor enrichment runs the
+provisioned model in-process with no external dependencies.
 See [CLI Reference — Enrichment](dir-cli-reference.md#enrichment)
-for provider setup and configuration details.
+for configuration details and YAML examples for each method.
 
 ### Supported import kinds
 

--- a/docs/content/dir/dir-component-trust-model.md
+++ b/docs/content/dir/dir-component-trust-model.md
@@ -94,7 +94,7 @@ vulnerabilities, policy violations, and malicious patterns before records are co
 
 ### How scanning works
 
-The Directory reconciler runs two scanner types against each record:
+The Directory reconciler runs three scanner types against each record:
 
 - **[MCP scanner](https://cisco-ai-defense.github.io/docs/mcp-scanner)** (`mcp-scanner behavioral`) — clones the source repository referenced in the
   record's `source_code` locator and runs behavioral analysis. Invoked automatically for
@@ -103,6 +103,9 @@ The Directory reconciler runs two scanner types against each record:
   agentskills bundle from the record's `integration/mcp` module artifact and runs static,
   bytecode, pipeline, behavioral, and trigger analyzers. Invoked automatically for records
   that include a skill bundle.
+- **[A2A scanner](https://github.com/cisco-ai-defense/a2a-scanner)** (`a2a-scanner scan-card`) — reads the A2A AgentCard stored in the record's
+  `a2a` module (`card_data` field) and scans it for policy violations and security issues.
+  Invoked automatically for records that include an A2A AgentCard.
 
 Scan results are persisted in two places:
 
@@ -140,7 +143,7 @@ Scanners are installed via `uv`:
 task deps:scanners
 ```
 
-This installs `mcp-scanner` and `skill-scanner` to `~/.local/bin/` (added to PATH automatically by `uv`). For CI environments, the task is also available as `task deps:mcp-scanner` and `task deps:skill-scanner` separately.
+This installs `mcp-scanner`, `skill-scanner`, and `a2a-scanner` to `~/.local/bin/` (added to PATH automatically by `uv`). For CI environments, the task is also available as `task deps:mcp-scanner`, `task deps:skill-scanner`, and `task deps:a2a-scanner` separately.
 
 ### Accessing scan results
 

--- a/docs/content/dir/dir-features-scenarios.md
+++ b/docs/content/dir/dir-features-scenarios.md
@@ -219,9 +219,11 @@ dirctl pull example.com/agents/my-record:v1.0.0@$RECORD_CID
 
 The Directory reconciler automatically scans records for security issues using
 [`mcp-scanner`](https://cisco-ai-defense.github.io/docs/mcp-scanner)
-(for MCP server source code) and
+(for MCP server source code),
 [`skill-scanner`](https://cisco-ai-defense.github.io/docs/skill-scanner)
-(for agent skill bundles). Scan results are
+(for agent skill bundles), and
+[`a2a-scanner`](https://github.com/cisco-ai-defense/a2a-scanner)
+(for A2A AgentCards). Scan results are
 stored as OCI referrers and indexed in the local database so they can be surfaced through
 search filters and pulled alongside records.
 
@@ -255,7 +257,7 @@ dirctl search --module "integration/mcp" --scan-severity MEDIUM
 
 `--safe` requires that at least one scanner ran and that no scanner reported `is_safe=false`.
 Records where all scanners were skipped (no source repo locator for MCP, no skill bundle for
-skill-scanner) are excluded.
+skill-scanner, no A2A AgentCard for a2a-scanner) are excluded.
 
 `--scan-severity <threshold>` returns records whose highest recorded severity is at or above
 the threshold. Severity levels from lowest to highest: `NONE`, `INFO`, `LOW`, `MEDIUM`,

--- a/docs/content/dir/dir-quickstart.md
+++ b/docs/content/dir/dir-quickstart.md
@@ -40,7 +40,7 @@ only page on the docs site with CLI installation instructions.
 
 Run the guided first-run setup once after installing. It provisions the OASF
 taxonomy extractor (a ~89 MB model plus the taxonomy) for local, LLM-free record
-enrichment and future free-text search:
+enrichment and natural language search:
 
 ```bash
 dirctl init


### PR DESCRIPTION
Several recently shipped features were missing from the docs. This PR documents NL search for `dirctl search` and `dirctl routing search` (invocation, signal decomposition, `--verbose/--sort/--schema-version` flags), adds `a2a-scanner` alongside the existing scanner docs in three places, and introduces extractor enrichment as a zero-LLM import path for users who have run `dirctl init`. Stale copy describing NL search as a future feature is also removed.