### PR TITLE
feat(cli): add --project scope to dirctl install/uninstall

### DIFF
--- a/cli/cmd/init/agents.go
+++ b/cli/cmd/init/agents.go
@@ -206,7 +206,8 @@ func apply(cmd *cobra.Command, env agentcfg.Env, arts agentinstall.Artifacts, ag
 		return
 	}
 
-	outcomes := agentinstall.Install(env, arts, agents, false)
+	// `dirctl init` wires the user's global environment.
+	outcomes := agentinstall.Install(env, arts, agents, agentcfg.Global, false)
 	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, false))
 }
 
@@ -228,7 +229,7 @@ func removeAgents(cmd *cobra.Command, env agentcfg.Env, opts *options) error {
 		return err
 	}
 
-	plan := agentinstall.Uninstall(env, arts, selected, true)
+	plan := agentinstall.Uninstall(env, arts, selected, agentcfg.Global, true)
 	if len(plan) == 0 {
 		return nil
 	}
@@ -255,7 +256,7 @@ func removeAgents(cmd *cobra.Command, env agentcfg.Env, opts *options) error {
 		}
 	}
 
-	outcomes := agentinstall.Uninstall(env, arts, selected, false)
+	outcomes := agentinstall.Uninstall(env, arts, selected, agentcfg.Global, false)
 	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, false))
 
 	return nil

--- a/cli/cmd/install/batch.go
+++ b/cli/cmd/install/batch.go
@@ -102,19 +102,20 @@ type installTarget struct {
 	arts  agentinstall.Artifacts
 }
 
-type recordApplyFn func(env agentcfg.Env, arts agentinstall.Artifacts, agents []agentcfg.Agent, dryRun bool) []agentcfg.Outcome
+type recordApplyFn func(env agentcfg.Env, arts agentinstall.Artifacts, agents []agentcfg.Agent, scope agentcfg.Scope, dryRun bool) []agentcfg.Outcome
 
 func buildTaggedOutcomes(
 	env agentcfg.Env,
 	targets []installTarget,
 	selected []agentcfg.Agent,
+	scope agentcfg.Scope,
 	dryRun bool,
 	apply recordApplyFn,
 ) []agentcfg.Outcome {
 	var outcomes []agentcfg.Outcome
 
 	for _, target := range targets {
-		recordOutcomes := apply(env, target.arts, selected, dryRun)
+		recordOutcomes := apply(env, target.arts, selected, scope, dryRun)
 		tagOutcomes(recordOutcomes, target.label)
 		outcomes = append(outcomes, recordOutcomes...)
 	}
@@ -209,14 +210,17 @@ func runBatch(cmd *cobra.Command, apply recordApplyFn, confirmFn func(*cobra.Com
 	}
 
 	env := agentcfg.ResolveEnv()
+	scope := scopeFromOpts()
 
 	selected, err := selectAgents(cmd, env)
 	if err != nil {
 		return err
 	}
 
+	printScope(cmd)
+
 	targets, skipped := buildBatchTargets(cmd, selectRecords(recs))
-	plan := buildTaggedOutcomes(env, targets, selected, true, apply)
+	plan := buildTaggedOutcomes(env, targets, selected, scope, true, apply)
 
 	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 	printSkippedSummary(cmd, skipped)
@@ -234,7 +238,7 @@ func runBatch(cmd *cobra.Command, apply recordApplyFn, confirmFn func(*cobra.Com
 		return nil
 	}
 
-	outcomes := buildTaggedOutcomes(env, targets, selected, opts.dryRun, apply)
+	outcomes := buildTaggedOutcomes(env, targets, selected, scope, opts.dryRun, apply)
 	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 	printSkippedSummary(cmd, skipped)
 

--- a/cli/cmd/install/flags.go
+++ b/cli/cmd/install/flags.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/agntcy/dir/cli/cmd/search"
 	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/presenter"
 	"github.com/spf13/cobra"
 )
 
@@ -21,8 +22,25 @@ func addSelectionFlags(cmd *cobra.Command, opts *options) {
 	flags.StringSliceVar(&opts.agents, "agents", []string{agentcfg.AllAgents},
 		fmt.Sprintf("Agents to target: %q (default, all detected) or a comma-separated list of agent IDs (%s)",
 			agentcfg.AllAgents, strings.Join(agentcfg.AgentIDs(), ", ")))
+	flags.BoolVar(&opts.project, "project", false, "Write into the current repo (project scope) instead of global config")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Preview changes without writing")
 	flags.BoolVarP(&opts.yes, "yes", "y", false, "Skip the confirmation prompt")
+}
+
+// scopeFromOpts maps the --project flag to the placement scope.
+func scopeFromOpts() agentcfg.Scope {
+	if opts.project {
+		return agentcfg.Project
+	}
+
+	return agentcfg.Global
+}
+
+// printScope announces project scope so the user sees where files will land.
+func printScope(cmd *cobra.Command) {
+	if opts.project {
+		presenter.Printf(cmd, "Scope: project (current repo)\n")
+	}
 }
 
 func addBatchFlags(cmd *cobra.Command, opts *options) {

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -124,21 +124,30 @@ func pullAndDerive(cmd *cobra.Command, input string) (agentinstall.Artifacts, er
 }
 
 // runInstallCmd is the shared body for the parent's bare-positional form and the
-// `run` subcommand: pull + derive, dry-run plan, confirm, apply, summary.
+// `run` subcommand.
 func runInstallCmd(cmd *cobra.Command, input string) error {
+	return runApplyCmd(cmd, input, agentinstall.Install, "\nProceed with these changes?")
+}
+
+// runApplyCmd is the single-record flow shared by install and uninstall: pull +
+// derive, dry-run plan, confirm, apply, summary. apply is Install or Uninstall.
+func runApplyCmd(cmd *cobra.Command, input string, apply recordApplyFn, confirmPrompt string) error {
 	arts, err := pullAndDerive(cmd, input)
 	if err != nil {
 		return err
 	}
 
 	env := agentcfg.ResolveEnv()
+	scope := scopeFromOpts()
 
 	selected, err := selectAgents(cmd, env)
 	if err != nil {
 		return err
 	}
 
-	plan := agentinstall.Install(env, arts, selected, true)
+	printScope(cmd)
+
+	plan := apply(env, arts, selected, scope, true)
 	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 
 	if len(plan) == 0 {
@@ -146,7 +155,7 @@ func runInstallCmd(cmd *cobra.Command, input string) error {
 	}
 
 	if !opts.yes && !opts.dryRun {
-		ok, err := confirm(cmd, "\nProceed with these changes?")
+		ok, err := confirm(cmd, confirmPrompt)
 		if err != nil {
 			return err
 		}
@@ -158,7 +167,7 @@ func runInstallCmd(cmd *cobra.Command, input string) error {
 		}
 	}
 
-	outcomes := agentinstall.Install(env, arts, selected, opts.dryRun)
+	outcomes := apply(env, arts, selected, scope, opts.dryRun)
 	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 
 	return nil

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -104,6 +104,24 @@ func TestConfirmEOFWithEmptyLine(t *testing.T) {
 	assert.Contains(t, err.Error(), "read confirmation")
 }
 
+// --- scopeFromOpts tests ---
+
+func TestScopeFromOptsProject(t *testing.T) {
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	require.NotNil(t, Command.PersistentFlags().Lookup("project"))
+
+	opts.project = false
+
+	assert.Equal(t, agentcfg.Global, scopeFromOpts())
+
+	opts.project = true
+
+	assert.Equal(t, agentcfg.Project, scopeFromOpts())
+}
+
 // --- selectAgents tests ---
 
 func TestSelectAgentsAllDetected(t *testing.T) {

--- a/cli/cmd/install/list.go
+++ b/cli/cmd/install/list.go
@@ -19,6 +19,9 @@ and the config files that install would touch. Makes no changes and does not
 contact the Directory.`,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		env := agentcfg.ResolveEnv()
+		scope := scopeFromOpts()
+
+		printScope(cmd)
 
 		for _, agent := range agentcfg.Registry() {
 			status := "not detected"
@@ -29,18 +32,13 @@ contact the Directory.`,
 			presenter.Printf(cmd, "%s [%s]\n", agent.Name, status)
 
 			if agent.MCP != nil {
-				path, err := agent.MCP.ConfigPath(env)
-				if err != nil {
-					presenter.Printf(cmd, "  MCP   (path error: %v)\n", err)
-				} else {
-					presenter.Printf(cmd, "  MCP   %s\n", path)
-				}
+				presenter.Printf(cmd, "  MCP   %s\n", agentcfg.ResolveMCPPath(agent.MCP, env, scope))
 			}
 
 			if agent.Skill != nil {
 				// The real slug is the record name, known only at install time; show
 				// the generic target with a placeholder.
-				presenter.Printf(cmd, "  Skill %s\n", agentcfg.ResolveSkillPath(agent.Skill, env, "<record>"))
+				presenter.Printf(cmd, "  Skill %s\n", agentcfg.ResolveSkillPath(agent.Skill, env, "<record>", scope))
 			}
 		}
 

--- a/cli/cmd/install/options.go
+++ b/cli/cmd/install/options.go
@@ -8,6 +8,7 @@ import "github.com/agntcy/dir/cli/cmd/search"
 // options holds the shared flags for the install subcommands.
 type options struct {
 	agents      []string
+	project     bool
 	dryRun      bool
 	yes         bool
 	limit       uint32

--- a/cli/cmd/install/uninstall.go
+++ b/cli/cmd/install/uninstall.go
@@ -5,9 +5,7 @@ package install
 
 import (
 	"github.com/agntcy/dir/cli/cmd/search"
-	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/agntcy/dir/cli/internal/agentinstall"
-	"github.com/agntcy/dir/cli/presenter"
 	"github.com/spf13/cobra"
 )
 
@@ -84,40 +82,5 @@ func init() {
 // top-level `uninstall` shorthand: pull + derive, dry-run plan, confirm, remove,
 // summary.
 func runUninstallCmd(cmd *cobra.Command, input string) error {
-	arts, err := pullAndDerive(cmd, input)
-	if err != nil {
-		return err
-	}
-
-	env := agentcfg.ResolveEnv()
-
-	selected, err := selectAgents(cmd, env)
-	if err != nil {
-		return err
-	}
-
-	plan := agentinstall.Uninstall(env, arts, selected, true)
-	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
-
-	if len(plan) == 0 {
-		return nil
-	}
-
-	if !opts.yes && !opts.dryRun {
-		ok, err := confirm(cmd, "\nRemove these artifacts?")
-		if err != nil {
-			return err
-		}
-
-		if !ok {
-			presenter.Printf(cmd, "Aborted. No changes made.\n")
-
-			return nil
-		}
-	}
-
-	outcomes := agentinstall.Uninstall(env, arts, selected, opts.dryRun)
-	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
-
-	return nil
+	return runApplyCmd(cmd, input, agentinstall.Uninstall, "\nRemove these artifacts?")
 }

--- a/cli/internal/agentcfg/mcp_engine.go
+++ b/cli/internal/agentcfg/mcp_engine.go
@@ -4,6 +4,7 @@
 package agentcfg
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -14,12 +15,32 @@ import (
 
 const configFilePerm = 0o600
 
+// mcpConfigPath resolves the MCP config path for the requested scope: the global
+// ConfigPath for Global, the ProjectConfigPath for Project. A nil resolver yields
+// ErrNoScopePath so the caller can skip.
+func mcpConfigPath(target *MCPTarget, env Env, scope Scope) (string, error) {
+	resolver := target.ConfigPath
+	if scope == Project {
+		resolver = target.ProjectConfigPath
+	}
+
+	if resolver == nil {
+		return "", ErrNoScopePath
+	}
+
+	return resolver(env)
+}
+
 // InstallMCP upserts the MCP server entry under serverName into the agent's
 // config file, preserving all sibling content. It is idempotent: re-running with
 // an identical entry reports ActionUnchanged and writes nothing. When dryRun is
 // set, it computes the action but does not write.
-func InstallMCP(target *MCPTarget, env Env, entry map[string]any, serverName string, dryRun bool) (Outcome, error) {
-	path, err := target.ConfigPath(env)
+func InstallMCP(target *MCPTarget, env Env, entry map[string]any, serverName string, scope Scope, dryRun bool) (Outcome, error) {
+	path, err := mcpConfigPath(target, env, scope)
+	if errors.Is(err, ErrNoScopePath) {
+		return skipScopeOutcome("mcp", scope), nil
+	}
+
 	if err != nil {
 		return failOutcome(Outcome{Artifact: "mcp"}, fmt.Errorf("resolve mcp config path: %w", err))
 	}
@@ -60,8 +81,12 @@ func InstallMCP(target *MCPTarget, env Env, entry map[string]any, serverName str
 // preserving all sibling servers. It never deletes the config file itself. An
 // absent entry (or missing file) reports ActionUnchanged, so uninstall is
 // idempotent. When dryRun is set, it computes the action but does not write.
-func RemoveMCP(target *MCPTarget, env Env, serverName string, dryRun bool) (Outcome, error) {
-	path, err := target.ConfigPath(env)
+func RemoveMCP(target *MCPTarget, env Env, serverName string, scope Scope, dryRun bool) (Outcome, error) {
+	path, err := mcpConfigPath(target, env, scope)
+	if errors.Is(err, ErrNoScopePath) {
+		return skipScopeOutcome("mcp", scope), nil
+	}
+
 	if err != nil {
 		return failOutcome(Outcome{Artifact: "mcp"}, fmt.Errorf("resolve mcp config path: %w", err))
 	}
@@ -116,9 +141,25 @@ func writeConfig(format codec.Format, path string, m map[string]any) error {
 	return nil
 }
 
-// MCPEntryPresent reports whether our server entry already exists in the config.
-func MCPEntryPresent(target *MCPTarget, env Env, serverName string) bool {
-	path, err := target.ConfigPath(env)
+// ResolveMCPPath resolves the MCP config path for the given scope, for display.
+// It never returns an error (display-only).
+func ResolveMCPPath(target *MCPTarget, env Env, scope Scope) string {
+	path, err := mcpConfigPath(target, env, scope)
+	if err != nil {
+		if errors.Is(err, ErrNoScopePath) {
+			return "(no " + scope.String() + " location for this agent)"
+		}
+
+		return "(path error: " + err.Error() + ")"
+	}
+
+	return path
+}
+
+// MCPEntryPresent reports whether our server entry already exists in the config
+// for the given scope.
+func MCPEntryPresent(target *MCPTarget, env Env, serverName string, scope Scope) bool {
+	path, err := mcpConfigPath(target, env, scope)
 	if err != nil {
 		return false
 	}

--- a/cli/internal/agentcfg/mcp_engine_test.go
+++ b/cli/internal/agentcfg/mcp_engine_test.go
@@ -35,7 +35,7 @@ func sampleEntry() map[string]any {
 func TestInstallMCPCreatesFileWithEntry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sub", "mcp.json")
 
-	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 	assert.Equal(t, path, outcome.Path)
@@ -54,7 +54,7 @@ func TestInstallMCPPreservesForeignServers(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"mcpServers":{"other":{"command":"node"}}}`), 0o600))
 
-	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 
 	data, _ := os.ReadFile(path)
@@ -73,13 +73,13 @@ func TestInstallMCPPreservesForeignServers(t *testing.T) {
 func TestInstallMCPIdempotentSecondRunUnchanged(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp.json")
 
-	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 
 	first, err := os.ReadFile(path)
 	require.NoError(t, err)
 
-	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUnchanged, outcome.Action)
 
@@ -91,13 +91,13 @@ func TestInstallMCPIdempotentSecondRunUnchanged(t *testing.T) {
 func TestInstallMCPUpdatesChangedEntry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp.json")
 
-	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	_, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 
 	changed := sampleEntry()
 	changed["env"] = map[string]any{"DIRECTORY_CLIENT_SERVER_ADDRESS": "h:2"}
 
-	outcome, err := InstallMCP(testMCPTarget(path), Env{}, changed, testServerName, false)
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, changed, testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUpdated, outcome.Action)
 }
@@ -105,7 +105,7 @@ func TestInstallMCPUpdatesChangedEntry(t *testing.T) {
 func TestInstallMCPDryRunWritesNothing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp.json")
 
-	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, true)
+	outcome, err := InstallMCP(testMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, true)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
@@ -127,7 +127,7 @@ func testYAMLMCPTarget(path string) *MCPTarget {
 func TestInstallMCPYAMLCreatesFileWithEntry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sub", "config.yaml")
 
-	outcome, err := InstallMCP(testYAMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	outcome, err := InstallMCP(testYAMLMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
@@ -146,7 +146,7 @@ func TestInstallMCPYAMLPreservesForeignServers(t *testing.T) {
 	require.NoError(t, os.WriteFile(path,
 		[]byte("mcpServers:\n  other:\n    command: node\n"), 0o600))
 
-	_, err := InstallMCP(testYAMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	_, err := InstallMCP(testYAMLMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 
 	data, _ := os.ReadFile(path)
@@ -164,7 +164,7 @@ func TestRemoveMCPYAMLDeletesOnlyOurKey(t *testing.T) {
 	require.NoError(t, os.WriteFile(path,
 		[]byte("mcpServers:\n  agntcy-dir-mcp:\n    command: dirctl\n  other:\n    command: node\n"), 0o600))
 
-	outcome, err := RemoveMCP(testYAMLMCPTarget(path), Env{}, testServerName, false)
+	outcome, err := RemoveMCP(testYAMLMCPTarget(path), Env{}, testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionRemoved, outcome.Action)
 
@@ -192,7 +192,7 @@ func testTOMLMCPTarget(path string) *MCPTarget {
 func TestInstallMCPTOMLCreatesFileWithEntry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sub", "config.toml")
 
-	outcome, err := InstallMCP(testTOMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	outcome, err := InstallMCP(testTOMLMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
@@ -211,7 +211,7 @@ func TestInstallMCPTOMLPreservesForeignServers(t *testing.T) {
 	require.NoError(t, os.WriteFile(path,
 		[]byte("[mcp_servers.other]\ncommand = \"node\"\n"), 0o600))
 
-	_, err := InstallMCP(testTOMLMCPTarget(path), Env{}, sampleEntry(), testServerName, false)
+	_, err := InstallMCP(testTOMLMCPTarget(path), Env{}, sampleEntry(), testServerName, Global, false)
 	require.NoError(t, err)
 
 	data, _ := os.ReadFile(path)
@@ -229,7 +229,7 @@ func TestRemoveMCPTOMLDeletesOnlyOurKey(t *testing.T) {
 	require.NoError(t, os.WriteFile(path,
 		[]byte("[mcp_servers.agntcy-dir-mcp]\ncommand = \"dirctl\"\n[mcp_servers.other]\ncommand = \"node\"\n"), 0o600))
 
-	outcome, err := RemoveMCP(testTOMLMCPTarget(path), Env{}, testServerName, false)
+	outcome, err := RemoveMCP(testTOMLMCPTarget(path), Env{}, testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionRemoved, outcome.Action)
 
@@ -250,18 +250,69 @@ func TestMCPEntryPresentTrue(t *testing.T) {
 	require.NoError(t, os.WriteFile(path,
 		[]byte(`{"mcpServers":{"agntcy-dir-mcp":{"command":"dirctl"}}}`), 0o600))
 
-	assert.True(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName))
+	assert.True(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName, Global))
 }
 
 func TestMCPEntryPresentFalseWhenAbsent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"mcpServers":{"other":{}}}`), 0o600))
 
-	assert.False(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName))
+	assert.False(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName, Global))
 }
 
 func TestMCPEntryPresentFalseWhenFileMissing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nonexistent.json")
 
-	assert.False(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName))
+	assert.False(t, MCPEntryPresent(testMCPTarget(path), Env{}, testServerName, Global))
+}
+
+// --- Project scope ---
+
+func testProjectMCPTarget(homePath, projectPath string) *MCPTarget {
+	return &MCPTarget{
+		ConfigPath:        func(_ Env) (string, error) { return homePath, nil },
+		ProjectConfigPath: func(_ Env) (string, error) { return projectPath, nil },
+		Format:            codec.JSON,
+		ServersKey:        []string{"mcpServers"},
+	}
+}
+
+func TestInstallMCPProjectScope(t *testing.T) {
+	homePath := filepath.Join(t.TempDir(), "home", "mcp.json")
+	projectPath := filepath.Join(t.TempDir(), "project", "mcp.json")
+
+	outcome, err := InstallMCP(testProjectMCPTarget(homePath, projectPath), Env{}, sampleEntry(), testServerName, Project, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionAdded, outcome.Action)
+	assert.Equal(t, projectPath, outcome.Path)
+
+	data, err := os.ReadFile(projectPath)
+	require.NoError(t, err)
+
+	m, err := codec.Decode(codec.JSON, data)
+	require.NoError(t, err)
+
+	_, ok := codec.GetNested(m, "mcpServers", testServerName)
+	assert.True(t, ok)
+
+	_, statErr := os.Stat(homePath)
+	assert.True(t, os.IsNotExist(statErr), "home config must not be written for a project-scope install")
+}
+
+func TestInstallMCPProjectScopeNoPathSkips(t *testing.T) {
+	homePath := filepath.Join(t.TempDir(), "home", "mcp.json")
+
+	target := &MCPTarget{
+		ConfigPath:        func(_ Env) (string, error) { return homePath, nil },
+		ProjectConfigPath: nil,
+		Format:            codec.JSON,
+		ServersKey:        []string{"mcpServers"},
+	}
+
+	outcome, err := InstallMCP(target, Env{}, sampleEntry(), testServerName, Project, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionSkipped, outcome.Action)
+
+	_, statErr := os.Stat(homePath)
+	assert.True(t, os.IsNotExist(statErr), "no file should be written when the project path is unavailable")
 }

--- a/cli/internal/agentcfg/mcp_remove_test.go
+++ b/cli/internal/agentcfg/mcp_remove_test.go
@@ -18,7 +18,7 @@ func TestRemoveMCPDeletesOnlyOurKey(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(
 		`{"mcpServers":{"agntcy-dir-mcp":{"command":"dirctl"},"other":{"command":"node"}}}`), 0o600))
 
-	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, false)
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionRemoved, outcome.Action)
 
@@ -36,7 +36,7 @@ func TestRemoveMCPAbsentIsUnchanged(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "mcp.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"mcpServers":{"other":{}}}`), 0o600))
 
-	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, false)
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUnchanged, outcome.Action)
 }
@@ -44,7 +44,7 @@ func TestRemoveMCPAbsentIsUnchanged(t *testing.T) {
 func TestRemoveMCPMissingFileIsUnchanged(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nope.json")
 
-	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, false)
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUnchanged, outcome.Action)
 }
@@ -54,7 +54,7 @@ func TestRemoveMCPDryRunNoWrite(t *testing.T) {
 	original := []byte(`{"mcpServers":{"agntcy-dir-mcp":{"command":"dirctl"}}}`)
 	require.NoError(t, os.WriteFile(path, original, 0o600))
 
-	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, true)
+	outcome, err := RemoveMCP(testMCPTarget(path), Env{}, testServerName, Global, true)
 	require.NoError(t, err)
 	assert.Equal(t, ActionRemoved, outcome.Action)
 

--- a/cli/internal/agentcfg/paths.go
+++ b/cli/internal/agentcfg/paths.go
@@ -151,6 +151,74 @@ func codexMCPPath(env Env) (string, error) {
 	return filepath.Join(env.Home, ".codex", "config.toml"), nil
 }
 
+// --- project (repo/cwd) MCP config paths ---
+// Only agents with a documented project-scope MCP location are listed here;
+// agents without one leave ProjectConfigPath nil and are skipped-with-note.
+
+func requireCwd(env Env, agent string) error {
+	if env.Cwd == "" {
+		return fmt.Errorf("cannot determine current directory for %s project config", agent)
+	}
+
+	return nil
+}
+
+func claudeCodeProjectMCPPath(env Env) (string, error) {
+	if err := requireCwd(env, "Claude Code"); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Cwd, ".mcp.json"), nil
+}
+
+func cursorProjectMCPPath(env Env) (string, error) {
+	if err := requireCwd(env, "Cursor"); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Cwd, ".cursor", "mcp.json"), nil
+}
+
+func vscodeProjectMCPPath(env Env) (string, error) {
+	if err := requireCwd(env, "VS Code"); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Cwd, ".vscode", "mcp.json"), nil
+}
+
+func rooProjectMCPPath(env Env) (string, error) {
+	if err := requireCwd(env, "Roo Code"); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Cwd, ".roo", "mcp.json"), nil
+}
+
+func geminiProjectMCPPath(env Env) (string, error) {
+	if err := requireCwd(env, "Gemini CLI"); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Cwd, ".gemini", "settings.json"), nil
+}
+
+func opencodeProjectMCPPath(env Env) (string, error) {
+	if err := requireCwd(env, "OpenCode"); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Cwd, "opencode.json"), nil
+}
+
+func zedProjectMCPPath(env Env) (string, error) {
+	if err := requireCwd(env, "Zed"); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(env.Cwd, ".zed", "settings.json"), nil
+}
+
 // --- skill / rules paths ---
 
 func claudeCodeSkillPath(env Env, slug string) (string, error) {
@@ -159,6 +227,22 @@ func claudeCodeSkillPath(env Env, slug string) (string, error) {
 	}
 
 	return filepath.Join(env.Home, ".claude", "skills", slug, "SKILL.md"), nil
+}
+
+func claudeCodeProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Claude Code project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".claude", "skills", slug, "SKILL.md"), nil
+}
+
+func continueProjectSkillPath(env Env, slug string) (string, error) {
+	if env.Cwd == "" {
+		return "", fmt.Errorf("cannot determine current directory for Continue project skill")
+	}
+
+	return filepath.Join(env.Cwd, ".continue", "rules", slug+".md"), nil
 }
 
 func zedUserSkillPath(env Env, slug string) (string, error) {

--- a/cli/internal/agentcfg/registry.go
+++ b/cli/internal/agentcfg/registry.go
@@ -19,10 +19,11 @@ func Registry() []Agent {
 			Name:   "Claude Code",
 			Flag:   "claude-code",
 			Detect: detectByMarker(claudeCodeMarker),
-			MCP:    jsonMCP(claudeCodeMCPPath, "mcpServers"),
+			MCP:    jsonMCP(claudeCodeMCPPath, "mcpServers", claudeCodeProjectMCPPath),
 			Skill: &SkillTarget{
-				Strategy: SkillFolder,
-				Path:     claudeCodeSkillPath,
+				Strategy:    SkillFolder,
+				Path:        claudeCodeSkillPath,
+				ProjectPath: claudeCodeProjectSkillPath,
 			},
 		},
 		{
@@ -30,7 +31,7 @@ func Registry() []Agent {
 			Name:   "Claude Desktop",
 			Flag:   "claude-desktop",
 			Detect: detectByMarker(claudeDesktopMarker),
-			MCP:    jsonMCP(claudeDesktopMCPPath, "mcpServers"),
+			MCP:    jsonMCP(claudeDesktopMCPPath, "mcpServers", nil), // desktop app: no repo-scope config
 			Skill: &SkillTarget{
 				Strategy:   SkillFolder,
 				Path:       claudeCodeSkillPath, // shares Claude Code's skills folder
@@ -42,7 +43,7 @@ func Registry() []Agent {
 			Name:   "Cursor",
 			Flag:   "cursor",
 			Detect: detectByMarker(cursorMarker),
-			MCP:    jsonMCP(cursorMCPPath, "mcpServers"),
+			MCP:    jsonMCP(cursorMCPPath, "mcpServers", cursorProjectMCPPath),
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
 				Path:        cursorUserSkillPath,
@@ -54,7 +55,7 @@ func Registry() []Agent {
 			Name:   "VS Code (Copilot)",
 			Flag:   "vscode",
 			Detect: detectByMarker(vscodeMarker),
-			MCP:    jsonMCP(vscodeMCPPath, "servers"),
+			MCP:    jsonMCP(vscodeMCPPath, "servers", vscodeProjectMCPPath),
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
 				Path:        copilotUserSkillPath,
@@ -66,7 +67,7 @@ func Registry() []Agent {
 			Name:   "Windsurf",
 			Flag:   "windsurf",
 			Detect: detectByMarker(windsurfMarker),
-			MCP:    jsonMCP(windsurfMCPPath, "mcpServers"),
+			MCP:    jsonMCP(windsurfMCPPath, "mcpServers", nil), // no documented project MCP location
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
 				Path:        windsurfUserSkillPath,
@@ -78,7 +79,7 @@ func Registry() []Agent {
 			Name:   "Cline",
 			Flag:   "cline",
 			Detect: detectByMarker(clineMarker),
-			MCP:    jsonMCP(clineMCPPath, "mcpServers"),
+			MCP:    jsonMCP(clineMCPPath, "mcpServers", nil), // MCP config is global only
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
 				Path:        clineUserSkillPath,
@@ -90,7 +91,7 @@ func Registry() []Agent {
 			Name:   "Roo Code",
 			Flag:   "roo",
 			Detect: detectByMarker(rooMarker),
-			MCP:    jsonMCP(rooMCPPath, "mcpServers"),
+			MCP:    jsonMCP(rooMCPPath, "mcpServers", rooProjectMCPPath),
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
 				Path:        rooUserSkillPath,
@@ -102,7 +103,7 @@ func Registry() []Agent {
 			Name:   "Gemini CLI",
 			Flag:   "gemini",
 			Detect: detectByMarker(geminiMarker),
-			MCP:    jsonMCP(geminiMCPPath, "mcpServers"),
+			MCP:    jsonMCP(geminiMCPPath, "mcpServers", geminiProjectMCPPath),
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
 				Path:        geminiUserSkillPath,
@@ -114,7 +115,7 @@ func Registry() []Agent {
 			Name:   "OpenCode",
 			Flag:   "opencode",
 			Detect: detectByMarker(opencodeMarker),
-			MCP:    jsonMCP(opencodeMCPPath, "mcp"),
+			MCP:    jsonMCP(opencodeMCPPath, "mcp", opencodeProjectMCPPath),
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
 				Path:        opencodeUserSkillPath,
@@ -127,10 +128,11 @@ func Registry() []Agent {
 			Flag:   "zed",
 			Detect: detectByMarker(zedMarker),
 			MCP: &MCPTarget{
-				ConfigPath: zedMCPPath,
-				Format:     codec.JSON,
-				ServersKey: []string{"context_servers"},
-				EntryStyle: ZedContextServer,
+				ConfigPath:        zedMCPPath,
+				ProjectConfigPath: zedProjectMCPPath,
+				Format:            codec.JSON,
+				ServersKey:        []string{"context_servers"},
+				EntryStyle:        ZedContextServer,
 			},
 			Skill: &SkillTarget{
 				Strategy:    SkillFolder,
@@ -144,15 +146,16 @@ func Registry() []Agent {
 			Flag:   "continue",
 			Detect: detectByMarker(continueMarker),
 			MCP: &MCPTarget{
-				ConfigPath: continueMCPPath,
+				ConfigPath: continueMCPPath, // no documented project MCP location
 				Format:     codec.YAML,
 				ServersKey: []string{"mcpServers"},
 				EntryStyle: CommandArgsEnv,
 			},
 			Skill: &SkillTarget{
-				Strategy: DedicatedFile,
-				Path:     continueSkillPath,
-				Render:   renderContinue,
+				Strategy:    DedicatedFile,
+				Path:        continueSkillPath,
+				ProjectPath: continueProjectSkillPath,
+				Render:      renderContinue,
 			},
 		},
 		{
@@ -161,7 +164,7 @@ func Registry() []Agent {
 			Flag:   "codex",
 			Detect: detectByMarker(codexMarker),
 			MCP: &MCPTarget{
-				ConfigPath: codexMCPPath,
+				ConfigPath: codexMCPPath, // MCP config is global only
 				Format:     codec.TOML,
 				ServersKey: []string{"mcp_servers"},
 				EntryStyle: CommandArgsEnv,
@@ -175,13 +178,15 @@ func Registry() []Agent {
 	}
 }
 
-// jsonMCP is a small constructor for the common JSON MCP target shape.
-func jsonMCP(configPath func(env Env) (string, error), serversKey string) *MCPTarget {
+// jsonMCP is a small constructor for the common JSON MCP target shape. projectPath
+// may be nil when the agent has no project-scope MCP location.
+func jsonMCP(configPath func(env Env) (string, error), serversKey string, projectPath func(env Env) (string, error)) *MCPTarget {
 	return &MCPTarget{
-		ConfigPath: configPath,
-		Format:     codec.JSON,
-		ServersKey: []string{serversKey},
-		EntryStyle: CommandArgsEnv,
+		ConfigPath:        configPath,
+		ProjectConfigPath: projectPath,
+		Format:            codec.JSON,
+		ServersKey:        []string{serversKey},
+		EntryStyle:        CommandArgsEnv,
 	}
 }
 

--- a/cli/internal/agentcfg/registry_test.go
+++ b/cli/internal/agentcfg/registry_test.go
@@ -69,7 +69,7 @@ func TestRegistrySkillTargetsResolve(t *testing.T) {
 			continue
 		}
 
-		path, _, err := resolveSkillTargetPath(a.Skill, env, "test-slug")
+		path, err := resolveSkillTargetPath(a.Skill, env, "test-slug", Global)
 		require.NoError(t, err, "agent %s skill path", a.ID)
 		assert.NotEmpty(t, path, "agent %s resolved empty skill path", a.ID)
 

--- a/cli/internal/agentcfg/result.go
+++ b/cli/internal/agentcfg/result.go
@@ -30,6 +30,17 @@ func failOutcome(outcome Outcome, err error) (Outcome, error) {
 	return outcome, err
 }
 
+// skipScopeOutcome builds a skipped outcome for an artifact that has no config
+// location for the requested scope, so a missing project/global path degrades
+// gracefully instead of failing the run.
+func skipScopeOutcome(artifact string, scope Scope) Outcome {
+	return Outcome{
+		Artifact: artifact,
+		Action:   ActionSkipped,
+		Reason:   "no " + scope.String() + " location for this agent's " + artifact,
+	}
+}
+
 // Outcome records what happened to one artifact (MCP or skill) for one agent.
 type Outcome struct {
 	Record   string // optional record label for batch install grouping

--- a/cli/internal/agentcfg/skill_engine.go
+++ b/cli/internal/agentcfg/skill_engine.go
@@ -21,16 +21,17 @@ const skillFilePerm = 0o644
 // strategy. It is idempotent: identical content reports ActionUnchanged. When
 // the global path is unavailable it falls back to the project path and notes
 // this in the outcome reason.
-func InstallSkill(target *SkillTarget, env Env, slug, canonical string, dryRun bool) (Outcome, error) {
-	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+func InstallSkill(target *SkillTarget, env Env, slug, canonical string, scope Scope, dryRun bool) (Outcome, error) {
+	path, err := resolveSkillTargetPath(target, env, slug, scope)
+	if errors.Is(err, ErrNoScopePath) {
+		return skipScopeOutcome("skill", scope), nil
+	}
+
 	if err != nil {
 		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
 	}
 
 	outcome := Outcome{Artifact: "skill", Path: path}
-	if usedProject {
-		outcome.Reason = "no global rules path for this agent — wrote a project rule in the current repo"
-	}
 
 	desired, err := renderForTarget(target, slug, canonical, path)
 	if err != nil {
@@ -82,8 +83,12 @@ func InstallSkill(target *SkillTarget, env Env, slug, canonical string, dryRun b
 
 // InstallSkillBundle extracts a skill bundle archive into an agent's skill folder.
 // It is idempotent: identical on-disk content reports ActionUnchanged.
-func InstallSkillBundle(target *SkillTarget, env Env, slug string, archive []byte, dryRun bool) (Outcome, error) {
-	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+func InstallSkillBundle(target *SkillTarget, env Env, slug string, archive []byte, scope Scope, dryRun bool) (Outcome, error) {
+	path, err := resolveSkillTargetPath(target, env, slug, scope)
+	if errors.Is(err, ErrNoScopePath) {
+		return skipScopeOutcome("skill", scope), nil
+	}
+
 	if err != nil {
 		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
 	}
@@ -91,9 +96,6 @@ func InstallSkillBundle(target *SkillTarget, env Env, slug string, archive []byt
 	destDir := filepath.Dir(path)
 
 	outcome := Outcome{Artifact: "skill", Path: destDir}
-	if usedProject {
-		outcome.Reason = "no global rules path for this agent — wrote a project rule in the current repo"
-	}
 
 	matches, err := exportfmt.SkillBundleMatchesDir(archive, destDir)
 	if err != nil {
@@ -128,14 +130,17 @@ func InstallSkillBundle(target *SkillTarget, env Env, slug string, archive []byt
 // RemoveSkill removes the DIR skill/rules we installed for an agent, preserving
 // any surrounding user content for managed-block files. Absent artifacts report
 // ActionUnchanged so uninstall is idempotent.
-func RemoveSkill(target *SkillTarget, env Env, slug string, dryRun bool) (Outcome, error) {
-	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+func RemoveSkill(target *SkillTarget, env Env, slug string, scope Scope, dryRun bool) (Outcome, error) {
+	path, err := resolveSkillTargetPath(target, env, slug, scope)
+	if errors.Is(err, ErrNoScopePath) {
+		return skipScopeOutcome("skill", scope), nil
+	}
+
 	if err != nil {
 		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
 	}
 
 	outcome := Outcome{Artifact: "skill", Path: path}
-	_ = usedProject
 
 	switch target.Strategy {
 	case SkillFolder:
@@ -262,37 +267,35 @@ func removeSkillBlock(outcome Outcome, path, slug string, dryRun bool) (Outcome,
 	return outcome, nil
 }
 
-// resolveSkillTargetPath resolves the global path, falling back to the project
-// path when the global resolver reports ErrNoGlobalPath. It reports whether the
-// project fallback was used.
-func resolveSkillTargetPath(target *SkillTarget, env Env, slug string) (string, bool, error) {
-	if target.Path != nil {
-		path, err := target.Path(env, slug)
-		if err == nil {
-			return path, false, nil
-		}
-
-		if !errors.Is(err, ErrNoGlobalPath) {
-			return "", false, err
-		}
+// resolveSkillTargetPath resolves the skill path for the requested scope: the
+// global Path for Global, the ProjectPath for Project. A nil resolver (or a
+// resolver reporting ErrNoScopePath) yields ErrNoScopePath so the caller can skip.
+func resolveSkillTargetPath(target *SkillTarget, env Env, slug string, scope Scope) (string, error) {
+	resolver := target.Path
+	if scope == Project {
+		resolver = target.ProjectPath
 	}
 
-	if target.ProjectPath != nil {
-		path, err := target.ProjectPath(env, slug)
-		if err != nil {
-			return "", false, err
-		}
-
-		return path, true, nil
+	if resolver == nil {
+		return "", ErrNoScopePath
 	}
 
-	return "", false, ErrNoGlobalPath
+	path, err := resolver(env, slug)
+	if err != nil {
+		if errors.Is(err, ErrNoScopePath) {
+			return "", ErrNoScopePath
+		}
+
+		return "", err
+	}
+
+	return path, nil
 }
 
 // ResolveSkillTargetPath is the exported wrapper around resolveSkillTargetPath,
 // used by the command layer for dedupe and display.
-func ResolveSkillTargetPath(target *SkillTarget, env Env, slug string) (string, bool, error) {
-	return resolveSkillTargetPath(target, env, slug)
+func ResolveSkillTargetPath(target *SkillTarget, env Env, slug string, scope Scope) (string, error) {
+	return resolveSkillTargetPath(target, env, slug, scope)
 }
 
 // readFileIfExists reads path and reports whether it exists. A missing file is

--- a/cli/internal/agentcfg/skill_engine.go
+++ b/cli/internal/agentcfg/skill_engine.go
@@ -18,9 +18,9 @@ import (
 const skillFilePerm = 0o644
 
 // InstallSkill renders and writes the DIR skill/rules for an agent using its
-// strategy. It is idempotent: identical content reports ActionUnchanged. When
-// the global path is unavailable it falls back to the project path and notes
-// this in the outcome reason.
+// strategy, at the requested scope (global or project). It is idempotent:
+// identical content reports ActionUnchanged. When the agent has no location for
+// the requested scope, it reports ActionSkipped with a reason.
 func InstallSkill(target *SkillTarget, env Env, slug, canonical string, scope Scope, dryRun bool) (Outcome, error) {
 	path, err := resolveSkillTargetPath(target, env, slug, scope)
 	if errors.Is(err, ErrNoScopePath) {

--- a/cli/internal/agentcfg/skill_engine_test.go
+++ b/cli/internal/agentcfg/skill_engine_test.go
@@ -25,7 +25,7 @@ func TestInstallSkillFolderWritesVerbatim(t *testing.T) {
 		Path:     func(Env, string) (string, error) { return skillPath, nil },
 	}
 
-	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
@@ -34,12 +34,12 @@ func TestInstallSkillFolderWritesVerbatim(t *testing.T) {
 	assert.Equal(t, sampleDoc, string(got))
 
 	// Idempotent.
-	again, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	again, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUnchanged, again.Action)
 
 	// Remove deletes the test-skill folder.
-	rm, err := RemoveSkill(target, Env{}, "test-skill", false)
+	rm, err := RemoveSkill(target, Env{}, "test-skill", Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionRemoved, rm.Action)
 
@@ -57,14 +57,14 @@ func TestInstallSkillDedicatedFileRendersAndRemoves(t *testing.T) {
 		Render:   renderContinue,
 	}
 
-	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
 	got, _ := os.ReadFile(path)
 	assert.Contains(t, string(got), "alwaysApply: true")
 
-	rm, err := RemoveSkill(target, Env{}, "test-skill", false)
+	rm, err := RemoveSkill(target, Env{}, "test-skill", Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionRemoved, rm.Action)
 
@@ -83,7 +83,7 @@ func TestInstallSkillManagedBlockPreservesUserContent(t *testing.T) {
 		Render:   renderManagedInner,
 	}
 
-	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
@@ -92,12 +92,12 @@ func TestInstallSkillManagedBlockPreservesUserContent(t *testing.T) {
 	assert.Contains(t, string(got), blockBegin("test-skill"))
 
 	// Idempotent.
-	again, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	again, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUnchanged, again.Action)
 
 	// Remove strips only our block.
-	rm, err := RemoveSkill(target, Env{}, "test-skill", false)
+	rm, err := RemoveSkill(target, Env{}, "test-skill", Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionRemoved, rm.Action)
 
@@ -106,24 +106,74 @@ func TestInstallSkillManagedBlockPreservesUserContent(t *testing.T) {
 	assert.NotContains(t, string(after), blockBegin("test-skill"))
 }
 
-func TestInstallSkillProjectFallback(t *testing.T) {
+func TestInstallSkillGlobalScopeSkipsWhenNoGlobalPath(t *testing.T) {
+	// Scope selection is now explicit (no automatic global->project fallback):
+	// a Global-scope install with no global Path resolver skips, even though a
+	// ProjectPath is available, and writes nothing.
 	root := t.TempDir()
 	projectPath := filepath.Join(root, "repo", ".cursor", "skills", "test-skill", "SKILL.md")
 
 	target := &SkillTarget{
 		Strategy:    SkillFolder,
-		Path:        func(Env, string) (string, error) { return "", ErrNoGlobalPath },
+		Path:        func(Env, string) (string, error) { return "", ErrNoScopePath },
 		ProjectPath: func(Env, string) (string, error) { return projectPath, nil },
 	}
 
-	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, false)
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, Global, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionSkipped, outcome.Action)
+	assert.NotEmpty(t, outcome.Reason, "scope skip should be explained")
+
+	_, statErr := os.Stat(projectPath)
+	assert.True(t, os.IsNotExist(statErr), "project path must not be written for a global-scope install")
+}
+
+func TestInstallSkillProjectScope(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	env := Env{Home: home, Cwd: cwd}
+
+	homePath := filepath.Join(home, "skills", "test-skill", "SKILL.md")
+	projectPath := filepath.Join(cwd, "skills", "test-skill", "SKILL.md")
+
+	target := &SkillTarget{
+		Strategy: SkillFolder,
+		Path: func(e Env, slug string) (string, error) {
+			return filepath.Join(e.Home, "skills", slug, "SKILL.md"), nil
+		},
+		ProjectPath: func(e Env, slug string) (string, error) { return filepath.Join(e.Cwd, "skills", slug, "SKILL.md"), nil },
+	}
+
+	outcome, err := InstallSkill(target, env, "test-skill", sampleDoc, Project, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 	assert.Equal(t, projectPath, outcome.Path)
-	assert.NotEmpty(t, outcome.Reason, "project fallback should be explained")
 
 	_, statErr := os.Stat(projectPath)
-	assert.NoError(t, statErr)
+	require.NoError(t, statErr, "project skill file must be written")
+
+	_, statErr = os.Stat(homePath)
+	assert.True(t, os.IsNotExist(statErr), "home skill file must not be written for a project-scope install")
+}
+
+func TestInstallSkillProjectScopeNoPathSkips(t *testing.T) {
+	home := t.TempDir()
+	env := Env{Home: home}
+
+	target := &SkillTarget{
+		Strategy: SkillFolder,
+		Path: func(e Env, slug string) (string, error) {
+			return filepath.Join(e.Home, "skills", slug, "SKILL.md"), nil
+		},
+		ProjectPath: nil,
+	}
+
+	outcome, err := InstallSkill(target, env, "test-skill", sampleDoc, Project, false)
+	require.NoError(t, err)
+	assert.Equal(t, ActionSkipped, outcome.Action)
+
+	_, statErr := os.Stat(filepath.Join(home, "skills", "test-skill", "SKILL.md"))
+	assert.True(t, os.IsNotExist(statErr), "no file should be written when the project path is unavailable")
 }
 
 func TestInstallSkillDryRunWritesNothing(t *testing.T) {
@@ -136,7 +186,7 @@ func TestInstallSkillDryRunWritesNothing(t *testing.T) {
 		Render:   renderRoo,
 	}
 
-	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, true)
+	outcome, err := InstallSkill(target, Env{}, "test-skill", sampleDoc, Global, true)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
@@ -154,7 +204,7 @@ func TestRemoveSkillAbsentIsUnchanged(t *testing.T) {
 		Render:   renderRoo,
 	}
 
-	outcome, err := RemoveSkill(target, Env{}, "test-skill", false)
+	outcome, err := RemoveSkill(target, Env{}, "test-skill", Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUnchanged, outcome.Action)
 }
@@ -173,12 +223,12 @@ func TestInstallSkillVersionReplace(t *testing.T) {
 	canonicalB := "# Version B\n\nThis is version B.\n"
 
 	// Install canonical A.
-	first, err := InstallSkill(target, Env{}, "rec", canonicalA, false)
+	first, err := InstallSkill(target, Env{}, "rec", canonicalA, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, first.Action)
 
 	// Install canonical B — same slug, different content.
-	second, err := InstallSkill(target, Env{}, "rec", canonicalB, false)
+	second, err := InstallSkill(target, Env{}, "rec", canonicalB, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUpdated, second.Action, "second install of same slug should report ActionUpdated")
 
@@ -200,7 +250,7 @@ func TestInstallSkillBundleExtractsArchive(t *testing.T) {
 		Path:     func(Env, string) (string, error) { return skillPath, nil },
 	}
 
-	outcome, err := InstallSkillBundle(target, Env{}, "test-skill", archive, false)
+	outcome, err := InstallSkillBundle(target, Env{}, "test-skill", archive, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, outcome.Action)
 
@@ -213,7 +263,7 @@ func TestInstallSkillBundleExtractsArchive(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "#!/bin/sh\n", string(extra))
 
-	again, err := InstallSkillBundle(target, Env{}, "test-skill", archive, false)
+	again, err := InstallSkillBundle(target, Env{}, "test-skill", archive, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUnchanged, again.Action)
 }
@@ -256,13 +306,13 @@ func TestInstallSkillManagedBlockVersionReplace(t *testing.T) {
 	canonicalB := "---\nname: rec\n---\n\n# Version B\n\nThis is version B.\n"
 
 	// Install canonical A into a fresh file.
-	first, err := InstallSkill(target, Env{}, "rec", canonicalA, false)
+	first, err := InstallSkill(target, Env{}, "rec", canonicalA, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionAdded, first.Action)
 
 	// Install the SAME slug with a DIFFERENT canonical: slug-scoped block
 	// detection must recognize our existing block and replace it in place.
-	second, err := InstallSkill(target, Env{}, "rec", canonicalB, false)
+	second, err := InstallSkill(target, Env{}, "rec", canonicalB, Global, false)
 	require.NoError(t, err)
 	assert.Equal(t, ActionUpdated, second.Action, "second install of same slug should report ActionUpdated")
 

--- a/cli/internal/agentcfg/skill_path.go
+++ b/cli/internal/agentcfg/skill_path.go
@@ -5,26 +5,21 @@ package agentcfg
 
 import "errors"
 
-// ErrNoGlobalPath is returned by a SkillTarget.Path resolver when the agent has
-// no global mechanism for the skill artifact, signalling the engine to fall back
-// to the project (cwd) path.
-var ErrNoGlobalPath = errors.New("no global skill path for this agent")
+// ErrNoScopePath is returned by a resolver when the agent has no config location
+// for the requested scope (global or project), signalling the engine to skip that
+// artifact with a note rather than fail.
+var ErrNoScopePath = errors.New("no config location for this scope")
 
-// ResolveSkillPath resolves the on-disk path for a skill target for display: the
-// global path when available, otherwise the project (cwd) fallback. It annotates
-// a project fallback and never returns an error (display-only).
-func ResolveSkillPath(target *SkillTarget, env Env, slug string) string {
-	path, usedProject, err := resolveSkillTargetPath(target, env, slug)
+// ResolveSkillPath resolves the on-disk skill path for the given scope, for
+// display. It never returns an error (display-only).
+func ResolveSkillPath(target *SkillTarget, env Env, slug string, scope Scope) string {
+	path, err := resolveSkillTargetPath(target, env, slug, scope)
 	if err != nil {
-		if errors.Is(err, ErrNoGlobalPath) {
-			return "(no global path; run inside a repo for a project rule)"
+		if errors.Is(err, ErrNoScopePath) {
+			return "(no " + scope.String() + " location for this agent)"
 		}
 
 		return "(path error: " + err.Error() + ")"
-	}
-
-	if usedProject {
-		return path + " (project fallback)"
 	}
 
 	return path

--- a/cli/internal/agentcfg/types.go
+++ b/cli/internal/agentcfg/types.go
@@ -21,6 +21,25 @@ type Env struct {
 	Cwd  string
 }
 
+// Scope selects which configuration location an artifact is written to.
+type Scope int
+
+const (
+	// Global targets the user/global config (default).
+	Global Scope = iota
+	// Project targets the current repository (Env.Cwd).
+	Project
+)
+
+// String renders the scope for user-facing messages.
+func (s Scope) String() string {
+	if s == Project {
+		return "project"
+	}
+
+	return "global"
+}
+
 // EntryStyle selects how an MCP server entry value is shaped for a given agent.
 type EntryStyle int
 
@@ -35,6 +54,9 @@ const (
 type MCPTarget struct {
 	// ConfigPath resolves the global config file path for the given environment.
 	ConfigPath func(env Env) (string, error)
+	// ProjectConfigPath resolves the project (repo/cwd) config file path. Nil if
+	// the agent has no project-scope MCP location.
+	ProjectConfigPath func(env Env) (string, error)
 	// Format is the config file encoding.
 	Format codec.Format
 	// ServersKey is the nested key path to the servers map (e.g. ["mcpServers"]).

--- a/cli/internal/agentinstall/apply.go
+++ b/cli/internal/agentinstall/apply.go
@@ -11,9 +11,9 @@ import (
 
 const skillBundleFolderOnlyReason = "skill bundle requires a multi-file skills directory; this agent only supports single instruction files"
 
-// Install applies the record's artifacts to the selected agents, one outcome
-// per touched artifact. Errors on one agent never abort the rest.
-func Install(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, dryRun bool) []agentcfg.Outcome {
+// Install applies the record's artifacts to the selected agents at the given
+// scope, one outcome per touched artifact. Errors on one agent never abort the rest.
+func Install(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, scope agentcfg.Scope, dryRun bool) []agentcfg.Outcome {
 	var outcomes []agentcfg.Outcome
 
 	seenSkill := map[string]bool{}
@@ -22,7 +22,7 @@ func Install(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, dryRun b
 		if agent.MCP != nil {
 			for _, srv := range arts.mcpServers {
 				entry := styleEntry(srv.entry, agent.MCP.EntryStyle)
-				o, _ := agentcfg.InstallMCP(agent.MCP, env, entry, srv.name, dryRun)
+				o, _ := agentcfg.InstallMCP(agent.MCP, env, entry, srv.name, scope, dryRun)
 				o.Agent = agent.Name
 				outcomes = append(outcomes, o)
 			}
@@ -40,15 +40,15 @@ func Install(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, dryRun b
 				continue
 			}
 
-			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
+			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug, scope) {
 				continue
 			}
 
 			var o agentcfg.Outcome
 			if arts.hasSkillBundle() {
-				o, _ = agentcfg.InstallSkillBundle(agent.Skill, env, arts.slug, arts.skillBundle, dryRun)
+				o, _ = agentcfg.InstallSkillBundle(agent.Skill, env, arts.slug, arts.skillBundle, scope, dryRun)
 			} else {
-				o, _ = agentcfg.InstallSkill(agent.Skill, env, arts.slug, arts.skill, dryRun)
+				o, _ = agentcfg.InstallSkill(agent.Skill, env, arts.slug, arts.skill, scope, dryRun)
 			}
 
 			o.Agent = agent.Name
@@ -59,8 +59,8 @@ func Install(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, dryRun b
 	return outcomes
 }
 
-// Uninstall removes the record's artifacts from the selected agents.
-func Uninstall(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, dryRun bool) []agentcfg.Outcome {
+// Uninstall removes the record's artifacts from the selected agents at the given scope.
+func Uninstall(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, scope agentcfg.Scope, dryRun bool) []agentcfg.Outcome {
 	var outcomes []agentcfg.Outcome
 
 	seenSkill := map[string]bool{}
@@ -68,7 +68,7 @@ func Uninstall(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, dryRun
 	for _, agent := range agents {
 		if agent.MCP != nil {
 			for _, srv := range arts.mcpServers {
-				o, _ := agentcfg.RemoveMCP(agent.MCP, env, srv.name, dryRun)
+				o, _ := agentcfg.RemoveMCP(agent.MCP, env, srv.name, scope, dryRun)
 				o.Agent = agent.Name
 				outcomes = append(outcomes, o)
 			}
@@ -79,11 +79,11 @@ func Uninstall(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, dryRun
 				continue
 			}
 
-			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug) {
+			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug, scope) {
 				continue
 			}
 
-			o, _ := agentcfg.RemoveSkill(agent.Skill, env, arts.slug, dryRun)
+			o, _ := agentcfg.RemoveSkill(agent.Skill, env, arts.slug, scope, dryRun)
 			o.Agent = agent.Name
 			outcomes = append(outcomes, o)
 		}
@@ -107,8 +107,8 @@ func styleEntry(base map[string]any, style agentcfg.EntryStyle) map[string]any {
 
 // dedupeSkill reports whether a skill target's resolved path was already acted on
 // this run (e.g. Claude Code and Claude Desktop share one skills folder).
-func dedupeSkill(seen map[string]bool, target *agentcfg.SkillTarget, env agentcfg.Env, slug string) bool {
-	path, _, err := agentcfg.ResolveSkillTargetPath(target, env, slug)
+func dedupeSkill(seen map[string]bool, target *agentcfg.SkillTarget, env agentcfg.Env, slug string, scope agentcfg.Scope) bool {
+	path, err := agentcfg.ResolveSkillTargetPath(target, env, slug, scope)
 	if err != nil || path == "" {
 		return false
 	}

--- a/cli/internal/agentinstall/apply_test.go
+++ b/cli/internal/agentinstall/apply_test.go
@@ -44,7 +44,7 @@ func TestRunInstallWritesMCPEntryIdempotently(t *testing.T) {
 	agent := agentcfg.Agent{Name: "Claude Code", MCP: target}
 	agents := []agentcfg.Agent{agent}
 
-	first := Install(env, arts, agents, false)
+	first := Install(env, arts, agents, agentcfg.Global, false)
 	require.Len(t, first, 1)
 	require.Equal(t, agentcfg.ActionAdded, first[0].Action)
 
@@ -56,9 +56,46 @@ func TestRunInstallWritesMCPEntryIdempotently(t *testing.T) {
 	_, present := codec.GetNested(m, "mcpServers", "code-review")
 	require.True(t, present)
 
-	second := Install(env, arts, agents, false)
+	second := Install(env, arts, agents, agentcfg.Global, false)
 	require.Len(t, second, 1)
 	require.Equal(t, agentcfg.ActionUnchanged, second[0].Action)
+}
+
+func TestInstallProjectScope(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: cwd}
+
+	// Claude Code skill target: home-based Path vs. cwd-based ProjectPath.
+	var target *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		if a.ID == claudeCodeID {
+			target = a.Skill
+		}
+	}
+
+	require.NotNil(t, target)
+
+	arts := Artifacts{
+		slug:  "code-review",
+		skill: "---\nname: code-review\ndescription: x\n---\n\nbody\n",
+	}
+	agent := agentcfg.Agent{Name: "Claude Code", Skill: target}
+	agents := []agentcfg.Agent{agent}
+
+	outcomes := Install(env, arts, agents, agentcfg.Project, false)
+	require.Len(t, outcomes, 1)
+	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
+
+	projectSkillFile := filepath.Join(cwd, ".claude", "skills", "code-review", "SKILL.md")
+	raw, err := os.ReadFile(projectSkillFile)
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	homeSkillFile := filepath.Join(home, ".claude", "skills", "code-review", "SKILL.md")
+	_, statErr := os.Stat(homeSkillFile)
+	require.True(t, os.IsNotExist(statErr), "home skill file must not be written for a project-scope install")
 }
 
 func TestRunInstallWritesSkill(t *testing.T) {
@@ -83,7 +120,7 @@ func TestRunInstallWritesSkill(t *testing.T) {
 	agent := agentcfg.Agent{Name: "Claude Code", Skill: target}
 	agents := []agentcfg.Agent{agent}
 
-	outcomes := Install(env, arts, agents, false)
+	outcomes := Install(env, arts, agents, agentcfg.Global, false)
 	require.Len(t, outcomes, 1)
 	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
 
@@ -145,7 +182,7 @@ func TestRunUninstallRemovesMCPEntryAndPreservesSibling(t *testing.T) {
 		}},
 	}
 	agent := agentcfg.Agent{Name: "Claude Code", MCP: mcpTarget}
-	outcomes := Uninstall(env, arts, []agentcfg.Agent{agent}, false)
+	outcomes := Uninstall(env, arts, []agentcfg.Agent{agent}, agentcfg.Global, false)
 	require.Len(t, outcomes, 1)
 	require.Equal(t, agentcfg.ActionRemoved, outcomes[0].Action)
 
@@ -178,10 +215,10 @@ func TestRunUninstallRemovesSkill(t *testing.T) {
 	agent := agentcfg.Agent{Name: "Claude Code", Skill: skillTarget}
 
 	// Install first.
-	Install(env, arts, []agentcfg.Agent{agent}, false)
+	Install(env, arts, []agentcfg.Agent{agent}, agentcfg.Global, false)
 
 	// Uninstall.
-	outcomes := Uninstall(env, arts, []agentcfg.Agent{agent}, false)
+	outcomes := Uninstall(env, arts, []agentcfg.Agent{agent}, agentcfg.Global, false)
 	require.Len(t, outcomes, 1)
 	require.Equal(t, agentcfg.ActionRemoved, outcomes[0].Action)
 }
@@ -215,7 +252,7 @@ func TestRunInstallDedupesSharedSkillPath(t *testing.T) {
 		{Name: "Claude Desktop", Skill: claudeDesktop},
 	}
 
-	outcomes := Install(env, arts, agents, false)
+	outcomes := Install(env, arts, agents, agentcfg.Global, false)
 
 	// Both agents resolve to the same skills path, so dedupeSkill collapses the
 	// shared target to a single skill outcome.
@@ -243,7 +280,7 @@ func TestRunInstallWritesSkillBundle(t *testing.T) {
 		skillBundle: skillBundleArchiveBytes(t),
 	}
 	agent := agentcfg.Agent{Name: "Claude Code", Skill: target}
-	outcomes := Install(env, arts, []agentcfg.Agent{agent}, false)
+	outcomes := Install(env, arts, []agentcfg.Agent{agent}, agentcfg.Global, false)
 	require.Len(t, outcomes, 1)
 	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
 
@@ -290,7 +327,7 @@ func TestRunInstallExtractsSkillBundleToFolderAgents(t *testing.T) {
 		{Name: "VS Code (Copilot)", Skill: vscode},
 	}
 
-	outcomes := Install(env, arts, agents, true)
+	outcomes := Install(env, arts, agents, agentcfg.Global, true)
 	require.Len(t, outcomes, 3)
 
 	byAgent := map[string]agentcfg.Outcome{}
@@ -322,7 +359,7 @@ func TestRunInstallSkipsSkillBundleForNonFolderAgents(t *testing.T) {
 		skill:       "---\nname: summarize\ndescription: x\n---\n\nbody\n",
 		skillBundle: skillBundleArchiveBytes(t),
 	}
-	outcomes := Install(env, arts, []agentcfg.Agent{{Name: "Continue", Skill: continueAgent}}, true)
+	outcomes := Install(env, arts, []agentcfg.Agent{{Name: "Continue", Skill: continueAgent}}, agentcfg.Global, true)
 	require.Len(t, outcomes, 1)
 	require.Equal(t, agentcfg.ActionSkipped, outcomes[0].Action)
 	require.Equal(t, skillBundleFolderOnlyReason, outcomes[0].Reason)

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -197,6 +197,7 @@ A2A-only record, points you to `dirctl export`.
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--agents` | Agents to target: `all` (every detected agent) or a comma-separated list of agent IDs (e.g. `--agents claude-code,cursor`; repeatable) | `all` |
+| `--project` | Write into the current repo (project scope) instead of the user's global config | `false` |
 | `--dry-run` | Preview the plan without writing | `false` |
 | `--yes` / `-y` | Skip the confirmation prompt | `false` |
 
@@ -204,6 +205,13 @@ Valid agent IDs: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `windsurf`
 `cline`, `roo`, `gemini`, `opencode`, `zed`, `continue`, `codex` (see
 `dirctl install list`). After completion, a summary lists every location added,
 updated, removed, or skipped with its absolute path.
+
+By default artifacts go into each agent's **global/user** config. With
+`--project`, they are written into the **current repository** instead (e.g.
+`.cursor/mcp.json`, `.vscode/mcp.json`, `.mcp.json`, `.cursor/skills/…`), so a
+record can be wired into the agents for just one project. Agents with no
+project-scope location for an artifact are skipped with a note; detection is
+unchanged (an undetected agent is still skipped).
 
 ```bash
 # Preview what installing a record would change
@@ -214,6 +222,9 @@ dirctl install cisco.com/agent:v1.0.0 --yes
 
 # Install into specific agents only
 dirctl install cisco.com/agent --agents claude-code,cursor
+
+# Install into the current repo instead of the global config
+dirctl install cisco.com/agent --project
 ```
 
 ### `dirctl install uninstall <cid-or-name> [flags]`

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -207,11 +207,12 @@ Valid agent IDs: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `windsurf`
 updated, removed, or skipped with its absolute path.
 
 By default artifacts go into each agent's **global/user** config. With
-`--project`, they are written into the **current repository** instead (e.g.
-`.cursor/mcp.json`, `.vscode/mcp.json`, `.mcp.json`, `.cursor/skills/…`), so a
-record can be wired into the agents for just one project. Agents with no
-project-scope location for an artifact are skipped with a note; detection is
-unchanged (an undetected agent is still skipped).
+`--project`, they are written into the **current repository** instead — under
+each agent's project-local MCP config (e.g. `.cursor/mcp.json`, `.vscode/mcp.json`,
+`.mcp.json`) and its project skill folder — so a record can be wired into the
+agents for just one project. Run `dirctl install list --project` to see the exact
+paths per agent. Agents with no project-scope location for an artifact are skipped
+with a note; detection is unchanged (an undetected agent is still skipped).
 
 ```bash
 # Preview what installing a record would change
@@ -231,8 +232,8 @@ dirctl install cisco.com/agent --project
 
 Removes what `install` added for that record — its MCP entry and/or skill —
 leaving all other content intact. Shares the same flags as install (`--agents`,
-`--dry-run`, `--yes`). Idempotent: an agent with nothing of ours installed is
-reported as unchanged, never an error.
+`--project`, `--dry-run`, `--yes`). Idempotent: an agent with nothing of ours
+installed is reported as unchanged, never an error.
 
 `dirctl uninstall <cid-or-name>` is a top-level shorthand for
 `dirctl install uninstall <cid-or-name>` (same flags and behavior).

--- a/docs/content/dir/dir-features-scenarios.md
+++ b/docs/content/dir/dir-features-scenarios.md
@@ -447,10 +447,15 @@ dirctl install cisco.com/agent:v1.0.0 --yes
 # Install into specific agents only
 dirctl install cisco.com/agent --agents claude-code,cursor
 
+# Install into the current repo (project scope) instead of the global config
+dirctl install cisco.com/agent --project
+
 # Remove what install added (top-level shorthand for `install uninstall`)
 dirctl uninstall cisco.com/agent
 ```
 
 Detection is always required — an agent is never written to unless it is detected. Re-installing
 a newer version of the same record replaces the old artifacts cleanly. `dirctl install list`
-shows which agents are detected and the config files install would touch.
+shows which agents are detected and the config files install would touch. By default artifacts
+go into each agent's global config; `--project` writes them into the current repository instead
+(agents without a project-scope location for an artifact are skipped with a note).

--- a/docs/superpowers/plans/2026-07-21-dirctl-install-project-scope.md
+++ b/docs/superpowers/plans/2026-07-21-dirctl-install-project-scope.md
@@ -1,0 +1,275 @@
+# `dirctl install --project` Implementation Plan
+
+> **For agentic workers:** executed inline in this session (no commits — the user will review/commit). Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a `--project` flag to `dirctl install`/`uninstall` that writes a record's artifacts into the current repo (project scope) instead of the user's global config.
+
+**Architecture:** Thread an `agentcfg.Scope` (Global | Project) through the placement engine (`agentcfg`), the orchestrator (`agentinstall`), and the command (`cli/cmd/install`). Add `MCPTarget.ProjectConfigPath`; repurpose the existing `SkillTarget.ProjectPath` (drop its silent global→project fallback). Missing scope location ⇒ `ActionSkipped` with a reason.
+
+**Tech Stack:** Go (module `github.com/agntcy/dir/cli`), cobra, existing `agentcfg` codec/engines.
+
+## Global Constraints
+
+- Copyright header verbatim on every Go file: `// Copyright AGNTCY Contributors (https://github.com/agntcy)` then `// SPDX-License-Identifier: Apache-2.0`.
+- **Do NOT commit anything** — leave all changes in the working tree.
+- Work on the current branch `feat/dirctl-install-project-scope`; no new branches/worktrees.
+- `cli` is its own Go module. Verify with `cd cli && go build ./... && go test ./internal/agentcfg/... ./internal/agentinstall/... ./cmd/install/...`; lint with `task lint:go`.
+- Flag is a boolean `--project` (default false = global). Project root = `Env.Cwd`.
+- Detection is unchanged/orthogonal. Missing project location ⇒ skip-with-note, never a hard error.
+
+---
+
+## Task 1: `Scope` type + scope-aware skill resolution
+
+**Files:** Modify `cli/internal/agentcfg/types.go`, `skill_path.go`, `skill_engine.go`; Test `skill_engine_test.go`, `skill_path_test.go`.
+
+**Produces:**
+- `type Scope int` with `Global Scope = iota`, `Project`.
+- `var ErrNoScopePath = errors.New("no config location for this scope")` (replaces `ErrNoGlobalPath`).
+- `resolveSkillTargetPath(target *SkillTarget, env Env, slug string, scope Scope) (string, error)` — Global→`Path`, Project→`ProjectPath`; a nil resolver or `ErrNoGlobalPath`-style signal ⇒ `ErrNoScopePath`. (Drops the `usedProject` bool and the fallback.)
+- `ResolveSkillTargetPath(target, env, slug, scope)` and `ResolveSkillPath(target, env, slug, scope)` gain `scope`.
+- `InstallSkill(target, env, slug, canonical string, scope Scope, dryRun bool)`, `InstallSkillBundle(target, env, slug, archive, scope, dryRun)`, `RemoveSkill(target, env, slug, scope, dryRun)`, and `renderForTarget(target, slug, canonical, path, scope)` gain `scope`. When resolution returns `ErrNoScopePath`, return `Outcome{Action: ActionSkipped, Reason: "no <scope> location for this agent's skill"}, nil` (not `ActionFailed`).
+
+- [ ] **Step 1 — types.go:** add the `Scope` type + consts (after `Env`):
+
+```go
+// Scope selects which configuration location an artifact is written to.
+type Scope int
+
+const (
+	// Global targets the user/global config (default).
+	Global Scope = iota
+	// Project targets the current repository (Env.Cwd).
+	Project
+)
+
+// String renders the scope for user-facing messages.
+func (s Scope) String() string {
+	if s == Project {
+		return "project"
+	}
+
+	return "global"
+}
+```
+
+- [ ] **Step 2 — skill_path.go:** rename `ErrNoGlobalPath` → `ErrNoScopePath` (update its doc comment to "no config location for the requested scope"), and rewrite `ResolveSkillPath` to be scope-aware:
+
+```go
+func ResolveSkillPath(target *SkillTarget, env Env, slug string, scope Scope) string {
+	path, err := resolveSkillTargetPath(target, env, slug, scope)
+	if err != nil {
+		if errors.Is(err, ErrNoScopePath) {
+			return "(no " + scope.String() + " location for this agent)"
+		}
+
+		return "(path error: " + err.Error() + ")"
+	}
+
+	return path
+}
+```
+
+- [ ] **Step 3 — skill_engine.go:** rewrite `resolveSkillTargetPath` (no fallback, scope-driven, drop the bool):
+
+```go
+func resolveSkillTargetPath(target *SkillTarget, env Env, slug string, scope Scope) (string, error) {
+	resolver := target.Path
+	if scope == Project {
+		resolver = target.ProjectPath
+	}
+
+	if resolver == nil {
+		return "", ErrNoScopePath
+	}
+
+	path, err := resolver(env, slug)
+	if err != nil {
+		if errors.Is(err, ErrNoScopePath) {
+			return "", ErrNoScopePath
+		}
+
+		return "", err
+	}
+
+	return path, nil
+}
+
+func ResolveSkillTargetPath(target *SkillTarget, env Env, slug string, scope Scope) (string, error) {
+	return resolveSkillTargetPath(target, env, slug, scope)
+}
+```
+
+Thread `scope` into `InstallSkill`, `InstallSkillBundle`, `RemoveSkill`, and `renderForTarget`. Replace the `usedProject`-reason blocks. At the top of each of the three engine funcs, resolve with scope and short-circuit skip:
+
+```go
+path, err := resolveSkillTargetPath(target, env, slug, scope)
+if errors.Is(err, ErrNoScopePath) {
+	return Outcome{Artifact: "skill", Action: ActionSkipped, Reason: "no " + scope.String() + " location for this agent's skill"}, nil
+}
+if err != nil {
+	return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
+}
+```
+
+(`renderForTarget`'s ManagedBlock branch reads the existing file via the already-resolved `path`, so it just needs the `scope`-resolved path passed in — no extra resolution.)
+
+- [ ] **Step 4 — tests:** update `skill_engine_test.go` / `skill_path_test.go` call sites to pass `agentcfg.Global` (existing behavior) and add:
+  - `TestInstallSkillProjectScope`: a target with `Path` and a distinct `ProjectPath`; `InstallSkill(..., Project, false)` writes to the project path.
+  - `TestInstallSkillNoProjectPathSkips`: target with `ProjectPath == nil`; `InstallSkill(..., Project, false)` returns `ActionSkipped` (no write, no error).
+
+- [ ] **Step 5 — verify:** `cd cli && go test ./internal/agentcfg/... ` (the module won't fully build until Task 4/5 update callers; scope the test to the package — expect the package's own tests to compile once its test call sites are updated. If cross-package callers break the build, that's expected and fixed in Tasks 4–5.)
+
+---
+
+## Task 2: `MCPTarget.ProjectConfigPath` + scope-aware MCP engine
+
+**Files:** Modify `cli/internal/agentcfg/types.go`, `mcp_engine.go`; Test `mcp_engine_test.go`, `mcp_remove_test.go`.
+
+**Produces:**
+- `MCPTarget` gains `ProjectConfigPath func(env Env) (string, error)` (nil ⇒ no project support).
+- `mcpConfigPath(target *MCPTarget, env Env, scope Scope) (string, error)` — Global→`ConfigPath`, Project→`ProjectConfigPath` (nil ⇒ `ErrNoScopePath`).
+- `InstallMCP(target, env, entry, serverName string, scope Scope, dryRun bool)`, `RemoveMCP(target, env, serverName, scope, dryRun)`, `MCPEntryPresent(target, env, serverName, scope)` gain `scope`. On `ErrNoScopePath`, `InstallMCP`/`RemoveMCP` return `Outcome{Artifact:"mcp", Action: ActionSkipped, Reason: "no <scope> location for this agent's MCP config"}, nil`; `MCPEntryPresent` returns `false`.
+
+- [ ] **Step 1 — types.go:** add to `MCPTarget`:
+
+```go
+	// ProjectConfigPath resolves the project (repo/cwd) config path. Nil if the
+	// agent has no project-scope MCP location.
+	ProjectConfigPath func(env Env) (string, error)
+```
+
+- [ ] **Step 2 — mcp_engine.go:** add the resolver and thread `scope`:
+
+```go
+func mcpConfigPath(target *MCPTarget, env Env, scope Scope) (string, error) {
+	resolver := target.ConfigPath
+	if scope == Project {
+		resolver = target.ProjectConfigPath
+	}
+
+	if resolver == nil {
+		return "", ErrNoScopePath
+	}
+
+	return resolver(env)
+}
+```
+
+Replace the `target.ConfigPath(env)` calls in `InstallMCP`, `RemoveMCP`, `MCPEntryPresent` with `mcpConfigPath(target, env, scope)`. In `InstallMCP`/`RemoveMCP`, when the error is `ErrNoScopePath`, return `Outcome{Artifact:"mcp", Action: ActionSkipped, Reason: "no " + scope.String() + " location for this agent's MCP config"}, nil`. In `MCPEntryPresent`, treat any resolver error as `false` (unchanged behavior).
+
+- [ ] **Step 3 — tests:** update existing MCP tests to pass `agentcfg.Global`; add:
+  - `TestInstallMCPProjectScope`: target with `ConfigPath` + distinct `ProjectConfigPath` under a temp cwd; `InstallMCP(..., Project, false)` writes to the project path.
+  - `TestInstallMCPNoProjectPathSkips`: `ProjectConfigPath == nil`; `Project` ⇒ `ActionSkipped`, no write.
+
+- [ ] **Step 4 — verify:** `cd cli && go vet ./internal/agentcfg/` (full build deferred to Task 5).
+
+---
+
+## Task 3: Per-agent project paths in the registry
+
+**Files:** Modify `cli/internal/agentcfg/paths.go`, `registry.go`; Test `registry_test.go`, `paths_test.go`.
+
+**Produces:** project MCP resolvers + the missing project skill resolvers, wired into the registry. `jsonMCP` gains an optional project path.
+
+- [ ] **Step 1 — paths.go:** add project MCP path resolvers (repo-relative under `env.Cwd`), verifying each against the agent's current docs; leave unknown ones unset (skip). Confirmed set:
+
+```go
+func claudeCodeProjectMCPPath(env Env) (string, error) { return filepath.Join(env.Cwd, ".mcp.json"), nil }
+func cursorProjectMCPPath(env Env) (string, error)     { return filepath.Join(env.Cwd, ".cursor", "mcp.json"), nil }
+func vscodeProjectMCPPath(env Env) (string, error)     { return filepath.Join(env.Cwd, ".vscode", "mcp.json"), nil }
+func rooProjectMCPPath(env Env) (string, error)        { return filepath.Join(env.Cwd, ".roo", "mcp.json"), nil }
+func geminiProjectMCPPath(env Env) (string, error)     { return filepath.Join(env.Cwd, ".gemini", "settings.json"), nil }
+func opencodeProjectMCPPath(env Env) (string, error)   { return filepath.Join(env.Cwd, "opencode.json"), nil }
+func zedProjectMCPPath(env Env) (string, error)        { return filepath.Join(env.Cwd, ".zed", "settings.json"), nil }
+```
+
+Add missing project **skill** resolvers where absent:
+
+```go
+func claudeCodeProjectSkillPath(env Env) (string, error) {
+	return filepath.Join(env.Cwd, ".claude", "skills", slug, "SKILL.md"), nil // slug threaded like the other *ProjectSkillPath funcs
+}
+func continueProjectSkillPath(env Env) (string, error) {
+	return filepath.Join(env.Cwd, ".continue", "rules", slug+".md"), nil
+}
+```
+
+> Match the exact signature of the existing `*ProjectSkillPath` funcs (they take `(env Env, slug string)`). Verify each project location against the agent's docs during implementation; any unverified agent's `ProjectConfigPath`/`ProjectPath` is left unset so the engine skips it.
+
+- [ ] **Step 2 — registry.go:** extend `jsonMCP` to accept an optional project resolver, and set `ProjectConfigPath` / project skill `ProjectPath` per agent per the spec's coverage table. Agents with no project location for an artifact leave that resolver nil.
+
+```go
+func jsonMCP(configPath func(env Env) (string, error), serversKey string, projectPath func(env Env) (string, error)) *MCPTarget {
+	return &MCPTarget{
+		ConfigPath:        configPath,
+		ProjectConfigPath: projectPath,
+		Format:            codec.JSON,
+		ServersKey:        []string{serversKey},
+		EntryStyle:        CommandArgsEnv,
+	}
+}
+```
+
+Update each `jsonMCP(...)` call to pass its project path (or `nil`). Set project skill paths for claude-code and continue; claude-desktop skill keeps `ProjectPath: nil` (skip).
+
+- [ ] **Step 3 — tests:** add a `registry_test.go` check that every agent's project resolvers, when set, produce a cwd-relative path; and that claude-desktop's skill `ProjectPath` is nil.
+
+- [ ] **Step 4 — verify:** `cd cli && go vet ./internal/agentcfg/`.
+
+---
+
+## Task 4: Thread scope through `agentinstall`
+
+**Files:** Modify `cli/internal/agentinstall/apply.go`; Test `apply_test.go`.
+
+**Produces:** `Install(env, arts, agents, scope, dryRun)`, `Uninstall(env, arts, agents, scope, dryRun)`, `dedupeSkill(seen, target, env, slug, scope)`.
+
+- [ ] **Step 1:** add `scope agentcfg.Scope` param to `Install` and `Uninstall`; pass it to every `InstallMCP`/`RemoveMCP`/`InstallSkill`/`InstallSkillBundle`/`RemoveSkill` call. Add `scope` to `dedupeSkill` and its `ResolveSkillTargetPath` call.
+- [ ] **Step 2 — tests:** update `apply_test.go` call sites to pass `agentcfg.Global`; add a project-scope install test asserting the project path is written under a temp cwd.
+- [ ] **Step 3 — verify:** `cd cli && go test ./internal/agentinstall/...` (builds once Tasks 1–3 land).
+
+---
+
+## Task 5: `--project` flag + command wiring + plan annotation
+
+**Files:** Modify `cli/cmd/install/options.go`, `flags.go`, `install.go`, `uninstall.go`, `batch.go`, `list.go`; Test `install_test.go`.
+
+**Produces:** `--project` on all install/uninstall entry points; `scopeFromOpts()` helper; batch `recordApplyFn` gains `scope`; list respects `--project`.
+
+- [ ] **Step 1 — options.go:** add `project bool` to `options`.
+- [ ] **Step 2 — flags.go:** in `addSelectionFlags`, register `flags.BoolVar(&opts.project, "project", false, "Write into the current repo (project scope) instead of global config")`. Add a helper:
+
+```go
+func scopeFromOpts() agentcfg.Scope {
+	if opts.project {
+		return agentcfg.Project
+	}
+
+	return agentcfg.Global
+}
+```
+
+- [ ] **Step 3 — install.go / uninstall.go:** pass `scopeFromOpts()` into `agentinstall.Install`/`Uninstall` in `runInstallCmd`/`runUninstallCmd`. Before printing the plan, when `opts.project`, print `presenter.Printf(cmd, "Scope: project (current repo)\n")` so the scope is explicit.
+- [ ] **Step 4 — batch.go:** change `recordApplyFn` to `func(env agentcfg.Env, arts agentinstall.Artifacts, agents []agentcfg.Agent, scope agentcfg.Scope, dryRun bool) []agentcfg.Outcome`; thread `scopeFromOpts()` through `buildTaggedOutcomes` and both `runBatch` apply calls; print the same scope line in `runBatch` when `opts.project`.
+- [ ] **Step 5 — list.go:** pass `scopeFromOpts()` to `agentcfg.ResolveSkillPath`, and for MCP use `agent.MCP.ProjectConfigPath` when `opts.project` (falling back to a "(no project location)" note when nil). Register `--project` on `ListCommand` too (add `addSelectionFlags`-style or a local bool) so `install list --project` shows project paths.
+- [ ] **Step 6 — tests:** `install_test.go` — assert `--project` sets `opts.project` and `scopeFromOpts()` returns `agentcfg.Project`; a `runInstallCmd`-level project test is covered by Task 4's engine tests.
+- [ ] **Step 7 — verify:** `cd cli && go build ./... && go test ./cmd/install/... ./internal/agentcfg/... ./internal/agentinstall/...`; then `task lint:go`.
+
+---
+
+## Task 6: Docs
+
+**Files:** Modify `docs/content/dir/dir-cli-reference.md`, `docs/content/dir/dir-features-scenarios.md`.
+
+- [ ] **Step 1:** In the CLI reference `## Agent Install` flag table, add a `--project` row: "Write into the current repo (project scope) instead of global config | `false`". Add a short paragraph + example (`dirctl install cisco.com/agent --project`).
+- [ ] **Step 2:** In the features guide Install section, add a sentence + example showing `--project` writing into the repo, noting agents without a project location are skipped.
+- [ ] **Step 3 — verify:** re-read the edited sections for accuracy.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Scope type + resolution (T1/T2) ✓; per-agent project paths (T3) ✓; orchestrator scope (T4) ✓; `--project` flag on all entry points + plan annotation + list (T5) ✓; skip-with-note via `ErrNoScopePath`→`ActionSkipped` (T1/T2) ✓; docs (T6) ✓; detection unchanged (untouched) ✓; project root = cwd (T3 resolvers use `env.Cwd`) ✓.
+- **Type consistency:** `Scope`/`Global`/`Project`, `ErrNoScopePath`, `mcpConfigPath`, `ProjectConfigPath`, `scopeFromOpts`, and the `scope Scope` parameter position (added before `dryRun` for engine funcs; after `agents` for `Install`/`Uninstall`) are used consistently across tasks.
+- **Note:** the module does not fully build until T5 updates all callers — expected for a signature-threading change; test per-package as each compiles, full build at T5.

--- a/docs/superpowers/specs/2026-07-21-dirctl-install-project-scope-design.md
+++ b/docs/superpowers/specs/2026-07-21-dirctl-install-project-scope-design.md
@@ -1,0 +1,182 @@
+# `dirctl install --project` — project-scope install — design
+
+**Status:** approved for planning
+**Date:** 2026-07-21
+**Author:** András Jáky
+**Issue:** agntcy/dir#1855
+
+## Summary
+
+`dirctl install` currently writes a record's artifacts (MCP server entry and/or
+Agent Skill) only into each detected agent's **global/user** configuration. Add a
+`--project` flag that instead writes them into the **current repository** (project
+scope), so a record can be wired into the agents for just one project. Default
+behavior is unchanged (global). The `uninstall` path is symmetric.
+
+## Motivation
+
+Global install is the right default for personal setup, but teams frequently want a
+record's MCP server / skill scoped to a single repo (checked in, shared with
+collaborators, isolated from other projects). Most supported agents already read a
+project-local config (`.cursor/mcp.json`, `.vscode/mcp.json`, `.mcp.json`,
+`.cursor/rules/`, repo `AGENTS.md`/`GEMINI.md`, …); `install` should be able to
+target those.
+
+## Goals
+
+- `dirctl install <record> --project` writes the record's artifacts into the
+  current repo instead of the user's global config.
+- `dirctl install uninstall <record> --project` (and top-level `dirctl uninstall
+  --project`) removes exactly those project-scope artifacts.
+- Works with everything `install` already supports: `--agents`, batch (search
+  filters), `--dry-run`, `--yes`.
+- Where an agent has no documented project-scope location for an artifact, that
+  artifact is skipped with a clear reason — never a hard error.
+
+## Non-goals
+
+- Changing global (default) behavior.
+- Git-root discovery / monorepo nesting logic — project root is the current
+  working directory.
+- Relaxing agent detection for project scope (see "Detection", below).
+- A per-agent scope mix in one run (scope is one choice per invocation).
+
+## Key decisions
+
+- **Flag:** a boolean `--project` (default off = global). Not an enum
+  `--scope=global|project` — there are exactly two states and a single toggle reads
+  cleanly here.
+- **Project root = current working directory** (`Env.Cwd`), matching the existing
+  project-path resolvers. No walk up to a git root.
+- **Detection is unchanged / orthogonal to scope.** `--project` changes only *where*
+  files are written. Agent selection still runs detection: a `--project` install
+  targets detected agents (or the specific `--agents` named, which are likewise only
+  acted on when detected). It never writes config for an agent the user doesn't have.
+- **Missing project location ⇒ skip-with-note**, per agent × artifact, surfaced in
+  the plan/summary. Consistent with multi-agent and batch runs where one target must
+  not abort the rest.
+
+## Architecture
+
+The placement engine lives in `cli/internal/agentcfg`; orchestration in
+`cli/internal/agentinstall`; the command in `cli/cmd/install`. The change threads a
+**scope** through all three.
+
+### Scope type (agentcfg)
+
+```go
+type Scope int
+const (
+    Global  Scope = iota // user/global config (default)
+    Project              // current repo (Env.Cwd)
+)
+```
+
+### Target descriptors
+
+- `MCPTarget` gains a project resolver:
+
+  ```go
+  type MCPTarget struct {
+      ConfigPath        func(env Env) (string, error) // global
+      ProjectConfigPath func(env Env) (string, error) // project (nil ⇒ no project support)
+      Format     codec.Format
+      ServersKey []string
+      EntryStyle EntryStyle
+  }
+  ```
+
+- `SkillTarget` already has `Path` (global) and `ProjectPath` (project). Today
+  `ProjectPath` is a dormant *fallback* (used only if `Path` returns
+  `ErrNoGlobalPath`, which no agent triggers anymore). Repurpose it as the explicit
+  project location and **remove the silent fallback**. A `nil` `ProjectPath` ⇒ no
+  project support for that agent's skill.
+
+### Resolution
+
+A single scope-aware resolver picks the location per artifact:
+
+- **Global:** MCP → `ConfigPath`; skill → `Path`. If a resolver reports
+  `ErrNoGlobalPath` (or is nil), skip-with-note.
+- **Project:** MCP → `ProjectConfigPath`; skill → `ProjectPath`. If nil, skip-with-note
+  ("no project-scope location for <agent> <artifact>").
+
+The MCP and skill engines (`InstallMCP`/`RemoveMCP`, `InstallSkill`/`RemoveSkill`)
+take the resolved path (or the scope) so the codec/managed-block/atomic-write logic
+is unchanged — only the destination differs. Identity (slug / server key) and
+idempotency semantics are unchanged.
+
+### Per-agent project coverage
+
+Skill project paths already exist for cursor, vscode, windsurf, cline, roo, gemini,
+opencode, zed, codex (the `*ProjectSkillPath` resolvers). Fill the gaps or skip:
+
+| Agent | Project MCP config | Project skill |
+|---|---|---|
+| Claude Code | `.mcp.json` (`mcpServers`) | `.claude/skills/<slug>/SKILL.md` |
+| Claude Desktop | — (not a repo tool) → skip | — → skip |
+| Cursor | `.cursor/mcp.json` (`mcpServers`) | `.cursor/rules/<slug>.mdc` *(exists)* |
+| VS Code (Copilot) | `.vscode/mcp.json` (`servers`) | `.github/instructions/<slug>.instructions.md` *(exists)* |
+| Windsurf | project MCP if documented, else skip | `.windsurf/rules/<slug>.md` *(exists)* |
+| Cline | — (MCP is global) → skip | `.clinerules/<slug>.md` *(exists)* |
+| Roo Code | `.roo/mcp.json` (`mcpServers`) | `.roo/rules/<slug>.md` *(exists)* |
+| Gemini CLI | `.gemini/settings.json` (`mcpServers`) | repo `GEMINI.md` managed block *(exists)* |
+| OpenCode | `opencode.json` (`mcp`) | repo `AGENTS.md` managed block *(exists)* |
+| Zed | `.zed/settings.json` (`context_servers`) | project rules *(exists)* |
+| Continue | `.continue/config.yaml` (`mcpServers`) if documented, else skip | `.continue/rules/<slug>.md` (add) |
+| Codex CLI | — (MCP is global) → skip | repo `AGENTS.md` managed block *(exists)* |
+
+The exact project location for each agent is verified against that agent's current
+documentation during implementation; any that cannot be confirmed is left unset and
+therefore skipped-with-note rather than guessed. The engine's skip-with-note path
+guarantees an unverified agent degrades gracefully.
+
+### Command surface (cli/cmd/install)
+
+- Add `--project` (bool, default false) to the shared install/uninstall flag set,
+  so it applies to `install run`, bare `install <record>`, `install uninstall`, and
+  top-level `uninstall`; it composes with `--agents`, batch filters, `--dry-run`,
+  `--yes`.
+- The command maps `--project` to `agentcfg.Project` (else `Global`) and passes it
+  into `agentinstall.Install`/`Uninstall` and the plan/summary rendering.
+
+### Plan / summary
+
+Each planned line shows the scope-appropriate path (project paths shown
+repo-relative or absolute under cwd). Artifacts with no location for the chosen
+scope render as skipped with the reason. The confirmation prompt and dry-run output
+make the scope explicit (e.g. a "(project)" annotation) so the user sees where files
+will land before confirming.
+
+## Testing
+
+- **Resolution:** scope=Global picks global paths; scope=Project picks project
+  paths; nil project resolver ⇒ skip-with-note (no write). Table test across agents.
+- **MCP engine:** project install writes to the repo-relative path for JSON/YAML/TOML
+  agents; sibling servers preserved; idempotent second run reports unchanged; uninstall
+  removes only our key. Run under a temp cwd.
+- **Skill engine:** project install for SkillFolder / DedicatedFile / ManagedBlock
+  writes under cwd; uninstall reverses; managed-block coexistence preserved.
+- **Command:** `--project` flips the scope; plan/summary annotate project scope;
+  detection still gates selection; `--project` composes with `--agents` and batch.
+- **Skip-with-note:** an agent with no project location for an artifact appears in the
+  summary as skipped with a reason and writes nothing.
+
+## Delivery phasing (for the implementation plan)
+
+1. `agentcfg`: add `Scope`, `MCPTarget.ProjectConfigPath`, scope-aware resolution;
+   remove the dormant skill fallback; unit tests.
+2. Per-agent project MCP paths + the missing project skill paths; registry wiring;
+   coverage tests.
+3. `agentinstall`: thread scope through `Install`/`Uninstall` and plan/summary.
+4. `cli/cmd/install`: `--project` flag on all entry points; scope annotation in
+   plan/summary; command tests.
+5. Docs: CLI reference (`## Agent Install`) + features guide gain a `--project`
+   note and examples.
+
+## Open questions / future work
+
+- Git-root discovery (write to the repo root even from a subdirectory).
+- Relaxing detection so a `--project` install can target an agent not installed on
+  the current machine (useful for "prepare this repo for teammates").
+- Per-agent scope in a single run.


### PR DESCRIPTION
## Summary

Adds a `--project` flag to `dirctl install` / `install uninstall` (and the top-level `dirctl uninstall`) that writes a record's artifacts into the **current repository** instead of the user's **global** config. Default behavior is unchanged (global).

Which artifacts get installed is still derived from the record's OASF modules; `--project` only changes *where* they land (e.g. `.cursor/mcp.json`, `.vscode/mcp.json`, `.mcp.json`, `.cursor/skills/…`).

## Changes

- **`agentcfg`:** new `Scope` (Global/Project) and `MCPTarget.ProjectConfigPath`; scope-aware skill + MCP path resolution. An agent with no location for the chosen scope is skipped with a note (`ErrNoScopePath` → `ActionSkipped`), replacing the old implicit global→project skill fallback.
- **Registry:** per-agent project MCP paths (Claude Code, Cursor, VS Code, Roo, Gemini, OpenCode, Zed) and project skill paths for Claude Code and Continue. Agents without a documented project location are skipped.
- **`agentinstall`:** scope threaded through `Install`/`Uninstall`.
- **Command:** `--project` on all install/uninstall entry points, a "Scope: project" banner in the plan/summary, and `install list --project`; `dirctl init` is pinned to global scope.
- **Docs:** `--project` documented in the CLI reference and features guide.

## Behavior notes

- Detection is unchanged/orthogonal: `--project` never writes for an agent the user doesn't have.
- Removed the dormant implicit skill fallback, so a *global* install for an agent with no global skill path now reports `skipped` rather than silently writing a project file.

## Testing

`go build`, `go vet`, `go test ./...` (cli module) all pass; `task lint:go` reports 0 issues. New unit tests cover project-scope skill/MCP install, no-project-path skip, orchestrator scope, and the `--project`→scope mapping. Manually smoke-tested `dirctl install list --project`.

Closes #1855
