### PR TITLE
fix(dir): fix type filter handling for skills

### DIFF
--- a/api/catalog/v1/catalog.go
+++ b/api/catalog/v1/catalog.go
@@ -295,24 +295,10 @@ func moduleToCatalogEntry(module coretypes.Module) *CatalogEntry {
 
 func getModuleMediaType(module coretypes.Module, proj catalogModuleProjection) string {
 	if module.GetName() == AgentSkillsModuleName {
-		return getAgentSkillsMediaType(module)
+		return module.GetArtifactMediaType()
 	}
 
 	return proj.MediaType
-}
-
-func getAgentSkillsMediaType(module coretypes.Module) string {
-	if hasArtifacts(module.GetData()) {
-		return ProtocolAgentSkillsBundleMediaType
-	}
-
-	return ProtocolAgentSkillsMdMediaType
-}
-
-func hasArtifacts(data map[string]any) bool {
-	artifacts, ok := data["artifacts"].([]any)
-
-	return ok && len(artifacts) > 0
 }
 
 // knownCatalogModules returns the record's modules that have a catalog

--- a/api/catalog/v1/catalog_test.go
+++ b/api/catalog/v1/catalog_test.go
@@ -205,6 +205,9 @@ func TestRecordToCatalog_AgentSkillsMediaTypes(t *testing.T) {
 			module: &oasftypesv1.Module{
 				Name: AgentSkillsModuleName,
 				Id:   10302,
+				Artifact: &oasftypesv1.Descriptor{
+					MediaType: ProtocolAgentSkillsMdMediaType,
+				},
 				Data: toStruct(t, map[string]any{
 					"skill_file": "SKILL.md",
 					"skill_manifest": map[string]any{
@@ -221,18 +224,15 @@ func TestRecordToCatalog_AgentSkillsMediaTypes(t *testing.T) {
 			module: &oasftypesv1.Module{
 				Name: AgentSkillsModuleName,
 				Id:   10302,
+				Artifact: &oasftypesv1.Descriptor{
+					MediaType: ProtocolAgentSkillsBundleMediaType,
+				},
 				Data: toStruct(t, map[string]any{
 					"skill_file": "SKILL.md",
 					"skill_manifest": map[string]any{
 						"name":        "summarize-text",
 						"description": "Summarize documents.",
 						"version":     "1.0.0",
-					},
-					"artifacts": []any{
-						map[string]any{
-							"path": "references/style-guide.md",
-							"type": "file",
-						},
 					},
 				}),
 			},

--- a/reconciler/tasks/signature/task_test.go
+++ b/reconciler/tasks/signature/task_test.go
@@ -204,11 +204,11 @@ func (f *fakeSignatureDB) GetRecords(opts ...types.FilterOption) ([]coretypes.Re
 	return nil, nil
 }
 
-func (f *fakeSignatureDB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.CatalogEntry, bool, error) {
+func (f *fakeSignatureDB) GetCatalogEntries(opts ...types.CatalogQueryOption) ([]*catalogv1.CatalogEntry, bool, error) {
 	return nil, false, nil
 }
 
-func (f *fakeSignatureDB) CountCatalogEntries(opts ...types.FilterOption) (uint32, error) {
+func (f *fakeSignatureDB) CountCatalogEntries(opts ...types.CatalogQueryOption) (uint32, error) {
 	return 0, nil
 }
 

--- a/server/controller/ai_finder.go
+++ b/server/controller/ai_finder.go
@@ -91,7 +91,7 @@ func (c *aiFinderController) ListAgents(ctx context.Context, req *catalogv1.List
 
 	pageSize := int(clampPageSize(req.GetPageSize()))
 
-	opts, ok := buildRecordFilterOptions(parsedFilter, order, pageSize, offset)
+	opts, ok := buildCatalogFilterOptions(parsedFilter, order, pageSize, offset)
 	if !ok {
 		// type= matched no indexed module: zero rows, not an error.
 		return &catalogv1.ListAgentsResponse{}, nil
@@ -109,10 +109,6 @@ func (c *aiFinderController) ListAgents(ctx context.Context, req *catalogv1.List
 		aiFinderLogger.Error("failed to list catalog entries", "error", err)
 
 		return nil, status.Error(codes.Internal, "failed to list catalog entries") //nolint:wrapcheck
-	}
-
-	if len(parsedFilter.Types) > 0 {
-		entries = filterCatalogEntriesByMediaType(entries, parsedFilter.Types)
 	}
 
 	var nextPageToken string
@@ -210,7 +206,10 @@ func (c *aiFinderController) GetAgent(ctx context.Context, req *catalogv1.GetAge
 		return nil, status.Errorf(codes.Canceled, "%v", err)
 	}
 
-	entries, _, err := c.db.GetCatalogEntries(types.WithCIDs(cid), types.WithLimit(1))
+	entries, _, err := c.db.GetCatalogEntries(
+		types.WithCIDs(cid),
+		types.WithLimit(1),
+	)
 	if err != nil {
 		aiFinderLogger.Error("failed to load catalog entry", "cid", cid, "error", err)
 

--- a/server/controller/ai_finder_filter.go
+++ b/server/controller/ai_finder_filter.go
@@ -45,44 +45,46 @@ type agentFilter struct {
 	AnnotationKeys []string
 }
 
-// oasfModuleForMediaType maps a media type onto the OASF module name the
-// registry indexes, or ("", false) for unknown types.
-func oasfModuleForMediaType(mediaType string) (string, bool) {
+func mediaTypeFilterForType(mediaType string) *types.MediaTypeFilter {
 	switch strings.ToLower(strings.TrimSpace(mediaType)) {
 	case catalogv1.ProtocolA2ACardJsonMediaType:
-		return translator.A2AModuleName, true
+		return &types.MediaTypeFilter{ModuleName: translator.A2AModuleName}
 	case catalogv1.ProtocolMCPCardJsonMediaType:
-		return translator.MCPModuleName, true
+		return &types.MediaTypeFilter{ModuleName: translator.MCPModuleName}
 	case catalogv1.ProtocolAgentSkillsMdMediaType:
-		return translator.AgentSkillsModuleName, true
+		return &types.MediaTypeFilter{
+			ModuleName:        translator.AgentSkillsModuleName,
+			ArtifactMediaType: catalogv1.ProtocolAgentSkillsMdMediaType,
+		}
 	case catalogv1.ProtocolAgentSkillsBundleMediaType:
-		return translator.AgentSkillsModuleName, true
+		return &types.MediaTypeFilter{
+			ModuleName:        translator.AgentSkillsModuleName,
+			ArtifactMediaType: catalogv1.ProtocolAgentSkillsBundleMediaType,
+		}
 	default:
-		return "", false
+		return nil
 	}
 }
 
-// filterCatalogEntriesByMediaType keeps entries whose media_type matches one of
-// the requested AI Catalog types. Required for Agent Skills because markdown
-// and bundle records share the same OASF module name in the DB index.
-func filterCatalogEntriesByMediaType(entries []*catalogv1.CatalogEntry, mediaTypes []string) []*catalogv1.CatalogEntry {
-	if len(mediaTypes) == 0 || len(entries) == 0 {
-		return entries
+// buildTypeFilterOptions maps parsed type= values to catalog media type filters.
+// Returns (nil, false) when type= was set but no value maps to a known type.
+func buildTypeFilterOptions(mediaTypes []string) ([]types.MediaTypeFilter, bool) {
+	if len(mediaTypes) == 0 {
+		return nil, true
 	}
 
-	allowed := make(map[string]struct{}, len(mediaTypes))
+	filters := make([]types.MediaTypeFilter, 0, len(mediaTypes))
 	for _, mediaType := range mediaTypes {
-		allowed[strings.ToLower(strings.TrimSpace(mediaType))] = struct{}{}
-	}
-
-	out := make([]*catalogv1.CatalogEntry, 0, len(entries))
-	for _, entry := range entries {
-		if _, ok := allowed[strings.ToLower(entry.GetMediaType())]; ok {
-			out = append(out, entry)
+		if filter := mediaTypeFilterForType(mediaType); filter != nil {
+			filters = append(filters, *filter)
 		}
 	}
 
-	return out
+	if len(filters) == 0 {
+		return nil, false
+	}
+
+	return filters, true
 }
 
 // (parentheses, OR keywords, unknown or duplicate fields, missing values) is
@@ -142,13 +144,13 @@ func parseAgentFilter(input string) (agentFilter, error) {
 	return out, nil
 }
 
-// buildRecordFilterOptions translates a parsed filter, order, and paging into
-// FilterOptions for the catalog query layer. The bool is false when type= was
-// set but no requested media type maps to an indexed module (zero rows).
+// buildCatalogFilterOptions translates a parsed filter, order, and paging into
+// catalog filter options. The bool is false when type= was set but no requested
+// media type maps to an indexed module (zero rows).
 //
 //nolint:cyclop
-func buildRecordFilterOptions(f agentFilter, order []orderByClause, pageSize, offset int) ([]types.FilterOption, bool) {
-	opts := []types.FilterOption{
+func buildCatalogFilterOptions(f agentFilter, order []orderByClause, pageSize, offset int) ([]types.CatalogQueryOption, bool) {
+	opts := []types.CatalogQueryOption{
 		types.WithLimit(pageSize),
 		types.WithOffset(offset),
 	}
@@ -158,19 +160,12 @@ func buildRecordFilterOptions(f agentFilter, order []orderByClause, pageSize, of
 	}
 
 	if len(f.Types) > 0 {
-		var modules []string
-
-		for _, mt := range f.Types {
-			if module, ok := oasfModuleForMediaType(mt); ok {
-				modules = append(modules, module)
-			}
-		}
-
-		if len(modules) == 0 {
+		typeFilters, ok := buildTypeFilterOptions(f.Types)
+		if !ok {
 			return nil, false
 		}
 
-		opts = append(opts, types.WithModuleNames(modules...))
+		opts = append(opts, types.WithMediaTypeFilters(typeFilters...))
 	}
 
 	// createdAfter / updatedAfter both resolve to a strict '>' comparison on

--- a/server/controller/ai_finder_test.go
+++ b/server/controller/ai_finder_test.go
@@ -13,6 +13,7 @@ import (
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/dir/server/config"
 	"github.com/agntcy/dir/server/types"
+	"github.com/agntcy/oasf-sdk/pkg/translator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -30,33 +31,39 @@ type fakeCatalogDB struct {
 	tags       []*catalogv1.CatalogTag
 	err        error
 	calls      int
-	gotFilters types.RecordFilters
+	gotFilters types.CatalogFilters
 }
 
-func (f *fakeCatalogDB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.CatalogEntry, bool, error) {
-	f.calls++
+func (f *fakeCatalogDB) captureFilters(opts ...types.CatalogQueryOption) {
+	cfg := types.CatalogFilters{}
 
-	cfg := types.RecordFilters{}
-	for _, o := range opts {
-		o(&cfg)
+	for _, opt := range opts {
+		if opt != nil {
+			opt.ApplyCatalog(&cfg)
+		}
 	}
 
 	f.gotFilters = cfg
+}
+
+func (f *fakeCatalogDB) GetCatalogEntries(opts ...types.CatalogQueryOption) ([]*catalogv1.CatalogEntry, bool, error) {
+	f.calls++
+	f.captureFilters(opts...)
 
 	if f.err != nil {
 		return nil, false, f.err
 	}
 
 	entries := f.entries
-	if cfg.Offset > 0 {
-		if cfg.Offset >= len(entries) {
+	if f.gotFilters.Offset > 0 {
+		if f.gotFilters.Offset >= len(entries) {
 			return nil, false, nil
 		}
 
-		entries = entries[cfg.Offset:]
+		entries = entries[f.gotFilters.Offset:]
 	}
 
-	limit := cfg.Limit
+	limit := f.gotFilters.Limit
 	if limit <= 0 {
 		limit = 20
 	}
@@ -69,7 +76,9 @@ func (f *fakeCatalogDB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalo
 	return entries, hasMore, nil
 }
 
-func (f *fakeCatalogDB) CountCatalogEntries(opts ...types.FilterOption) (uint32, error) {
+func (f *fakeCatalogDB) CountCatalogEntries(opts ...types.CatalogQueryOption) (uint32, error) {
+	f.captureFilters(opts...)
+
 	if f.err != nil {
 		return 0, f.err
 	}
@@ -143,7 +152,9 @@ func TestListAgents_FilterTranslation(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"*weather*"}, db.gotFilters.Names)
-	assert.Equal(t, []string{"integration/a2a"}, db.gotFilters.ModuleNames)
+	require.Len(t, db.gotFilters.MediaTypeFilters, 1)
+	assert.Equal(t, "integration/a2a", db.gotFilters.MediaTypeFilters[0].ModuleName)
+	assert.Empty(t, db.gotFilters.MediaTypeFilters[0].ArtifactMediaType)
 	assert.Equal(t, []string{">2024-01-01T00:00:00Z"}, db.gotFilters.CreatedAts)
 }
 
@@ -310,55 +321,55 @@ func TestParseAgentFilter(t *testing.T) {
 	}
 }
 
-func TestBuildRecordFilterOptionsVerified(t *testing.T) {
+func TestBuildCatalogFilterOptionsVerified(t *testing.T) {
 	verified := true
 	f := agentFilter{Verified: &verified}
 
-	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	opts, ok := buildCatalogFilterOptions(f, nil, 20, 0)
 	require.True(t, ok)
 
-	var filters types.RecordFilters
+	cfg := types.CatalogFilters{}
 	for _, opt := range opts {
-		opt(&filters)
+		opt.ApplyCatalog(&cfg)
 	}
 
-	require.NotNil(t, filters.Verified)
-	assert.True(t, *filters.Verified)
+	require.NotNil(t, cfg.Verified)
+	assert.True(t, *cfg.Verified)
 }
 
-func TestBuildRecordFilterOptionsTrusted(t *testing.T) {
+func TestBuildCatalogFilterOptionsTrusted(t *testing.T) {
 	trusted := true
 	f := agentFilter{Trusted: &trusted}
 
-	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	opts, ok := buildCatalogFilterOptions(f, nil, 20, 0)
 	require.True(t, ok)
 
-	var filters types.RecordFilters
+	cfg := types.CatalogFilters{}
 	for _, opt := range opts {
-		opt(&filters)
+		opt.ApplyCatalog(&cfg)
 	}
 
-	require.NotNil(t, filters.Trusted)
-	assert.True(t, *filters.Trusted)
+	require.NotNil(t, cfg.Trusted)
+	assert.True(t, *cfg.Trusted)
 }
 
-func TestBuildRecordFilterOptionsSafe(t *testing.T) {
+func TestBuildCatalogFilterOptionsSafe(t *testing.T) {
 	safe := true
 	f := agentFilter{Safe: &safe}
 
-	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	opts, ok := buildCatalogFilterOptions(f, nil, 20, 0)
 	require.True(t, ok)
 
-	var filters types.RecordFilters
+	cfg := types.CatalogFilters{}
 	for _, opt := range opts {
-		opt(&filters)
+		opt.ApplyCatalog(&cfg)
 	}
 
-	require.NotNil(t, filters.ScanSafe)
-	assert.True(t, *filters.ScanSafe)
+	require.NotNil(t, cfg.ScanSafe)
+	assert.True(t, *cfg.ScanSafe)
 }
 
-func TestBuildRecordFilterOptionsTags(t *testing.T) {
+func TestBuildCatalogFilterOptionsTags(t *testing.T) {
 	f := agentFilter{
 		SkillNames:     []string{"natural_language_processing/*", "coding/*"},
 		DomainNames:    []string{"healthcare/*"},
@@ -366,18 +377,18 @@ func TestBuildRecordFilterOptionsTags(t *testing.T) {
 		AnnotationKeys: []string{"env"},
 	}
 
-	opts, ok := buildRecordFilterOptions(f, nil, 20, 0)
+	opts, ok := buildCatalogFilterOptions(f, nil, 20, 0)
 	require.True(t, ok)
 
-	var filters types.RecordFilters
+	cfg := types.CatalogFilters{}
 	for _, opt := range opts {
-		opt(&filters)
+		opt.ApplyCatalog(&cfg)
 	}
 
-	assert.Equal(t, []string{"natural_language_processing/*", "coding/*"}, filters.SkillNames)
-	assert.Equal(t, []string{"healthcare/*"}, filters.DomainNames)
-	assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, filters.Annotations)
-	assert.Equal(t, []string{"env"}, filters.AnnotationKeys)
+	assert.Equal(t, []string{"natural_language_processing/*", "coding/*"}, cfg.SkillNames)
+	assert.Equal(t, []string{"healthcare/*"}, cfg.DomainNames)
+	assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, cfg.Annotations)
+	assert.Equal(t, []string{"env"}, cfg.AnnotationKeys)
 }
 
 func TestParseTags(t *testing.T) {
@@ -598,24 +609,26 @@ func TestExportAgent_NilData(t *testing.T) {
 	assert.Equal(t, codes.Internal, status.Code(err))
 }
 
-func TestOASFModuleForMediaType_AgentSkillBundle(t *testing.T) {
-	module, ok := oasfModuleForMediaType(catalogv1.ProtocolAgentSkillsBundleMediaType)
-	assert.True(t, ok)
-	assert.Equal(t, "core/language_model/agentskills", module)
-}
-
-func TestFilterCatalogEntriesByMediaType(t *testing.T) {
-	entries := []*catalogv1.CatalogEntry{
-		{MediaType: catalogv1.ProtocolAgentSkillsMdMediaType},
-		{MediaType: catalogv1.ProtocolAgentSkillsBundleMediaType},
-		{MediaType: catalogv1.ProtocolMCPCardJsonMediaType},
-	}
-
-	got := filterCatalogEntriesByMediaType(entries, []string{
-		catalogv1.ProtocolAgentSkillsBundleMediaType,
+func TestBuildTypeFilterOptions(t *testing.T) {
+	t.Run("agent skills markdown", func(t *testing.T) {
+		filters, ok := buildTypeFilterOptions([]string{catalogv1.ProtocolAgentSkillsMdMediaType})
+		require.True(t, ok)
+		require.Len(t, filters, 1)
+		assert.Equal(t, translator.AgentSkillsModuleName, filters[0].ModuleName)
+		assert.Equal(t, catalogv1.ProtocolAgentSkillsMdMediaType, filters[0].ArtifactMediaType)
 	})
-	require.Len(t, got, 1)
-	assert.Equal(t, catalogv1.ProtocolAgentSkillsBundleMediaType, got[0].GetMediaType())
+
+	t.Run("agent skills bundle", func(t *testing.T) {
+		filters, ok := buildTypeFilterOptions([]string{catalogv1.ProtocolAgentSkillsBundleMediaType})
+		require.True(t, ok)
+		require.Len(t, filters, 1)
+		assert.Equal(t, catalogv1.ProtocolAgentSkillsBundleMediaType, filters[0].ArtifactMediaType)
+	})
+
+	t.Run("unknown type", func(t *testing.T) {
+		_, ok := buildTypeFilterOptions([]string{"application/unknown"})
+		assert.False(t, ok)
+	})
 }
 
 func TestListTags_ReturnsSortedTags(t *testing.T) {

--- a/server/database/catalog_test.go
+++ b/server/database/catalog_test.go
@@ -21,9 +21,10 @@ var _ coretypes.Module = (*catalogModuleFixture)(nil)
 // catalogModuleFixture is a coretypes.Module carrying structured data, which the
 // shared testModule fixture does not.
 type catalogModuleFixture struct {
-	id   uint64
-	name string
-	data map[string]any
+	id                uint64
+	name              string
+	data              map[string]any
+	artifactMediaType string
 }
 
 // GetAnnotations implements [types.Module].
@@ -31,7 +32,7 @@ func (m *catalogModuleFixture) GetAnnotations() map[string]string { return nil }
 func (m *catalogModuleFixture) GetID() uint64                     { return m.id }
 func (m *catalogModuleFixture) GetName() string                   { return m.name }
 func (m *catalogModuleFixture) GetData() map[string]any           { return m.data }
-func (m *catalogModuleFixture) GetArtifactMediaType() string      { return "" }
+func (m *catalogModuleFixture) GetArtifactMediaType() string      { return m.artifactMediaType }
 
 func catalogRecord(cid, name, createdAt string, modules []coretypes.Module) coretypes.Record {
 	return &testRecord{
@@ -62,6 +63,30 @@ var (
 
 	unprojectableRecord = catalogRecord("cid-none", "delta", "2024-04-01T00:00:00Z", []coretypes.Module{
 		&catalogModuleFixture{id: 9, name: "integration/acp"},
+	})
+
+	agentSkillsMdRecord = catalogRecord("cid-skill-md", "skill-md", "2024-05-01T00:00:00Z", []coretypes.Module{
+		&catalogModuleFixture{
+			id:                10302,
+			name:              catalogv1.AgentSkillsModuleName,
+			artifactMediaType: catalogv1.ProtocolAgentSkillsMdMediaType,
+			data: map[string]any{
+				"skill_file":     "SKILL.md",
+				"skill_manifest": map[string]any{"name": "md-skill", "version": "1.0.0"},
+			},
+		},
+	})
+
+	agentSkillsBundleRecord = catalogRecord("cid-skill-gz", "skill-gz", "2024-05-02T00:00:00Z", []coretypes.Module{
+		&catalogModuleFixture{
+			id:                10302,
+			name:              catalogv1.AgentSkillsModuleName,
+			artifactMediaType: catalogv1.ProtocolAgentSkillsBundleMediaType,
+			data: map[string]any{
+				"skill_file":     "SKILL.md",
+				"skill_manifest": map[string]any{"name": "bundle-skill", "version": "1.0.0"},
+			},
+		},
 	})
 )
 
@@ -148,13 +173,32 @@ func TestGetCatalogEntries_UnsupportedSortColumn(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestGetCatalogEntries_NilOption(t *testing.T) {
+func TestCountCatalogEntries_AgentSkillsMediaType(t *testing.T) {
 	db := setupTestDB(t)
+	for _, r := range []coretypes.Record{agentSkillsMdRecord, agentSkillsBundleRecord} {
+		require.NoError(t, db.AddRecord(r))
+	}
 
-	var nilOpt types.FilterOption
+	count, err := db.CountCatalogEntries(types.WithMediaTypeFilters(types.MediaTypeFilter{
+		ModuleName:        catalogv1.AgentSkillsModuleName,
+		ArtifactMediaType: catalogv1.ProtocolAgentSkillsMdMediaType,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), count)
 
-	_, _, err := db.GetCatalogEntries(nilOpt)
-	require.Error(t, err)
+	count, err = db.CountCatalogEntries(types.WithMediaTypeFilters(types.MediaTypeFilter{
+		ModuleName:        catalogv1.AgentSkillsModuleName,
+		ArtifactMediaType: catalogv1.ProtocolAgentSkillsBundleMediaType,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), count)
+
+	count, err = db.CountCatalogEntries(types.WithMediaTypeFilters(
+		types.MediaTypeFilter{ModuleName: catalogv1.AgentSkillsModuleName, ArtifactMediaType: catalogv1.ProtocolAgentSkillsMdMediaType},
+		types.MediaTypeFilter{ModuleName: catalogv1.AgentSkillsModuleName, ArtifactMediaType: catalogv1.ProtocolAgentSkillsBundleMediaType},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), count)
 }
 
 func TestCountCatalogEntries(t *testing.T) {
@@ -174,15 +218,6 @@ func TestCountCatalogEntries(t *testing.T) {
 	count, err = db.CountCatalogEntries(types.WithNames("*alpha*"))
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1), count)
-}
-
-func TestCountCatalogEntries_NilOption(t *testing.T) {
-	db := setupTestDB(t)
-
-	var nilOpt types.FilterOption
-
-	_, err := db.CountCatalogEntries(nilOpt)
-	require.Error(t, err)
 }
 
 func TestListCatalogTags(t *testing.T) {

--- a/server/database/gorm/catalog.go
+++ b/server/database/gorm/catalog.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 
 	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
 	"github.com/agntcy/dir/server/types"
@@ -15,6 +16,8 @@ import (
 
 // defaultCatalogPageSize is applied when the caller does not set a limit.
 const defaultCatalogPageSize = 20
+
+const emptyJSONObject = "{}"
 
 // catalogSortColumns allow-lists the columns a controller may sort by,
 // mapping the logical name to the qualified column so caller-supplied sort
@@ -27,34 +30,22 @@ var catalogSortColumns = map[string]string{
 	"record_cid":     "records.record_cid",
 }
 
-func parseOpts(opts ...types.FilterOption) (*types.RecordFilters, error) {
-	cfg := &types.RecordFilters{}
-
-	for _, opt := range opts {
-		if opt == nil {
-			return nil, fmt.Errorf("nil filter option provided")
-		}
-
-		opt(cfg)
-	}
-
-	return cfg, nil
-}
-
 // CountCatalogEntries returns the number of distinct records matching the
-// given filters. Limit and offset options are ignored.
-func (d *DB) CountCatalogEntries(opts ...types.FilterOption) (uint32, error) {
-	cfg, err := parseOpts(opts...)
+// given filters. Limit and offset are ignored.
+func (d *DB) CountCatalogEntries(opts ...types.CatalogQueryOption) (uint32, error) {
+	cfg, err := types.CatalogFiltersFromOptions(opts...)
 	if err != nil {
-		return 0, err
+		return 0, err //nolint:wrapcheck
 	}
 
-	cfg.Limit = 0
-	cfg.Offset = 0
+	recordCfg := cfg.RecordFilters
+	recordCfg.Limit = 0
+	recordCfg.Offset = 0
 
 	query := d.gormDB.Model(&Record{})
-	query = d.handleFilterOptions(query, cfg)
+	query = d.handleFilterOptions(query, &recordCfg)
 	query = applyKnownCatalogModuleFilter(query)
+	query = applyMediaTypeFilter(query, cfg.MediaTypeFilters)
 	query = query.Distinct("records.record_cid")
 
 	var count int64
@@ -132,16 +123,18 @@ func (d *DB) ListCatalogTags() ([]*catalogv1.CatalogTag, error) {
 	return tags, nil
 }
 
-// GetCatalogEntries returns the AI Catalog entries matching the given record
-// filters, using peek-ahead pagination (Limit+1) to report hasMore. Records
-// with no AI Catalog projection are skipped rather than failing the page.
-func (d *DB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.CatalogEntry, bool, error) {
-	cfg, err := parseOpts(opts...)
+// GetCatalogEntries returns the AI Catalog entries matching the given filters,
+// using peek-ahead pagination (Limit+1) to report hasMore. Records with no AI
+// Catalog projection are skipped rather than failing the page.
+func (d *DB) GetCatalogEntries(opts ...types.CatalogQueryOption) ([]*catalogv1.CatalogEntry, bool, error) {
+	cfg, err := types.CatalogFiltersFromOptions(opts...)
 	if err != nil {
-		return nil, false, err
+		return nil, false, err //nolint:wrapcheck
 	}
 
-	pageSize := cfg.Limit
+	recordCfg := cfg.RecordFilters
+
+	pageSize := recordCfg.Limit
 	if pageSize <= 0 {
 		pageSize = defaultCatalogPageSize
 	}
@@ -161,16 +154,17 @@ func (d *DB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.Catalog
 		Preload("ScanReports").
 		Limit(pageSize + 1)
 
-	if cfg.Offset > 0 {
-		query = query.Offset(cfg.Offset)
+	if recordCfg.Offset > 0 {
+		query = query.Offset(recordCfg.Offset)
 	}
 
-	query = d.handleFilterOptions(query, cfg)
+	query = d.handleFilterOptions(query, &recordCfg)
 	query = applyKnownCatalogModuleFilter(query)
+	query = applyMediaTypeFilter(query, cfg.MediaTypeFilters)
 
-	query, err = applyCatalogOrder(query, cfg)
+	query, err = applyCatalogOrder(query, &recordCfg)
 	if err != nil {
-		return nil, false, err
+		return nil, false, err //nolint:wrapcheck
 	}
 
 	var records []Record
@@ -213,8 +207,6 @@ func (d *DB) GetCatalogEntries(opts ...types.FilterOption) ([]*catalogv1.Catalog
 }
 
 func applyKnownCatalogModuleFilter(query *gorm.DB) *gorm.DB {
-	const emptyJSONObject = "{}"
-
 	moduleNames := catalogv1.KnownCatalogModuleNames()
 
 	return query.Where(`
@@ -225,6 +217,73 @@ EXISTS (
 	AND catalog_modules.data IS NOT NULL
 	AND catalog_modules.data != ?
 )`, moduleNames, emptyJSONObject)
+}
+
+// applyMediaTypeFilter restricts the query to records matching one or more
+// catalog media types. Agent Skills markdown vs gzip is determined by the
+// indexed modules.artifact_media_type column.
+func applyMediaTypeFilter(query *gorm.DB, filters []types.MediaTypeFilter) *gorm.DB {
+	if len(filters) == 0 {
+		return query
+	}
+
+	conditions := make([]string, 0, len(filters))
+	args := make([]any, 0, len(filters))
+
+	for _, filter := range filters {
+		condition, filterArgs, err := mediaTypeExistsCondition(filter)
+		if err != nil {
+			logger.Error("unsupported media type filter", "error", err)
+
+			return query.Where("1 = 0")
+		}
+
+		if condition == "" {
+			continue
+		}
+
+		conditions = append(conditions, condition)
+		args = append(args, filterArgs...)
+	}
+
+	if len(conditions) == 0 {
+		return query
+	}
+
+	condition := strings.Join(conditions, " OR ")
+	if len(conditions) > 1 {
+		condition = "(" + condition + ")"
+	}
+
+	return query.Where(condition, args...)
+}
+
+func mediaTypeExistsCondition(filter types.MediaTypeFilter) (string, []any, error) {
+	if filter.ModuleName == "" {
+		return "", nil, fmt.Errorf("media type filter missing module name")
+	}
+
+	args := []any{filter.ModuleName, emptyJSONObject}
+
+	clause := `
+EXISTS (
+	SELECT 1 FROM modules media_type_modules
+	WHERE media_type_modules.record_cid = records.record_cid
+	AND media_type_modules.name = ?
+	AND media_type_modules.data IS NOT NULL
+	AND media_type_modules.data != ?`
+
+	if filter.ArtifactMediaType != "" {
+		clause += `
+	AND media_type_modules.artifact_media_type = ?`
+
+		args = append(args, filter.ArtifactMediaType)
+	}
+
+	clause += `
+)`
+
+	return clause, args, nil
 }
 
 func convertScanReports(reports []ScanReport) []catalogv1.ScanReportSummary {

--- a/server/types/catalog.go
+++ b/server/types/catalog.go
@@ -1,0 +1,54 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import "fmt"
+
+type CatalogFilters struct {
+	RecordFilters
+	MediaTypeFilters []MediaTypeFilter
+}
+
+type MediaTypeFilter struct {
+	ModuleName        string
+	ArtifactMediaType string
+}
+
+type CatalogQueryOption interface {
+	ApplyCatalog(*CatalogFilters)
+}
+
+type CatalogFilterOption func(*CatalogFilters)
+
+func (opt FilterOption) ApplyCatalog(cfg *CatalogFilters) {
+	if opt != nil {
+		opt(&cfg.RecordFilters)
+	}
+}
+
+func (opt CatalogFilterOption) ApplyCatalog(cfg *CatalogFilters) {
+	if opt != nil {
+		opt(cfg)
+	}
+}
+
+func CatalogFiltersFromOptions(opts ...CatalogQueryOption) (*CatalogFilters, error) {
+	cfg := &CatalogFilters{}
+
+	for _, opt := range opts {
+		if opt == nil {
+			return nil, fmt.Errorf("nil catalog query option provided")
+		}
+
+		opt.ApplyCatalog(cfg)
+	}
+
+	return cfg, nil
+}
+
+func WithMediaTypeFilters(filters ...MediaTypeFilter) CatalogFilterOption {
+	return func(cfg *CatalogFilters) {
+		cfg.MediaTypeFilters = append(cfg.MediaTypeFilters, filters...)
+	}
+}

--- a/server/types/database.go
+++ b/server/types/database.go
@@ -121,12 +121,12 @@ type NameVerificationDatabaseAPI interface {
 // AI Finder GET /v1/agents endpoint.
 type CatalogDatabaseAPI interface {
 	// GetCatalogEntries returns the AI Catalog entries matching the given
-	// record filters, along with whether more results exist beyond the page.
-	GetCatalogEntries(opts ...FilterOption) (entries []*catalogv1.CatalogEntry, hasMore bool, err error)
+	// filters, along with whether more results exist beyond the page.
+	GetCatalogEntries(opts ...CatalogQueryOption) (entries []*catalogv1.CatalogEntry, hasMore bool, err error)
 
 	// CountCatalogEntries returns the number of distinct records matching the
 	// given filters. Limit and offset options are ignored.
-	CountCatalogEntries(opts ...FilterOption) (uint32, error)
+	CountCatalogEntries(opts ...CatalogQueryOption) (uint32, error)
 
 	// ListCatalogTags returns distinct catalog tags derived from OASF skills,
 	// domains, and record annotations, sorted lexicographically by label.


### PR DESCRIPTION
fixing the media type filters

<img width="393" height="634" alt="Screenshot 2026-07-28 at 17 53 26" src="https://github.com/user-attachments/assets/b937242c-899a-4bf0-b524-cd5bd78aaf63" />

right now, the skills are not getting properly filtered in the SQL query

this PR adjusts the `type` filter so it can handle both the gzip and md agent skills
