### PR TITLE
fix(cli): import extractor schema version scope

### DIFF
--- a/cli/cmd/import/config.go
+++ b/cli/cmd/import/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/agntcy/dir-importer/config"
 	enricherconfig "github.com/agntcy/dir-importer/enricher/config"
 	"github.com/agntcy/dir-importer/enricher/toolhost"
+	"github.com/agntcy/dir-importer/transformer"
 	internalextractor "github.com/agntcy/dir/cli/internal/extractor"
 	sdk "github.com/agntcy/oasf-sdk/pkg/extractor"
 	"github.com/spf13/pflag"
@@ -85,10 +86,10 @@ type taxonomyEntry struct {
 func (o *options) loadConfig(flags *pflag.FlagSet) error {
 	fileHasEnricher := false
 
-	// SchemaVersion is derived below (from the config file or the extractor's
-	// latest version); it is not flag-backed, so flag resets never clear it.
-	// Reset it up front so a prior in-process invocation — the e2e suite reuses
-	// this command's package-level options — cannot leak its value into this run.
+	// SchemaVersion comes only from the config file (below) and is not flag-backed,
+	// so flag resets never clear it. Reset it up front so a prior in-process
+	// invocation — the e2e suite reuses this command's package-level options —
+	// cannot leak its value into this run and stamp records with the wrong version.
 	o.SchemaVersion = ""
 
 	if o.ConfigFile != "" {
@@ -135,20 +136,17 @@ func (o *options) loadConfig(flags *pflag.FlagSet) error {
 				return fmt.Errorf("extractor enricher: %w", loadErr)
 			}
 
-			// The extractor classifies against its newest provisioned OASF version
-			// (oasfExtractorAdapter uses sdk.Latest()), so it assigns classes that
-			// only exist in that version. Records are validated against the schema of
-			// their own schema_version, so an unset version would fall back to the
-			// transformer default (an older release) and the server would reject the
-			// newer classes as unknown. Align the stamped version with the extractor
-			// unless the config pins one explicitly.
-			if o.SchemaVersion == "" {
-				o.SchemaVersion = sdkExt.LatestVersion()
+			// Scope the extractor to the same OASF version the transformer stamps on
+			// the record (its schema_version, defaulting to transformer.DefaultSchemaVersion
+			// when unset) so the assigned classes validate against the record's schema.
+			schemaVersion := o.SchemaVersion
+			if schemaVersion == "" {
+				schemaVersion = transformer.DefaultSchemaVersion
 			}
 
 			o.Enricher = enricherconfig.Config{
 				Extractor: &enricherconfig.ExtractorConfig{
-					Extractor: &oasfExtractorAdapter{ext: sdkExt},
+					Extractor: &oasfExtractorAdapter{ext: sdkExt, schemaVersion: schemaVersion},
 				},
 			}
 		}

--- a/cli/cmd/import/extractor_adapter.go
+++ b/cli/cmd/import/extractor_adapter.go
@@ -15,13 +15,18 @@ import (
 // the import pipeline can use the local OASF extractor for in-process enrichment.
 type oasfExtractorAdapter struct {
 	ext *sdk.Extractor
+	// schemaVersion is the OASF version the enriched record is stamped with; the
+	// extractor is scoped to it so assigned classes match the schema the server
+	// validates the record against.
+	schemaVersion string
 }
 
 func (a *oasfExtractorAdapter) Extract(ctx context.Context, text string) (enricherconfig.ExtractResult, error) {
-	// Latest() restricts results to classes present in the newest provisioned OASF version,
-	// preventing stale classes from older versions (e.g. 0.8.0) from being assigned to records
-	// that will be validated against the current schema.
-	result, err := a.ext.Extract(ctx, text, sdk.Latest())
+	// Scope the extractor to the record's own schema version so it only assigns
+	// classes that exist in that version. Latest() would drift ahead of the record's
+	// stamped version (e.g. after an OASF release) and the server would reject the
+	// newer classes as unknown when validating against the record's schema.
+	result, err := a.ext.Extract(ctx, text, sdk.Versions(a.schemaVersion))
 	if err != nil {
 		return enricherconfig.ExtractResult{}, fmt.Errorf("extract taxonomy: %w", err)
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -20,7 +20,7 @@ replace (
 
 require (
 	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260703134941-ebce38fee5a5.1
-	github.com/agntcy/dir-importer v1.5.1
+	github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182
 	github.com/agntcy/dir-mcp v1.3.3
 	github.com/agntcy/dir-runtime/discovery v1.3.3
 	github.com/agntcy/dir-runtime/server v1.3.3

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.5.1 h1:JkdGEHO6bn5C8igbO6J7/bEmNDqDlj1Qd51fuPV1fS4=
-github.com/agntcy/dir-importer v1.5.1/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
+github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182 h1:7sJuArFBh7isJq1WEw/i5r//RHlwICVqy89DAd8v1lA=
+github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
 github.com/agntcy/dir-mcp v1.3.3 h1:jXKMAIPbRJbtp+YuqNqM77l4cBCGUkZ/D/SkokZ1EZw=
 github.com/agntcy/dir-mcp v1.3.3/go.mod h1:bHI1khnD0ni8gl9l3xxfJJNFD8qHqN6wPHN2kC3hdjs=
 github.com/agntcy/dir-runtime/discovery v1.3.3 h1:iXmR2MZ41UEZWSspZL6tB5IO09nS82WCQVroDacCEnM=

--- a/tests/e2e/local/10_export_test.go
+++ b/tests/e2e/local/10_export_test.go
@@ -29,10 +29,10 @@ func importerWithStaticEnricher(ctx context.Context, client importerconfig.Clien
 	cfg.Enricher = enricherconfig.Config{
 		Static: &enricherconfig.StaticConfig{
 			Skills: []*typesv1.Skill{
-				{Name: "natural_language_processing/natural_language_understanding/contextual_comprehension", Id: 10101},
+				{Name: "software_engineering/code_quality/code_review", Id: 60701},
 			},
 			Domains: []*typesv1.Domain{
-				{Name: "technology/software_engineering", Id: 102},
+				{Name: "technology/artificial_intelligence/ai_agents", Id: 11107},
 			},
 		},
 	}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -16,7 +16,7 @@ replace (
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0
 
 require (
-	github.com/agntcy/dir-importer v1.5.1
+	github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182
 	github.com/agntcy/dir/api v1.6.1
 	github.com/agntcy/dir/cli v1.6.1
 	github.com/agntcy/dir/client v1.6.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -198,8 +198,8 @@ github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7l
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/agntcy/dir-importer v1.5.1 h1:JkdGEHO6bn5C8igbO6J7/bEmNDqDlj1Qd51fuPV1fS4=
-github.com/agntcy/dir-importer v1.5.1/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
+github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182 h1:7sJuArFBh7isJq1WEw/i5r//RHlwICVqy89DAd8v1lA=
+github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
 github.com/agntcy/dir-mcp v1.3.3 h1:jXKMAIPbRJbtp+YuqNqM77l4cBCGUkZ/D/SkokZ1EZw=
 github.com/agntcy/dir-mcp v1.3.3/go.mod h1:bHI1khnD0ni8gl9l3xxfJJNFD8qHqN6wPHN2kC3hdjs=
 github.com/agntcy/dir-runtime/discovery v1.3.3 h1:iXmR2MZ41UEZWSspZL6tB5IO09nS82WCQVroDacCEnM=


### PR DESCRIPTION
## Summary

Fixes the extractor-enricher import path after the **OASF 1.1.0** release and moves the import stack onto 1.1.0.

The `16_extractor_enricher` e2e test began failing once OASF 1.1.0 was published: the import reported success (exit 0) but wrote no CIDs, so the test failed reading `imported.cids`.

## Root cause

The extractor enricher classified records via `sdk.Latest()`, which follows the newest **provisioned** OASF taxonomy. Once 1.1.0 was provisioned, it assigned 1.1.0-only classes (e.g. skill `60701`). But records were stamped `schema_version: 1.0.0` (the transformer default). The server validates each record against the schema of its **own** `schema_version` (`{schema_url}/api/{version}/validate/...`), so the 1.1.0 classes were rejected against the 1.0.0 schema as `id_unknown` → 0 records imported. Because `dirctl import` still exits 0 when nothing imports, `--output-cids` silently wrote no file.

## Changes

**1. Scope the extractor to the record's declared schema version** (`fix(import)`)
- `extractor_adapter.go`: replace `sdk.Latest()` with `sdk.Versions(a.schemaVersion)` so the extractor only assigns classes that exist in the version the record is stamped (and validated) with.
- `config.go`: pass the effective schema version (`o.SchemaVersion`, or `transformer.DefaultSchemaVersion` when unset) into the adapter. `o.SchemaVersion` is reset at the top of `loadConfig` because it is not flag-backed and the e2e suite runs `dirctl` in-process, reusing the command's package-level options — without the reset a prior invocation's value leaks into later runs.

This keeps the extractor's taxonomy version and the record's `schema_version` aligned by construction, for any declared version, and won't drift again on the next OASF release.

**2. Bump dir-importer to OASF 1.1.0** (`chore(deps)`)
- Pins dir-importer to [agntcy/dir-importer#71](https://github.com/agntcy/dir-importer/pull/71), which sets `DefaultSchemaVersion` and the LLM enricher prompts to `1.1.0`. Records now default to 1.1.0, consistent with the extractor scoping and the reference `import.config.yaml`.
- Updates the `10_export` static-enricher fixture to 1.1.0 taxonomy classes (`software_engineering/code_quality/code_review`, `technology/artificial_intelligence/ai_agents`), since the new default schema would otherwise reject its old 1.0.0 classes.

> [!NOTE]
> dir-importer has no 1.1.0 release tag yet, so this pins the merged `main` commit via a pseudo-version. Swap it for the tagged release once published.

