### PR TITLE
fix(ci): stop concatenating per-module versions into RELEASE_VERSION

### DIFF
--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -6,9 +6,10 @@ version: "3"
 vars:
   ## Version
   RELEASE_VERSION:
-    # versions.yaml carries a version: key per module-set, so grep-all would
-    # concatenate them with a newline. Take the first (api) version and stop.
-    sh: awk '/version:/{print $2; exit}' versions.yaml
+    # versions.yaml carries a version: key per module-set; grep-all would
+    # concatenate them with a newline. Select the api module-set version
+    # explicitly (it stamps api/version.Version) rather than relying on order.
+    sh: awk '/^  api:/{f=1} f&&/version:/{print $2; exit}' versions.yaml
   RELEASE_VERSION_LDFLAG: "-X 'github.com/agntcy/dir/api/version.Version={{ .RELEASE_VERSION }}'"
   COMMIT_SHA:
     sh: git rev-parse --short HEAD

--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -6,7 +6,9 @@ version: "3"
 vars:
   ## Version
   RELEASE_VERSION:
-    sh: grep 'version:' versions.yaml | awk '{print $2}'
+    # versions.yaml carries a version: key per module-set, so grep-all would
+    # concatenate them with a newline. Take the first (api) version and stop.
+    sh: awk '/version:/{print $2; exit}' versions.yaml
   RELEASE_VERSION_LDFLAG: "-X 'github.com/agntcy/dir/api/version.Version={{ .RELEASE_VERSION }}'"
   COMMIT_SHA:
     sh: git rev-parse --short HEAD


### PR DESCRIPTION
## Problem

When the local `dir` daemon starts, it self-registers an `org.agntcy/directory` OASF record describing the node. That record's `version` field came out malformed with an embedded newline — e.g. `"v1.6.1\n1.6.1"` — which downstream tooling then rendered as two lines (this surfaced as a broken row in the [lazydir](https://github.com/agntcy/lazydir) Records panel).

## Root cause

`RELEASE_VERSION` in `Taskfile.vars.yml` was computed as:

```yaml
sh: grep 'version:' versions.yaml | awk '{print $2}'
```

`versions.yaml` is a multi-module config with a `version:` key **per module-set** (`api` and `server`). `grep` therefore matched **both** lines and `awk` emitted the two values separated by a newline. Task's `sh:` only strips the *trailing* newline, so the interior `\n` survived into the `-X ...version.Version=` ldflag, into `api/version.Version`, and into the self-registered record's `version`.

## Fix

Select a single module-set's version and stop before the second match:

```yaml
sh: awk '/version:/{print $2; exit}' versions.yaml
```

This takes the first (`api`) version — the one that stamps `api/version.Version` — and produces exactly one clean value. No new tool dependency (stays `awk`, portable across GNU/BSD).

## Verification

- Raw command output: before → `v1.6.1\nv1.6.1\n` (interior newline); after → `v1.6.1\n` (single value; Task trims the trailing newline).
- Through Task: `task build --dry` now renders `...version.Version=v1.6.1`.
- `task --list-all` / `task build --dry` succeed → the Taskfile still parses.
