### PR TITLE
fix(database): resolve ambiguous column reference in usage metrics upserts

### DIFF
--- a/server/database/gorm/usage_metrics.go
+++ b/server/database/gorm/usage_metrics.go
@@ -55,7 +55,7 @@ func (d *DB) IncrementPullCount(cid string) error {
 	err := d.gormDB.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "record_cid"}},
 		DoUpdates: clause.Assignments(map[string]any{
-			"pull_count":   gorm.Expr("pull_count + 1"),
+			"pull_count":   gorm.Expr("record_usage_metrics.pull_count + 1"),
 			"last_used_at": now,
 			"updated_at":   now,
 		}),
@@ -80,7 +80,7 @@ func (d *DB) IncrementLookupCount(cid string) error {
 	err := d.gormDB.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "record_cid"}},
 		DoUpdates: clause.Assignments(map[string]any{
-			"lookup_count": gorm.Expr("lookup_count + 1"),
+			"lookup_count": gorm.Expr("record_usage_metrics.lookup_count + 1"),
 			"last_used_at": now,
 			"updated_at":   now,
 		}),


### PR DESCRIPTION
Pull and lookup counts in the catalog were silently stuck at zero on PostgreSQL-backed deployments. The upserts that increment these counters used bare column names (`pull_count + 1`, `lookup_count + 1`) inside the `ON CONFLICT DO UPDATE SET` clause, which PostgreSQL rejects as ambiguous — it cannot determine whether the name refers to the existing row or the incoming excluded row:

`ERROR: column reference "pull_count" is ambiguous (SQLSTATE 42702)`

The error was non-fatal by design, so pulls succeeded but counts were never recorded. Qualifying the column references with the table name (`record_usage_metrics.pull_count + 1`) removes the ambiguity. This bug was masked in SQLite (used by the local daemon), which does not enforce the same strictness.

Tested in daemon (sqlite) locally ✅ 