### PR TITLE
fix(dir): add trusted, verified, safe filters

### DIFF
--- a/samples/ard-over-ads/go.mod
+++ b/samples/ard-over-ads/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
-	github.com/agntcy/dir-importer v1.5.1 // indirect
+	github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182 // indirect
 	github.com/agntcy/dir-mcp v1.3.3 // indirect
 	github.com/agntcy/dir-runtime/discovery v1.3.3 // indirect
 	github.com/agntcy/dir-runtime/server v1.3.3 // indirect

--- a/samples/ard-over-ads/go.sum
+++ b/samples/ard-over-ads/go.sum
@@ -200,6 +200,7 @@ github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KO
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/agntcy/dir-importer v1.5.1 h1:JkdGEHO6bn5C8igbO6J7/bEmNDqDlj1Qd51fuPV1fS4=
 github.com/agntcy/dir-importer v1.5.1/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
+github.com/agntcy/dir-importer v1.5.2-0.20260722103554-a0ac00e66182/go.mod h1:sLTEgb3TVQCiHwpE41tPEZC9D99Xft+qz1THdFpE4bI=
 github.com/agntcy/dir-mcp v1.3.3 h1:jXKMAIPbRJbtp+YuqNqM77l4cBCGUkZ/D/SkokZ1EZw=
 github.com/agntcy/dir-mcp v1.3.3/go.mod h1:bHI1khnD0ni8gl9l3xxfJJNFD8qHqN6wPHN2kC3hdjs=
 github.com/agntcy/dir-runtime/discovery v1.3.3 h1:iXmR2MZ41UEZWSspZL6tB5IO09nS82WCQVroDacCEnM=

--- a/server/controller/ai_finder_filter.go
+++ b/server/controller/ai_finder_filter.go
@@ -19,7 +19,7 @@ import (
 //
 //	filter = clause { WS+ "AND" WS+ clause } ;
 //	clause = field "=" value ;
-//	field  = "displayName" | "type" | "publisherId" | "createdAfter" | "updatedAfter" ;
+//	field  = "displayName" | "type" | "publisherId" | "createdAfter" | "updatedAfter" | "verified" | "trusted" | "safe" ;
 //	value  = token { "," token } ;
 //	token  = unquoted_token | quoted_string ;
 //
@@ -36,6 +36,9 @@ type agentFilter struct {
 	PublisherIDs []string
 	CreatedAfter time.Time
 	UpdatedAfter time.Time
+	Verified     *bool
+	Trusted      *bool
+	Safe         *bool
 }
 
 // oasfModuleForMediaType maps a media type onto the OASF module name the
@@ -172,6 +175,18 @@ func buildRecordFilterOptions(f agentFilter, order []orderByClause, pageSize, of
 
 	if !f.UpdatedAfter.IsZero() {
 		opts = append(opts, types.WithCreatedAts(">"+f.UpdatedAfter.UTC().Format(time.RFC3339)))
+	}
+
+	if f.Verified != nil {
+		opts = append(opts, types.WithVerified(*f.Verified))
+	}
+
+	if f.Trusted != nil {
+		opts = append(opts, types.WithTrusted(*f.Trusted))
+	}
+
+	if f.Safe != nil {
+		opts = append(opts, types.WithScanSafe(*f.Safe))
 	}
 
 	if len(order) > 0 {
@@ -404,8 +419,54 @@ func applyClause(out *agentFilter, field string, values []string) error {
 
 		return nil
 
+	case "verified":
+		verified, err := singleBool(field, values)
+		if err != nil {
+			return err
+		}
+
+		out.Verified = &verified
+
+		return nil
+
+	case "trusted":
+		trusted, err := singleBool(field, values)
+		if err != nil {
+			return err
+		}
+
+		out.Trusted = &trusted
+
+		return nil
+
+	case "safe":
+		safe, err := singleBool(field, values)
+		if err != nil {
+			return err
+		}
+
+		out.Safe = &safe
+
+		return nil
+
 	default:
-		return fmt.Errorf("unknown filter field %q (allowed: displayName, type, publisherId, createdAfter, updatedAfter)", field)
+		return fmt.Errorf("unknown filter field %q (allowed: displayName, type, publisherId, createdAfter, updatedAfter, verified, trusted, safe)", field)
+	}
+}
+
+// singleBool validates a single-value boolean clause (true/false, case-insensitive).
+func singleBool(field string, values []string) (bool, error) {
+	if len(values) != 1 {
+		return false, fmt.Errorf("filter field %q accepts a single value, got %d", field, len(values))
+	}
+
+	switch strings.ToLower(strings.TrimSpace(values[0])) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("filter field %q: invalid boolean %q (expected true or false)", field, values[0])
 	}
 }
 

--- a/server/controller/ai_finder_test.go
+++ b/server/controller/ai_finder_test.go
@@ -209,6 +209,34 @@ func TestParseAgentFilter(t *testing.T) {
 		assert.Equal(t, "hello, world", f.DisplayName)
 	})
 
+	t.Run("verified=true", func(t *testing.T) {
+		f, err := parseAgentFilter(`verified=true`)
+		require.NoError(t, err)
+		require.NotNil(t, f.Verified)
+		assert.True(t, *f.Verified)
+	})
+
+	t.Run("verified=false", func(t *testing.T) {
+		f, err := parseAgentFilter(`verified=FALSE`)
+		require.NoError(t, err)
+		require.NotNil(t, f.Verified)
+		assert.False(t, *f.Verified)
+	})
+
+	t.Run("trusted=true", func(t *testing.T) {
+		f, err := parseAgentFilter(`trusted=true`)
+		require.NoError(t, err)
+		require.NotNil(t, f.Trusted)
+		assert.True(t, *f.Trusted)
+	})
+
+	t.Run("safe=true", func(t *testing.T) {
+		f, err := parseAgentFilter(`safe=true`)
+		require.NoError(t, err)
+		require.NotNil(t, f.Safe)
+		assert.True(t, *f.Safe)
+	})
+
 	invalid := []struct {
 		name  string
 		input string
@@ -219,6 +247,10 @@ func TestParseAgentFilter(t *testing.T) {
 		{"empty value", "displayName="},
 		{"multi-value displayName", "displayName=a,b"},
 		{"bad timestamp", "createdAfter=not-a-date"},
+		{"bad verified value", "verified=maybe"},
+		{"multi-value verified", "verified=true,false"},
+		{"bad trusted value", "trusted=maybe"},
+		{"bad safe value", "safe=maybe"},
 		{"unterminated quote", `displayName="oops`},
 	}
 	for _, tc := range invalid {
@@ -227,6 +259,54 @@ func TestParseAgentFilter(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+func TestBuildRecordFilterOptionsVerified(t *testing.T) {
+	verified := true
+	f := agentFilter{Verified: &verified}
+
+	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	require.True(t, ok)
+
+	var filters types.RecordFilters
+	for _, opt := range opts {
+		opt(&filters)
+	}
+
+	require.NotNil(t, filters.Verified)
+	assert.True(t, *filters.Verified)
+}
+
+func TestBuildRecordFilterOptionsTrusted(t *testing.T) {
+	trusted := true
+	f := agentFilter{Trusted: &trusted}
+
+	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	require.True(t, ok)
+
+	var filters types.RecordFilters
+	for _, opt := range opts {
+		opt(&filters)
+	}
+
+	require.NotNil(t, filters.Trusted)
+	assert.True(t, *filters.Trusted)
+}
+
+func TestBuildRecordFilterOptionsSafe(t *testing.T) {
+	safe := true
+	f := agentFilter{Safe: &safe}
+
+	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	require.True(t, ok)
+
+	var filters types.RecordFilters
+	for _, opt := range opts {
+		opt(&filters)
+	}
+
+	require.NotNil(t, filters.ScanSafe)
+	assert.True(t, *filters.ScanSafe)
 }
 
 func TestParseOrderBy(t *testing.T) {


### PR DESCRIPTION
this PR adds the `trusted`, `verified` and `safe` filters to the ListAgents endpoint

<img width="520" height="647" alt="Screenshot 2026-07-27 at 12 51 04" src="https://github.com/user-attachments/assets/f6511ded-353d-4948-9ad8-31bdf9ece48f" />

this will be used later by the UI (a follow-up PR will add it)

---

NB: right now, the UI implements the `Trusted` / `Verified` filters in a simpler - and I believe, incorrect - way. it only checks if the catalog entry has a signature

the `trusted` and `verified` filters are going to properly check if the record signature is:
- verified = has signature + it's in verified status
- trusted = has name verification + it's in verified status