### PR TITLE
chore(reconciler): bump scanner versions

### DIFF
--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -30,8 +30,8 @@ vars:
     - "docker.io/bitnami/postgresql:{{.POSTGRESQL_VERSION}}"
 
   ## Scanner versions
-  MCP_SCANNER_VERSION: "4.8.0"
-  SKILL_SCANNER_VERSION: "2.0.11"
+  MCP_SCANNER_VERSION: "4.8.1"
+  SKILL_SCANNER_VERSION: "2.0.12"
   A2A_SCANNER_VERSION: "1.0.1"
 
   ## Image config

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -8,8 +8,8 @@ variable "IMAGE_REPO" { default = "ghcr.io/agntcy" }
 variable "IMAGE_TAG" { default = "v0.1.0-rc" }
 variable "BUILD_LDFLAGS" { default = "-s -w -extldflags -static" }
 variable "IMAGE_NAME_SUFFIX" { default = "" }
-variable "MCP_SCANNER_VERSION" { default = "4.8.0" }
-variable "SKILL_SCANNER_VERSION" { default = "2.0.11" }
+variable "MCP_SCANNER_VERSION" { default = "4.8.1" }
+variable "SKILL_SCANNER_VERSION" { default = "2.0.12" }
 variable "A2A_SCANNER_VERSION" { default = "1.0.1" }
 
 function "get_tag" {

--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -29,6 +29,10 @@ services:
     build:
       context: ../../
       dockerfile: reconciler/Dockerfile
+      args:
+        MCP_SCANNER_VERSION: ${MCP_SCANNER_VERSION:-4.8.1}
+        SKILL_SCANNER_VERSION: ${SKILL_SCANNER_VERSION:-2.0.12}
+        A2A_SCANNER_VERSION: ${A2A_SCANNER_VERSION:-1.0.1}
     env_file:
       - ./reconciler.env
     depends_on:


### PR DESCRIPTION
Bumps `cisco-ai-mcp-scanner` from 4.8.0 to 4.8.1 and `cisco-ai-skill-scanner` from 2.0.11 to 2.0.12 to address vulnerabilities flagged by the container security scan. The version values are kept consistent across `Taskfile.vars.yml` and `docker-bake.hcl` as before.