### PR TITLE
fix(dir): add Annotations to RecordFilters

### DIFF
--- a/server/database/database_test.go
+++ b/server/database/database_test.go
@@ -337,3 +337,65 @@ func TestGetRecordCIDs_NilOption(t *testing.T) {
 	_, err := db.GetRecordCIDs(nilOpt)
 	assert.Error(t, err)
 }
+
+func TestGetRecordCIDs_Annotations(t *testing.T) {
+	db := setupTestDB(t)
+
+	ownerAlice := &testRecord{
+		cid:           "bafybeigdyrztannotowneralice000000000000000000000000000000000001",
+		name:          "directory.agntcy.org/test/owner-alice",
+		version:       "1.0.0",
+		schemaVersion: "0.8.0",
+		createdAt:     "2024-01-15T10:30:00Z",
+		annotations: map[string]string{
+			"owner": "alice",
+			"env":   "prod",
+		},
+	}
+	envAlice := &testRecord{
+		cid:           "bafybeigdyrztannotenvalice000000000000000000000000000000000002",
+		name:          "directory.agntcy.org/test/env-alice",
+		version:       "1.0.0",
+		schemaVersion: "0.8.0",
+		createdAt:     "2024-01-15T10:30:00Z",
+		annotations: map[string]string{
+			"owner": "bob",
+			"env":   "alice",
+		},
+	}
+
+	require.NoError(t, db.AddRecord(ownerAlice))
+	require.NoError(t, db.AddRecord(envAlice))
+
+	t.Run("annotations match key and value on same row", func(t *testing.T) {
+		cids, err := db.GetRecordCIDs(types.WithAnnotations(types.Annotation{Key: "owner", Value: "alice"}))
+		require.NoError(t, err)
+		assert.Equal(t, []string{ownerAlice.GetCid()}, cids)
+	})
+
+	t.Run("annotations use exact case-sensitive matching", func(t *testing.T) {
+		cids, err := db.GetRecordCIDs(types.WithAnnotations(types.Annotation{Key: "Owner", Value: "alice"}))
+		require.NoError(t, err)
+		assert.Empty(t, cids)
+	})
+
+	t.Run("separate key and value filters can cross-match rows", func(t *testing.T) {
+		cids, err := db.GetRecordCIDs(
+			types.WithAnnotationKeys("owner", "env"),
+			types.WithAnnotationValues("alice"),
+		)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{ownerAlice.GetCid(), envAlice.GetCid()}, cids)
+	})
+
+	t.Run("multiple annotations are OR-combined", func(t *testing.T) {
+		cids, err := db.GetRecordCIDs(
+			types.WithAnnotations(
+				types.Annotation{Key: "owner", Value: "alice"},
+				types.Annotation{Key: "env", Value: "alice"},
+			),
+		)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{ownerAlice.GetCid(), envAlice.GetCid()}, cids)
+	})
+}

--- a/server/database/gorm/record.go
+++ b/server/database/gorm/record.go
@@ -503,6 +503,13 @@ func (d *DB) handleFilterOptions(query *gorm.DB, cfg *types.RecordFilters) *gorm
 		}
 	}
 
+	if len(cfg.Annotations) > 0 {
+		condition, args := utils.BuildAnnotationExistsCondition(cfg.Annotations)
+		if condition != "" {
+			query = query.Where(condition, args...)
+		}
+	}
+
 	// Handle created_at filter with comparison operator support.
 	if len(cfg.CreatedAts) > 0 {
 		condition, args := utils.BuildComparisonConditions("records.oasf_created_at", cfg.CreatedAts)

--- a/server/database/utils/wildcard.go
+++ b/server/database/utils/wildcard.go
@@ -5,6 +5,8 @@ package utils
 
 import (
 	"strings"
+
+	"github.com/agntcy/dir/server/types"
 )
 
 // ContainsWildcards checks if a pattern contains wildcard characters (* or ?).
@@ -69,4 +71,27 @@ func convertGlobToLike(pattern string) string {
 	result = strings.ReplaceAll(result, "?", "_")
 
 	return result
+}
+
+// BuildAnnotationExistsCondition builds an EXISTS subquery that matches
+// annotations by key/value. Multiple annotations are OR-combined.
+func BuildAnnotationExistsCondition(annotations []types.Annotation) (string, []any) {
+	if len(annotations) == 0 {
+		return "", nil
+	}
+
+	conditions := make([]string, 0, len(annotations))
+	args := make([]any, 0, len(annotations)*2) //nolint:mnd
+
+	for _, annotation := range annotations {
+		conditions = append(conditions, "(a.key = ? AND a.value = ?)")
+		args = append(args, annotation.Key, annotation.Value)
+	}
+
+	condition := strings.Join(conditions, " OR ")
+	if len(conditions) > 1 {
+		condition = "(" + condition + ")"
+	}
+
+	return "EXISTS (SELECT 1 FROM annotations a WHERE a.record_cid = records.record_cid AND " + condition + ")", args
 }

--- a/server/types/search.go
+++ b/server/types/search.go
@@ -26,9 +26,15 @@ type RecordFilters struct {
 	ScanSeverities   []string // Filter by max scan severity >= threshold (e.g. "HIGH")
 	AnnotationKeys   []string
 	AnnotationValues []string
+	Annotations      []Annotation
 	Descriptions     []string // Match against record description field.
 
 	OrderBy []RecordOrderClause // Order by directives applied in sequence.
+}
+
+type Annotation struct {
+	Key   string
+	Value string
 }
 
 // RecordOrderClause is a single ORDER BY directive.
@@ -197,6 +203,12 @@ func WithAnnotationKeys(keys ...string) FilterOption {
 func WithAnnotationValues(values ...string) FilterOption {
 	return func(sc *RecordFilters) {
 		sc.AnnotationValues = append(sc.AnnotationValues, values...)
+	}
+}
+
+func WithAnnotations(annotations ...Annotation) FilterOption {
+	return func(sc *RecordFilters) {
+		sc.Annotations = append(sc.Annotations, annotations...)
 	}
 }
 


### PR DESCRIPTION
right now, `RecordFilters` supports `AnnotationKeys` and `AnnotationValues` filters ... **BUT** these are not good for **exact** matches

this PR adds the `Annotations` filter which can match exact annotations (by both key **AND** value)

---

why do we need this?

since annotations are included as tags in the AI Catalog UI, we need the ability to filter for them. so we will use this code in a follow-up PR