### PR TITLE
fix(init): project client context connection env onto the DIR MCP entry

### DIFF
--- a/cli/cmd/init/agents.go
+++ b/cli/cmd/init/agents.go
@@ -6,13 +6,25 @@ package init
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/agntcy/dir/cli/internal/agentinstall"
 	"github.com/agntcy/dir/cli/presenter"
+	clientconfig "github.com/agntcy/dir/client/config"
 	"github.com/agntcy/dir/server/skill"
 	"github.com/spf13/cobra"
+)
+
+// `dirctl mcp serve` reads its Directory connection settings only from
+// DIRECTORY_CLIENT_* env — it consults neither the client config file nor
+// current_context. So the installed MCP entry must carry them. auth_mode is as
+// essential as the address: an empty mode makes the client attempt OIDC
+// auto-detection, which fails outright when multiple issuers are cached.
+const (
+	dirServerAddressEnv = "DIRECTORY_CLIENT_SERVER_ADDRESS"
+	dirAuthModeEnv      = "DIRECTORY_CLIENT_AUTH_MODE"
 )
 
 const agentStepIntro = `
@@ -49,6 +61,69 @@ func dirArtifacts() (agentinstall.Artifacts, error) {
 	return arts, nil
 }
 
+// mcpServerEnv builds the DIRECTORY_CLIENT_* env the spawned `dirctl mcp serve`
+// needs to reach the same node dirctl itself uses: the current client context's
+// connection settings, with DIRECTORY_CLIENT_* env overrides applied. Validation
+// is skipped and unknown fields tolerated so a partially-set or forward-compat
+// config still yields usable values; any read error degrades to the local
+// default (insecure daemon).
+//
+// Only non-secret fields are projected. The two secrets — auth_token and
+// spiffe_token — are deliberately excluded so a bearer token never lands in an
+// agent's config file; auth modes that need them still require the user to
+// supply the secret via their own environment.
+func mcpServerEnv() map[string]string {
+	cfg, _, err := clientconfig.Resolve(clientconfig.ResolveOptions{
+		SkipValidation:     true,
+		AllowUnknownFields: true,
+	})
+	if err != nil || cfg == nil {
+		// No resolvable context (e.g. the user declined Step 1): mirror the
+		// local default so the server dials the daemon insecurely rather than
+		// falling into OIDC auto-detection with an empty auth mode.
+		return map[string]string{
+			dirServerAddressEnv: localServerAddress,
+			dirAuthModeEnv:      localAuthMode,
+		}
+	}
+
+	addr := strings.TrimSpace(cfg.ServerAddress)
+	if addr == "" {
+		addr = localServerAddress
+	}
+
+	authMode := strings.TrimSpace(cfg.AuthMode)
+	if authMode == "" {
+		authMode = localAuthMode
+	}
+
+	env := map[string]string{
+		dirServerAddressEnv: addr,
+		dirAuthModeEnv:      authMode,
+	}
+
+	// Non-secret, mode-specific fields — projected only when set.
+	for k, v := range map[string]string{
+		"DIRECTORY_CLIENT_TLS_CERT_FILE":      cfg.TlsCertFile,
+		"DIRECTORY_CLIENT_TLS_KEY_FILE":       cfg.TlsKeyFile,
+		"DIRECTORY_CLIENT_TLS_CA_FILE":        cfg.TlsCAFile,
+		"DIRECTORY_CLIENT_SPIFFE_SOCKET_PATH": cfg.SpiffeSocketPath,
+		"DIRECTORY_CLIENT_JWT_AUDIENCE":       cfg.JWTAudience,
+		"DIRECTORY_CLIENT_OIDC_ISSUER":        cfg.OIDCIssuer,
+		"DIRECTORY_CLIENT_OIDC_CLIENT_ID":     cfg.OIDCClientID,
+	} {
+		if s := strings.TrimSpace(v); s != "" {
+			env[k] = s
+		}
+	}
+
+	if cfg.TlsSkipVerify {
+		env["DIRECTORY_CLIENT_TLS_SKIP_VERIFY"] = "true"
+	}
+
+	return env
+}
+
 // runAgentSetup runs Step 3 against the resolved ambient environment, using the
 // interactive checkbox prompt for per-agent selection.
 func runAgentSetup(cmd *cobra.Command, opts *options) error {
@@ -82,6 +157,12 @@ func installAgents(cmd *cobra.Command, env agentcfg.Env, opts *options, selectAg
 	if err != nil {
 		return err
 	}
+
+	// Point the built-in DIR MCP server at the resolved context. `dirctl mcp
+	// serve` takes its target only from DIRECTORY_CLIENT_* env, so without this
+	// the spawned server ignores the context just configured and falls back to
+	// the default address.
+	arts.SetMCPEnv(mcpServerEnv())
 
 	// Non-interactive: never prompt. With --yes, install both artifacts into
 	// every candidate; without it, skip rather than act unattended.

--- a/cli/cmd/init/agents_test.go
+++ b/cli/cmd/init/agents_test.go
@@ -44,6 +44,10 @@ func TestInstallAgentsWritesMCPAndSkill(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(raw), `"agntcy-dir"`, "MCP server should be keyed by the translator-normalized name")
 	assert.NotContains(t, string(raw), "agntcy-dir-mcp", "the -mcp suffix must be stripped by normalization")
+	assert.Contains(t, string(raw), dirServerAddressEnv,
+		"MCP entry must carry the server address env so `dirctl mcp serve` reaches the configured node")
+	assert.Contains(t, string(raw), dirAuthModeEnv,
+		"MCP entry must carry the auth mode env; an empty mode makes the server attempt OIDC auto-detection")
 
 	// Skill folder was created under ~/.claude/skills.
 	entries, err := os.ReadDir(filepath.Join(env.Home, ".claude", "skills"))

--- a/cli/internal/agentinstall/derive.go
+++ b/cli/internal/agentinstall/derive.go
@@ -167,6 +167,32 @@ func mcpEntry(srv translator.MCPServer) map[string]any {
 	}
 }
 
+// SetMCPEnv overlays the given environment variables onto every derived MCP
+// server entry, creating the "env" map when absent. `dirctl init` uses this to
+// point the built-in DIR MCP server at the resolved client context: the spawned
+// `dirctl mcp serve` reads its target only from DIRECTORY_CLIENT_* env vars, so
+// without this the server would ignore the configured context and dial the
+// default address instead.
+//
+// The receiver is by value to match the type's other methods (recvcheck): it
+// mutates the shared entry maps, which are reference types, so the caller sees
+// the change regardless.
+func (a Artifacts) SetMCPEnv(vars map[string]string) {
+	for i := range a.mcpServers {
+		entry := a.mcpServers[i].entry
+
+		env, ok := entry["env"].(map[string]any)
+		if !ok {
+			env = map[string]any{}
+			entry["env"] = env
+		}
+
+		for k, v := range vars {
+			env[k] = v
+		}
+	}
+}
+
 // moduleNames lists the module names present in the record data, for error text.
 func moduleNames(data *structpb.Struct) []string {
 	mods, ok := data.GetFields()["modules"]

--- a/cli/internal/agentinstall/derive_test.go
+++ b/cli/internal/agentinstall/derive_test.go
@@ -54,6 +54,30 @@ func TestDeriveMCPOnly(t *testing.T) {
 	require.True(t, isAnyMap, "env must be map[string]any")
 }
 
+func TestSetMCPEnvOverlaysOntoEntries(t *testing.T) {
+	arts, err := DeriveArtifacts(loadRecord(t, "mcp.json"))
+	require.NoError(t, err)
+	require.Len(t, arts.mcpServers, 1)
+
+	arts.SetMCPEnv(map[string]string{"DIRECTORY_CLIENT_SERVER_ADDRESS": "localhost:8888"})
+
+	env, ok := arts.mcpServers[0].entry["env"].(map[string]any)
+	require.True(t, ok, "env must remain map[string]any")
+	require.Equal(t, "localhost:8888", env["DIRECTORY_CLIENT_SERVER_ADDRESS"])
+}
+
+func TestSetMCPEnvCreatesEnvMapWhenAbsent(t *testing.T) {
+	arts := Artifacts{
+		mcpServers: []mcpServer{{name: "srv", entry: map[string]any{"command": "dirctl"}}},
+	}
+
+	arts.SetMCPEnv(map[string]string{"DIRECTORY_CLIENT_SERVER_ADDRESS": "example:9999"})
+
+	env, ok := arts.mcpServers[0].entry["env"].(map[string]any)
+	require.True(t, ok, "env map should be created when absent")
+	require.Equal(t, "example:9999", env["DIRECTORY_CLIENT_SERVER_ADDRESS"])
+}
+
 func TestDeriveMulti(t *testing.T) {
 	arts, err := DeriveArtifacts(loadRecord(t, "multi.json"))
 	require.NoError(t, err)


### PR DESCRIPTION
## What

`dirctl init` now writes the client context's connection settings into the DIR MCP server entry's `env`, instead of leaving it empty.

## Why

`dirctl mcp serve` reads its Directory connection settings **only** from `DIRECTORY_CLIENT_*` environment variables — it consults neither the client config file nor `current_context`. The installed entry shipped `env: {}`, so every spawned server ignored the context just configured during `init` and fell back to the `0.0.0.0:8888` default. Worse, with an empty auth mode the client attempts OIDC auto-detection, which fails outright on machines with multiple cached issuers — surfacing as `agntcy-dir · ✘ failed` in the host.

## What's projected

From the resolved context (env overrides applied, validation skipped so a partial config still works):

- **Always:** `SERVER_ADDRESS` and `AUTH_MODE` (empty mode defaults to `insecure`, matching the local daemon default).
- **When set:** TLS cert/key/CA paths, `TLS_SKIP_VERIFY`, SPIFFE socket, OIDC issuer/client-id, JWT audience.
- **Never:** `AUTH_TOKEN` and `SPIFFE_TOKEN` — the two secrets are excluded so a bearer token never lands in an agent config file.

Injection happens in the `init` flow only (via a new `Artifacts.SetMCPEnv` helper), so the generic published record and `dirctl install <record>` are unaffected.

## Testing

- Unit tests for `SetMCPEnv` (overlay onto existing entries; create the `env` map when absent).
- `dirctl init` test asserts the written config carries both the address and auth-mode env keys.
