### PR TITLE
fix(dir): apply catalog module filter to SQL

### DIFF
--- a/api/catalog/v1/catalog.go
+++ b/api/catalog/v1/catalog.go
@@ -52,6 +52,17 @@ type catalogModuleProjection struct {
 	Label     string
 }
 
+func KnownCatalogModuleNames() []string {
+	names := make([]string, 0, len(catalogModules))
+	for name := range catalogModules {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
 // catalogModules maps OASF integration module names onto their AI Catalog
 // projection rules. A record is projectable only if it carries at least
 // one of these modules.

--- a/api/catalog/v1/catalog_test.go
+++ b/api/catalog/v1/catalog_test.go
@@ -285,6 +285,16 @@ func TestAnnotationLabel(t *testing.T) {
 	assert.Equal(t, "owner=alice", AnnotationLabel("owner", "alice"))
 }
 
+func TestKnownCatalogModuleNames(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{
+		AgentSkillsModuleName,
+		"integration/a2a",
+		"integration/mcp",
+	}, KnownCatalogModuleNames())
+}
+
 func TestDeriveTrustStatus(t *testing.T) {
 	t.Parallel()
 

--- a/server/database/catalog_test.go
+++ b/server/database/catalog_test.go
@@ -164,7 +164,7 @@ func TestCountCatalogEntries(t *testing.T) {
 
 	count, err := db.CountCatalogEntries()
 	require.NoError(t, err)
-	assert.Equal(t, uint32(4), count)
+	assert.Equal(t, uint32(3), count)
 
 	count, err = db.CountCatalogEntries(types.WithModuleNames(translator.A2AModuleName))
 	require.NoError(t, err)

--- a/server/database/gorm/catalog.go
+++ b/server/database/gorm/catalog.go
@@ -54,6 +54,7 @@ func (d *DB) CountCatalogEntries(opts ...types.FilterOption) (uint32, error) {
 
 	query := d.gormDB.Model(&Record{})
 	query = d.handleFilterOptions(query, cfg)
+	query = applyKnownCatalogModuleFilter(query)
 	query = query.Distinct("records.record_cid")
 
 	var count int64
@@ -165,6 +166,7 @@ func (d *DB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.Catalog
 	}
 
 	query = d.handleFilterOptions(query, cfg)
+	query = applyKnownCatalogModuleFilter(query)
 
 	query, err = applyCatalogOrder(query, cfg)
 	if err != nil {
@@ -208,6 +210,21 @@ func (d *DB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.Catalog
 	}
 
 	return entries, hasMore, nil
+}
+
+func applyKnownCatalogModuleFilter(query *gorm.DB) *gorm.DB {
+	const emptyJSONObject = "{}"
+
+	moduleNames := catalogv1.KnownCatalogModuleNames()
+
+	return query.Where(`
+EXISTS (
+	SELECT 1 FROM modules catalog_modules
+	WHERE catalog_modules.record_cid = records.record_cid
+	AND catalog_modules.name IN ?
+	AND catalog_modules.data IS NOT NULL
+	AND catalog_modules.data != ?
+)`, moduleNames, emptyJSONObject)
 }
 
 func convertScanReports(reports []ScanReport) []catalogv1.ScanReportSummary {


### PR DESCRIPTION
right now, the records without a known catalog module (MCP, A2A, Skill) are being filtered out **AFTER** we have fetched them from the database

this is not great

we should include the module filter in the query itself

this is needed for counts to work consistently
