### PR TITLE
fix(cli): register cloud KMS providers

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -23,6 +23,7 @@ ignored = [
   "github.com/xi2/xz", # Public Domain https://github.com/xi2/xz/blob/master/LICENSE
   "github.com/libp2p/go-libp2p-gorpc", # MIT https://github.com/libp2p/go-libp2p-gorpc/blob/master/LICENSE-MIT
   "github.com/libp2p/go-libp2p-pubsub", # MIT https://github.com/libp2p/go-libp2p-pubsub/blob/master/LICENSE-MIT
+  "github.com/hashicorp/vault/api", # MPL-2.0 https://github.com/hashicorp/vault/blob/main/api/LICENSE
   "go.mongodb.org/mongo-driver", # Apache License 2.0 https://github.com/mongodb/mongo-go-driver/blob/master/LICENSE
   "modernc.org/sqlite", # BSD-3-Clause https://gitlab.com/cznic/sqlite/-/blob/master/LICENSE
   "modernc.org/libc", # BSD-3-Clause https://gitlab.com/cznic/libc/-/blob/master/LICENSE

--- a/cli/cmd/sign/kms_providers.go
+++ b/cli/cmd/sign/kms_providers.go
@@ -1,0 +1,11 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package sign
+
+import (
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
+)

--- a/cli/cmd/sign/kms_providers_test.go
+++ b/cli/cmd/sign/kms_providers_test.go
@@ -1,0 +1,29 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package sign
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/sigstore/sigstore/pkg/signature/kms"
+)
+
+func TestKMSProvidersRegistered(t *testing.T) {
+	t.Parallel()
+
+	providers := kms.SupportedProviders()
+	slices.Sort(providers)
+
+	for _, expected := range []string{
+		"awskms://",
+		"azurekms://",
+		"gcpkms://",
+		"hashivault://",
+	} {
+		if !slices.Contains(providers, expected) {
+			t.Errorf("registered KMS providers = %v, want %q", providers, expected)
+		}
+	}
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -38,6 +38,10 @@ require (
 	github.com/rs/zerolog v1.35.1
 	github.com/sigstore/cosign/v3 v3.1.1
 	github.com/sigstore/sigstore v1.10.8
+	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8
+	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8
+	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.10.8
+	github.com/sigstore/sigstore/pkg/signature/kms/hashivault v1.10.8
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -54,6 +58,8 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect
+	cloud.google.com/go/kms v1.31.0 // indirect
+	cloud.google.com/go/longrunning v1.0.0 // indirect
 	cloud.google.com/go/monitoring v1.28.0 // indirect
 	cloud.google.com/go/storage v1.62.2 // indirect
 	dario.cat/mergo v1.0.2 // indirect
@@ -61,6 +67,8 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0 // indirect
 	github.com/Azure/go-ntlmssp v0.1.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
@@ -119,6 +127,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.25 // indirect
+	github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.102.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.2.0 // indirect
@@ -130,6 +139,7 @@ require (
 	github.com/bitnami/go-version v0.0.0-20260425104222-0af72917255b // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/carabiner-dev/attestation v0.2.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
 	github.com/cheggaaa/pb/v3 v3.1.7 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
@@ -199,12 +209,19 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-getter v1.8.6 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
+	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
+	github.com/hashicorp/vault/api v1.22.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20240805132620-81f5be970eca // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/josephburnett/jd/v2 v2.5.0 // indirect
@@ -248,6 +265,7 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/morikuni/aec v1.1.0 // indirect
+	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/nathanaelle/password v1.0.0 // indirect
 	github.com/nats-io/nats.go v1.52.0 // indirect
 	github.com/nats-io/nkeys v0.4.16 // indirect
@@ -285,6 +303,7 @@ require (
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/rust-secure-code/go-rustaudit v0.0.0-20250226111315-e20ec32e963c // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/samber/oops v1.21.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -1387,6 +1387,18 @@ Record name verification proves that the signing key is authorized by the domain
 
 Signs records for integrity and authenticity. When signing a record with a verifiable name (e.g., `https://domain/path`), the system automatically attempts to verify domain authorization via JWKS. See [Name Verification](#name-verification) for details.
 
+The `--key` flag accepts PEM content, a local file, an HTTP(S) URL, an environment
+variable reference, or a KMS URI. The supported KMS URI formats are:
+
+| Provider | URI format |
+|----------|------------|
+| AWS KMS | `awskms://[ENDPOINT]/[ID/ALIAS/ARN]` |
+| Google Cloud KMS | `gcpkms://projects/[PROJECT]/locations/[LOC]/keyRings/[RING]/cryptoKeys/[KEY]` |
+| Azure Key Vault | `azurekms://[VAULT_NAME][VAULT_URI]/[KEY]` |
+| HashiCorp Vault | `hashivault://[KEY]` |
+
+Configure the selected provider's credentials before running `dirctl`.
+
 ??? example
 
     ```bash
@@ -1398,6 +1410,9 @@ Signs records for integrity and authenticity. When signing a record with a verif
 
     # Sign with a pre-issued OIDC token (non-interactive)
     dirctl sign <cid> --oidc-token "$OIDC_TOKEN"
+
+    # Sign with a key managed by Google Cloud KMS
+    dirctl sign <cid> --key "gcpkms://projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY"
     ```
 
 ### `dirctl naming verify <reference>`

--- a/docs/content/dir/dir-component-trust-model.md
+++ b/docs/content/dir/dir-component-trust-model.md
@@ -65,6 +65,10 @@ Directory supports several signing flows depending on the environment:
 - **Self-managed keys** — uses a signing keypair (for example, generated with Cosign) where
   the private key signs the record. Suitable for CI/CD where browser-based authentication is
   not possible or desired.
+- **KMS-backed keys** — uses a key managed by AWS KMS, Google Cloud KMS, Azure Key Vault,
+  or HashiCorp Vault. The provider handles access credentials, and private key material
+  remains in the KMS. Suitable for automated environments that centralize key custody and
+  rotation.
 
 For CLI walkthroughs of each method, see
 [Usage Guide — Signing and Verification](dir-features-scenarios.md#signing-and-verification).

--- a/docs/content/dir/dir-features-scenarios.md
+++ b/docs/content/dir/dir-features-scenarios.md
@@ -151,6 +151,31 @@ dirctl push record.json --sign --key cosign.key
 dirctl verify $RECORD_CID
 ```
 
+### Method 4: KMS-Backed Keys
+
+This method keeps private key material in a cloud or Vault key management service.
+Configure the selected provider's credentials, then pass its key URI to `dirctl sign`.
+Directory supports the AWS KMS, Google Cloud KMS, Azure Key Vault, and HashiCorp Vault
+providers registered by Sigstore.
+
+```bash
+# AWS KMS
+dirctl sign "$RECORD_CID" --key 'awskms://[ENDPOINT]/[ID/ALIAS/ARN]'
+
+# Google Cloud KMS
+dirctl sign "$RECORD_CID" \
+  --key 'gcpkms://projects/[PROJECT]/locations/[LOC]/keyRings/[RING]/cryptoKeys/[KEY]'
+
+# Azure Key Vault
+dirctl sign "$RECORD_CID" --key 'azurekms://[VAULT_NAME][VAULT_URI]/[KEY]'
+
+# HashiCorp Vault
+dirctl sign "$RECORD_CID" --key 'hashivault://[KEY]'
+
+# Verify the signed record
+dirctl verify "$RECORD_CID"
+```
+
 ## Name Verification
 
 Name verification proves that the signing key is authorized by the domain claimed in the

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -31,7 +31,13 @@ require (
 )
 
 require (
+	cloud.google.com/go/kms v1.31.0 // indirect
+	cloud.google.com/go/longrunning v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.5.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/kms v1.52.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/coder/websocket v1.8.14 // indirect
 	github.com/dylibso/observe-sdk/go v0.0.0-20240819160327-2d926c5d788a // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
@@ -41,13 +47,26 @@ require (
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-github/v88 v88.0.0 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.2.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
+	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
+	github.com/hashicorp/vault/api v1.22.0 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b // indirect
+	github.com/jellydator/ttlcache/v3 v3.4.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
+	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/nlpodyssey/cybertron v0.2.1 // indirect
 	github.com/nlpodyssey/gopickle v0.2.0 // indirect
 	github.com/nlpodyssey/gotokenizers v0.2.0 // indirect
 	github.com/nlpodyssey/spago v1.1.0 // indirect
 	github.com/rs/zerolog v1.35.1 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8 // indirect
+	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8 // indirect
+	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.10.8 // indirect
+	github.com/sigstore/sigstore/pkg/signature/kms/hashivault v1.10.8 // indirect
 	github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	gopkg.in/ini.v1 v1.67.3 // indirect


### PR DESCRIPTION
## Summary

- register Sigstore’s AWS, Azure, GCP, and HashiCorp Vault KMS providers for `dirctl sign`
- add credential-free regression coverage for all four supported KMS prefixes
- keep the provider dependency graph inside the CLI module rather than the shared client library
- keep the repository tests module tidy with its local CLI replacement

## Root cause

`SignerVerifierFromKeyRef` accepts KMS references, but Sigstore providers register through package `init` functions. The `dirctl sign` process did not import those provider packages, so the provider registry was empty and KMS URIs failed as unrecognized schemes.

## Validation

Using Go 1.26.5 on Linux ARM64:

- exact regression fails on the unpatched current `main` with all four providers absent
- `go -C cli test ./cmd/sign -run "^TestKMSProvidersRegistered$" -count=1`
- `go -C cli test ./... -count=1`
- `go -C cli vet ./...`
- `go -C cli build ./...`
- golangci-lint 2.11.3 against the CLI module: `0 issues`
- `go -C cli mod tidy -diff`
- `go -C tests mod tidy -diff`
- `go -C tests list -deps ./...`
- golangci-lint 2.11.3 across the tests module: `0 issues`
- production-file revert makes the regression fail; restoring it makes the test pass
- `git diff --check`

The test verifies registration without cloud credentials or network calls. Live signing still depends on each provider’s credentials and service availability.

Implementation and validation used Codex assistance. I reviewed the final diff, dependency placement, and test results.

Fixes #1882