### PR TITLE
fix(datastore): synchronize in-memory routing datastore

### DIFF
--- a/server/datastore/datastore.go
+++ b/server/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/agntcy/dir/server/types"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/sync"
 	badger "github.com/ipfs/go-ds-badger"
 )
 
@@ -31,5 +32,5 @@ func New(opts ...Option) (types.Datastore, error) {
 	}
 
 	// create in-memory datastore
-	return datastore.NewMapDatastore(), nil
+	return sync.MutexWrap(datastore.NewMapDatastore()), nil
 }

--- a/server/datastore/datastore_test.go
+++ b/server/datastore/datastore_test.go
@@ -1,0 +1,100 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package datastore
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	ds "github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/query"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMemoryDatastoreConcurrentQueryAndPut(t *testing.T) {
+	const (
+		seedEntryCount = 1024
+		workerCount    = 4
+		iterationCount = 256
+	)
+
+	ctx := t.Context()
+
+	store, err := New()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, store.Close())
+	})
+
+	for i := 0; i < seedEntryCount; i++ {
+		key := ds.NewKey(fmt.Sprintf("/skills/seed/%d", i))
+		require.NoError(t, store.Put(ctx, key, []byte("seed")))
+	}
+
+	start := make(chan struct{})
+	errCh := make(chan error, workerCount*2)
+
+	var wg sync.WaitGroup
+
+	for worker := 0; worker < workerCount; worker++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for i := 0; i < iterationCount; i++ {
+				key := ds.NewKey(fmt.Sprintf("/skills/writer-%d/%d", worker, i))
+				if err := store.Put(ctx, key, []byte("value")); err != nil {
+					errCh <- fmt.Errorf("put %s: %w", key, err)
+
+					return
+				}
+			}
+		}()
+	}
+
+	for range workerCount {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			<-start
+
+			for range iterationCount {
+				results, err := store.Query(ctx, query.Query{Prefix: "/skills"})
+				if err != nil {
+					errCh <- fmt.Errorf("query labels: %w", err)
+
+					return
+				}
+
+				_, readErr := results.Rest()
+				closeErr := results.Close()
+
+				if readErr != nil {
+					errCh <- fmt.Errorf("read query results: %w", readErr)
+
+					return
+				}
+
+				if closeErr != nil {
+					errCh <- fmt.Errorf("close query results: %w", closeErr)
+
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
## Summary

- wrap the default in-memory `MapDatastore` with `sync.MutexWrap`
- add a concurrent `Query`/`Put` regression test at the datastore construction boundary
- leave the persistent Badger backend unchanged

## Root cause

The default datastore constructor returned a raw `github.com/ipfs/go-datastore.MapDatastore`. That implementation is not thread-safe. Directory shares this datastore across routing components that can query and write concurrently, matching the reported `concurrent map iteration and map write` panic in `MapDatastore.Query`.

Synchronizing at construction covers every consumer of the shared in-memory datastore; locking only the failing query path would leave other direct readers and writers uncoordinated.

Fixes #1886

## Validation

- pre-fix focused race reproduction: fails with a Go race report and `fatal error: concurrent map iteration and map write`
- synchronized focused reproduction: `go test -race -count=10 ./safe` passes
- `gofmt` passes for both changed files
- whitespace/diff validation passes
- both commits include the required DCO sign-off

The repository-native test could not be executed in the worker VM because it had Go 1.23.2 while `server/go.mod` requires Go 1.26.5, and the environment could not fetch that toolchain/module graph. The new test is included so upstream CI can compile and exercise the production construction path.