### PR TITLE
fix(dir): fix IsReady errors

### DIFF
--- a/server/routing/routing.go
+++ b/server/routing/routing.go
@@ -151,9 +151,20 @@ func (r *route) Stop() error {
 // IsReady checks if the routing subsystem is ready to serve traffic.
 func (r *route) IsReady(ctx context.Context) bool {
 	// Check if local list request is successful
-	_, err := r.local.List(ctx, &routingv1.ListRequest{})
+	limit := uint32(1)
+
+	itemChan, err := r.local.List(ctx, &routingv1.ListRequest{Limit: &limit})
 	if err != nil {
 		localLogger.Debug("Routing not ready: local list request failed", "error", err)
+
+		return false
+	}
+
+	for range itemChan {
+	}
+
+	if err := ctx.Err(); err != nil {
+		localLogger.Debug("Routing not ready: local list canceled", "error", err)
 
 		return false
 	}


### PR DESCRIPTION
fixes the "Failed to get namespace entries for labels" error messages. this was spamming the logs

these were caused by IsReady - it would open a channel but not read it, causing this error