### PR TITLE
fix(dir): add tags filter to ListAgents endpoint

### DIFF
--- a/server/controller/ai_finder_filter.go
+++ b/server/controller/ai_finder_filter.go
@@ -19,7 +19,7 @@ import (
 //
 //	filter = clause { WS+ "AND" WS+ clause } ;
 //	clause = field "=" value ;
-//	field  = "displayName" | "type" | "publisherId" | "createdAfter" | "updatedAfter" | "verified" | "trusted" | "safe" ;
+//	field  = "displayName" | "type" | "publisherId" | "createdAfter" | "updatedAfter" | "verified" | "trusted" | "safe" | "tags" ;
 //	value  = token { "," token } ;
 //	token  = unquoted_token | quoted_string ;
 //
@@ -31,14 +31,18 @@ const filterMaxLen = 2048
 
 // agentFilter is the parsed representation of the ListAgents filter query.
 type agentFilter struct {
-	DisplayName  string
-	Types        []string
-	PublisherIDs []string
-	CreatedAfter time.Time
-	UpdatedAfter time.Time
-	Verified     *bool
-	Trusted      *bool
-	Safe         *bool
+	DisplayName    string
+	Types          []string
+	PublisherIDs   []string
+	CreatedAfter   time.Time
+	UpdatedAfter   time.Time
+	Verified       *bool
+	Trusted        *bool
+	Safe           *bool
+	SkillNames     []string
+	DomainNames    []string
+	Annotations    []types.Annotation
+	AnnotationKeys []string
 }
 
 // oasfModuleForMediaType maps a media type onto the OASF module name the
@@ -141,6 +145,8 @@ func parseAgentFilter(input string) (agentFilter, error) {
 // buildRecordFilterOptions translates a parsed filter, order, and paging into
 // FilterOptions for the catalog query layer. The bool is false when type= was
 // set but no requested media type maps to an indexed module (zero rows).
+//
+//nolint:cyclop
 func buildRecordFilterOptions(f agentFilter, order []orderByClause, pageSize, offset int) ([]types.FilterOption, bool) {
 	opts := []types.FilterOption{
 		types.WithLimit(pageSize),
@@ -187,6 +193,22 @@ func buildRecordFilterOptions(f agentFilter, order []orderByClause, pageSize, of
 
 	if f.Safe != nil {
 		opts = append(opts, types.WithScanSafe(*f.Safe))
+	}
+
+	if len(f.SkillNames) > 0 {
+		opts = append(opts, types.WithSkillNames(f.SkillNames...))
+	}
+
+	if len(f.DomainNames) > 0 {
+		opts = append(opts, types.WithDomainNames(f.DomainNames...))
+	}
+
+	if len(f.Annotations) > 0 {
+		opts = append(opts, types.WithAnnotations(f.Annotations...))
+	}
+
+	if len(f.AnnotationKeys) > 0 {
+		opts = append(opts, types.WithAnnotationKeys(f.AnnotationKeys...))
 	}
 
 	if len(order) > 0 {
@@ -449,8 +471,18 @@ func applyClause(out *agentFilter, field string, values []string) error {
 
 		return nil
 
+	case "tags":
+		skillNames, domainNames, annotations, annotationKeys := parseTags(values)
+
+		out.SkillNames = skillNames
+		out.DomainNames = domainNames
+		out.Annotations = annotations
+		out.AnnotationKeys = annotationKeys
+
+		return nil
+
 	default:
-		return fmt.Errorf("unknown filter field %q (allowed: displayName, type, publisherId, createdAfter, updatedAfter, verified, trusted, safe)", field)
+		return fmt.Errorf("unknown filter field %q (allowed: displayName, type, publisherId, createdAfter, updatedAfter, verified, trusted, safe, tags)", field)
 	}
 }
 
@@ -482,4 +514,64 @@ func singleTimestamp(field string, values []string) (time.Time, error) {
 	}
 
 	return ts.UTC(), nil
+}
+
+func parseTags(tags []string) ([]string, []string, []types.Annotation, []string) {
+	var (
+		skillNames     []string
+		domainNames    []string
+		annotations    []types.Annotation
+		annotationKeys []string
+	)
+
+	for _, tag := range tags {
+		switch {
+		case isSkillTag(tag):
+			skillNames = append(skillNames, parseSkillName(tag))
+		case isDomainTag(tag):
+			domainNames = append(domainNames, parseDomainName(tag))
+		case isAnnotationTag(tag):
+			annotations = append(annotations, parseAnnotation(tag))
+		default:
+			annotationKeys = append(annotationKeys, tag)
+		}
+	}
+
+	return skillNames, domainNames, annotations, annotationKeys
+}
+
+func isSkillTag(tag string) bool {
+	s := strings.Split(tag, ":")
+
+	return len(s) == 4 && s[0] == "oasf" && s[1] == "*" && s[2] == "skills" && s[3] != ""
+}
+
+func parseSkillName(tag string) string {
+	s := strings.Split(tag, ":")
+
+	return s[3]
+}
+
+func isDomainTag(tag string) bool {
+	s := strings.Split(tag, ":")
+
+	return len(s) == 4 && s[0] == "oasf" && s[1] == "*" && s[2] == "domains" && s[3] != ""
+}
+
+func parseDomainName(tag string) string {
+	s := strings.Split(tag, ":")
+
+	return s[3]
+}
+
+func isAnnotationTag(tag string) bool {
+	key, value, ok := strings.Cut(tag, "=")
+
+	return ok && key != "" && value != ""
+}
+
+func parseAnnotation(tag string) types.Annotation {
+	key, value, _ := strings.Cut(tag, "=")
+
+	return types.Annotation{Key: key, Value: value}
 }

--- a/server/controller/ai_finder_test.go
+++ b/server/controller/ai_finder_test.go
@@ -237,6 +237,54 @@ func TestParseAgentFilter(t *testing.T) {
 		assert.True(t, *f.Safe)
 	})
 
+	t.Run("tags skill tag", func(t *testing.T) {
+		f, err := parseAgentFilter(`tags=oasf:*:skills:natural_language_processing/*`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"natural_language_processing/*"}, f.SkillNames)
+		assert.Empty(t, f.DomainNames)
+	})
+
+	t.Run("tags comma-OR", func(t *testing.T) {
+		f, err := parseAgentFilter(`tags=oasf:*:skills:foo/*,oasf:*:skills:bar`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo/*", "bar"}, f.SkillNames)
+		assert.Empty(t, f.DomainNames)
+	})
+
+	t.Run("tags domain tag", func(t *testing.T) {
+		f, err := parseAgentFilter(`tags=oasf:*:domains:healthcare/*`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"healthcare/*"}, f.DomainNames)
+		assert.Empty(t, f.SkillNames)
+	})
+
+	t.Run("tags mixed skill and domain", func(t *testing.T) {
+		f, err := parseAgentFilter(`tags=oasf:*:skills:foo,oasf:*:domains:bar`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo"}, f.SkillNames)
+		assert.Equal(t, []string{"bar"}, f.DomainNames)
+	})
+
+	t.Run("tags annotation pair", func(t *testing.T) {
+		f, err := parseAgentFilter(`tags="owner=alice"`)
+		require.NoError(t, err)
+		assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, f.Annotations)
+	})
+
+	t.Run("tags annotation key only", func(t *testing.T) {
+		f, err := parseAgentFilter(`tags=owner`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"owner"}, f.AnnotationKeys)
+	})
+
+	t.Run("tags mixed catalog tag kinds", func(t *testing.T) {
+		f, err := parseAgentFilter(`tags=oasf:*:skills:foo,"owner=alice",env`)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo"}, f.SkillNames)
+		assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, f.Annotations)
+		assert.Equal(t, []string{"env"}, f.AnnotationKeys)
+	})
+
 	invalid := []struct {
 		name  string
 		input string
@@ -251,6 +299,7 @@ func TestParseAgentFilter(t *testing.T) {
 		{"multi-value verified", "verified=true,false"},
 		{"bad trusted value", "trusted=maybe"},
 		{"bad safe value", "safe=maybe"},
+		{"empty annotation key", "tags==alice"},
 		{"unterminated quote", `displayName="oops`},
 	}
 	for _, tc := range invalid {
@@ -307,6 +356,41 @@ func TestBuildRecordFilterOptionsSafe(t *testing.T) {
 
 	require.NotNil(t, filters.ScanSafe)
 	assert.True(t, *filters.ScanSafe)
+}
+
+func TestBuildRecordFilterOptionsTags(t *testing.T) {
+	f := agentFilter{
+		SkillNames:     []string{"natural_language_processing/*", "coding/*"},
+		DomainNames:    []string{"healthcare/*"},
+		Annotations:    []types.Annotation{{Key: "owner", Value: "alice"}},
+		AnnotationKeys: []string{"env"},
+	}
+
+	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	require.True(t, ok)
+
+	var filters types.RecordFilters
+	for _, opt := range opts {
+		opt(&filters)
+	}
+
+	assert.Equal(t, []string{"natural_language_processing/*", "coding/*"}, filters.SkillNames)
+	assert.Equal(t, []string{"healthcare/*"}, filters.DomainNames)
+	assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, filters.Annotations)
+	assert.Equal(t, []string{"env"}, filters.AnnotationKeys)
+}
+
+func TestParseTags(t *testing.T) {
+	skillNames, domainNames, annotations, annotationKeys := parseTags([]string{
+		"oasf:*:skills:retrieval_augmented_generation/*",
+		"oasf:*:domains:healthcare/*",
+		"owner=alice",
+		"env",
+	})
+	assert.Equal(t, []string{"retrieval_augmented_generation/*"}, skillNames)
+	assert.Equal(t, []string{"healthcare/*"}, domainNames)
+	assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, annotations)
+	assert.Equal(t, []string{"env"}, annotationKeys)
 }
 
 func TestParseOrderBy(t *testing.T) {


### PR DESCRIPTION
this PR adds the `tags` filter to the `ListAgents` endpoint

<img width="396" height="710" alt="Screenshot 2026-07-27 at 15 58 49" src="https://github.com/user-attachments/assets/a7d410b3-c429-4f71-929b-a2d80a5a3d48" />

this filter will be used by the UI in a follow-up PR
