### PR TITLE
fix(dir): index artifact.media_type in database

### DIFF
--- a/api/core/adapters/oasf_v1.go
+++ b/api/core/adapters/oasf_v1.go
@@ -74,11 +74,17 @@ func (v *v1Adapter) GetLocators() []coretypes.Locator {
 func (v *v1Adapter) GetModules() []coretypes.Module {
 	modules := make([]coretypes.Module, 0, len(v.record.GetModules()))
 	for _, m := range v.record.GetModules() {
+		artifactMediaType := ""
+		if artifact := m.GetArtifact(); artifact != nil {
+			artifactMediaType = artifact.GetMediaType()
+		}
+
 		modules = append(modules, &module{
-			Annotations: m.GetAnnotations(),
-			Name:        m.GetName(),
-			ID:          uint64(m.GetId()),
-			Data:        m.GetData().AsMap(),
+			Annotations:       m.GetAnnotations(),
+			Name:              m.GetName(),
+			ID:                uint64(m.GetId()),
+			Data:              m.GetData().AsMap(),
+			ArtifactMediaType: artifactMediaType,
 		})
 	}
 

--- a/api/core/adapters/objects.go
+++ b/api/core/adapters/objects.go
@@ -4,16 +4,18 @@
 package adapters
 
 type module struct {
-	Annotations map[string]string
-	Name        string
-	ID          uint64
-	Data        map[string]any
+	Annotations       map[string]string
+	Name              string
+	ID                uint64
+	Data              map[string]any
+	ArtifactMediaType string
 }
 
 func (module *module) GetAnnotations() map[string]string { return module.Annotations }
 func (module *module) GetName() string                   { return module.Name }
 func (module *module) GetID() uint64                     { return module.ID }
 func (module *module) GetData() map[string]any           { return module.Data }
+func (module *module) GetArtifactMediaType() string      { return module.ArtifactMediaType }
 
 type skill struct {
 	Annotations map[string]string

--- a/api/core/types/record.go
+++ b/api/core/types/record.go
@@ -30,6 +30,7 @@ type Module interface {
 	GetName() string
 	GetID() uint64
 	GetData() map[string]any
+	GetArtifactMediaType() string
 }
 
 // Skill defines the necessary data for a skill.

--- a/server/database/catalog_test.go
+++ b/server/database/catalog_test.go
@@ -31,6 +31,7 @@ func (m *catalogModuleFixture) GetAnnotations() map[string]string { return nil }
 func (m *catalogModuleFixture) GetID() uint64                     { return m.id }
 func (m *catalogModuleFixture) GetName() string                   { return m.name }
 func (m *catalogModuleFixture) GetData() map[string]any           { return m.data }
+func (m *catalogModuleFixture) GetArtifactMediaType() string      { return "" }
 
 func catalogRecord(cid, name, createdAt string, modules []coretypes.Module) coretypes.Record {
 	return &testRecord{

--- a/server/database/database_test.go
+++ b/server/database/database_test.go
@@ -56,14 +56,16 @@ func (l *testLocator) GetDigest() string                 { return "" }
 func (l *testLocator) GetAnnotations() map[string]string { return nil }
 
 type testModule struct {
-	id   uint64
-	name string
+	id                uint64
+	name              string
+	artifactMediaType string
 }
 
 func (m *testModule) GetID() uint64                     { return m.id }
 func (m *testModule) GetName() string                   { return m.name }
 func (m *testModule) GetData() map[string]any           { return nil }
 func (m *testModule) GetAnnotations() map[string]string { return nil }
+func (m *testModule) GetArtifactMediaType() string      { return m.artifactMediaType }
 
 type testDomain struct {
 	id   uint64

--- a/server/database/gorm/module.go
+++ b/server/database/gorm/module.go
@@ -17,6 +17,10 @@ type Module struct {
 	Name      string `gorm:"not null"`
 	ModuleID  uint64 `gorm:"column:module_id"`
 
+	// ArtifactMediaType is the OASF module.artifact.media_type value when present
+	// (e.g. application/agent-skills+gzip).
+	ArtifactMediaType string `gorm:"column:artifact_media_type;index"`
+
 	// Data is the module's structured payload (e.g. the A2A agent card or
 	// MCP server definition).
 	//
@@ -42,15 +46,20 @@ func (module *Module) GetAnnotations() map[string]string {
 	return nil
 }
 
+func (module *Module) GetArtifactMediaType() string {
+	return module.ArtifactMediaType
+}
+
 // convertModules transforms interface types to Database structs.
 func convertModules(modules []coretypes.Module, recordCID string) []Module {
 	result := make([]Module, len(modules))
 	for i, module := range modules {
 		result[i] = Module{
-			RecordCID: recordCID,
-			Name:      module.GetName(),
-			ModuleID:  module.GetID(),
-			Data:      module.GetData(),
+			RecordCID:         recordCID,
+			Name:              module.GetName(),
+			ModuleID:          module.GetID(),
+			Data:              module.GetData(),
+			ArtifactMediaType: module.GetArtifactMediaType(),
 		}
 	}
 

--- a/server/database/gorm/module_test.go
+++ b/server/database/gorm/module_test.go
@@ -1,0 +1,103 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package gorm
+
+import (
+	"testing"
+
+	coretypes "github.com/agntcy/dir/api/core/types"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type moduleFixture struct {
+	id                uint64
+	name              string
+	data              map[string]any
+	artifactMediaType string
+}
+
+func (m *moduleFixture) GetAnnotations() map[string]string { return nil }
+func (m *moduleFixture) GetID() uint64                     { return m.id }
+func (m *moduleFixture) GetName() string                   { return m.name }
+func (m *moduleFixture) GetData() map[string]any           { return m.data }
+func (m *moduleFixture) GetArtifactMediaType() string      { return m.artifactMediaType }
+
+type recordFixture struct {
+	cid     string
+	name    string
+	version string
+	modules []coretypes.Module
+}
+
+func (r *recordFixture) GetCid() string                    { return r.cid }
+func (r *recordFixture) GetName() string                   { return r.name }
+func (r *recordFixture) GetVersion() string                { return r.version }
+func (r *recordFixture) GetDescription() string            { return "" }
+func (r *recordFixture) GetSchemaVersion() string          { return "1.0.0" }
+func (r *recordFixture) GetCreatedAt() string              { return "2024-01-01T00:00:00Z" }
+func (r *recordFixture) GetAuthors() []string              { return nil }
+func (r *recordFixture) GetSkills() []coretypes.Skill      { return nil }
+func (r *recordFixture) GetLocators() []coretypes.Locator  { return nil }
+func (r *recordFixture) GetModules() []coretypes.Module    { return r.modules }
+func (r *recordFixture) GetDomains() []coretypes.Domain    { return nil }
+func (r *recordFixture) GetAnnotations() map[string]string { return nil }
+func (r *recordFixture) GetPreviousRecordCid() string      { return "" }
+
+func TestConvertModules_PersistsArtifactMediaType(t *testing.T) {
+	const mediaType = "application/agent-skills+gzip"
+
+	modules := convertModules([]coretypes.Module{
+		&moduleFixture{
+			id:                10302,
+			name:              "core/language_model/agentskills",
+			artifactMediaType: mediaType,
+		},
+	}, "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
+
+	require.Len(t, modules, 1)
+	assert.Equal(t, mediaType, modules[0].ArtifactMediaType)
+}
+
+func TestAddRecord_PersistsModuleArtifactMediaType(t *testing.T) {
+	const (
+		cid       = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
+		mediaType = "application/agent-skills+gzip"
+	)
+
+	db, err := New(testDB(t))
+	require.NoError(t, err)
+
+	record := &recordFixture{
+		cid:     cid,
+		name:    "example/skill",
+		version: "1.0.0",
+		modules: []coretypes.Module{
+			&moduleFixture{
+				id:                10302,
+				name:              "core/language_model/agentskills",
+				artifactMediaType: mediaType,
+			},
+		},
+	}
+
+	require.NoError(t, db.AddRecord(record))
+
+	var modules []Module
+	require.NoError(t, db.gormDB.Where("record_cid = ?", cid).Find(&modules).Error)
+	require.Len(t, modules, 1)
+	assert.Equal(t, mediaType, modules[0].ArtifactMediaType)
+}
+
+func testDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file::memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("PRAGMA foreign_keys = ON").Error)
+
+	return db
+}


### PR DESCRIPTION
we need to index the module's `artifact.media_type` field in the database

<img width="425" height="607" alt="Screenshot 2026-07-28 at 15 40 41" src="https://github.com/user-attachments/assets/83c79d8d-d14d-4d50-810e-7180ee178d28" />

this is needed for these filters to work, so we can filter for artifact types like:
- `application/agent-skills+gzip`
- `application/agent-skills+md`

so, this PR adds the `artifact_media_type` column to the modules table
