### PR TITLE
fix(routing): allow republish interval override via environment

### DIFF
--- a/cli/cmd/daemon/daemon.config.yaml
+++ b/cli/cmd/daemon/daemon.config.yaml
@@ -40,6 +40,12 @@ server:
     datastore_dir: "routing"
     # bootstrap_peers:
     #   - "/dns4/remote-dir.example.com/tcp/8999/p2p/<peer-id>"
+
+    # How often local CID provider announcements are republished. Lower values
+    # let newly joined nodes converge on existing content sooner, at the cost of
+    # more announcement traffic and more work for every subscriber.
+    republish_interval: "36h"
+
     gossipsub:
       enabled: true
     # DHT-based record + referrer autosync (deny-by-default; disabled unless set).

--- a/cli/cmd/daemon/daemon_test.go
+++ b/cli/cmd/daemon/daemon_test.go
@@ -26,6 +26,28 @@ func TestLoadConfigUsesMacOSFriendlyLocalRegistryPort(t *testing.T) {
 	require.Equal(t, "localhost:5555", cfg.Reconciler.LocalRegistry.RegistryAddress)
 }
 
+// TestLoadConfigRepublishIntervalEnvOverride asserts that the routing republish
+// interval can be overridden by environment alone. AutomaticEnv only resolves
+// keys viper already knows, so this depends on the key being declared in the
+// embedded daemon.config.yaml.
+func TestLoadConfigRepublishIntervalEnvOverride(t *testing.T) {
+	originalOpts := opts
+	opts = &Options{DataDir: t.TempDir()}
+	t.Cleanup(func() {
+		opts = originalOpts
+	})
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	require.Equal(t, 36*time.Hour, cfg.Server.Routing.RepublishInterval)
+
+	t.Setenv("DIRECTORY_DAEMON_SERVER_ROUTING_REPUBLISH_INTERVAL", "10m")
+
+	cfg, err = loadConfig()
+	require.NoError(t, err)
+	require.Equal(t, 10*time.Minute, cfg.Server.Routing.RepublishInterval)
+}
+
 // TestEmbeddedZot tests the embedded Zot server.
 func TestEmbeddedZot(t *testing.T) {
 	address := storeconfig.DefaultRegistryAddress

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -510,6 +510,13 @@ func LoadConfig(opts ...ConfigOption) (*Config, error) {
 	_ = v.BindEnv("routing.datastore_dir")
 	v.SetDefault("routing.datastore_dir", "")
 
+	// Note: No defaults set for the intervals below. A zero value means the
+	// routing package falls back to its RefreshInterval/RepublishInterval
+	// constants.
+	_ = v.BindEnv("routing.refresh_interval")
+
+	_ = v.BindEnv("routing.republish_interval")
+
 	//
 	// Routing GossipSub configuration
 	// Note: Only enable/disable is configurable. Protocol parameters (topic, message size)

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -43,6 +43,8 @@ func TestConfig(t *testing.T) {
 				"DIRECTORY_SERVER_ROUTING_LISTEN_ADDRESS":              "/ip4/1.1.1.1/tcp/1",
 				"DIRECTORY_SERVER_ROUTING_BOOTSTRAP_PEERS":             "/ip4/1.1.1.1/tcp/1,/ip4/1.1.1.1/tcp/2",
 				"DIRECTORY_SERVER_ROUTING_KEY_PATH":                    "/path/to/key",
+				"DIRECTORY_SERVER_ROUTING_REFRESH_INTERVAL":            "5s",
+				"DIRECTORY_SERVER_ROUTING_REPUBLISH_INTERVAL":          "10m",
 				"DIRECTORY_SERVER_DATABASE_TYPE":                       "postgres",
 				"DIRECTORY_SERVER_DATABASE_POSTGRES_HOST":              "localhost",
 				"DIRECTORY_SERVER_DATABASE_POSTGRES_PORT":              "5432",
@@ -95,7 +97,9 @@ func TestConfig(t *testing.T) {
 						"/ip4/1.1.1.1/tcp/1",
 						"/ip4/1.1.1.1/tcp/2",
 					},
-					KeyPath: "/path/to/key",
+					KeyPath:           "/path/to/key",
+					RefreshInterval:   5 * time.Second,
+					RepublishInterval: 10 * time.Minute,
 					GossipSub: routing.GossipSubConfig{
 						Enabled: true, // Default value
 					},


### PR DESCRIPTION
`routing.republish_interval` could not be set by environment variable: the apiserver loader never bound it, and the daemon's embedded config never declared it, so AutomaticEnv had no key to resolve. Bind the refresh and republish intervals in the apiserver loader and declare `republish_interval` in the embedded daemon config at its built-in 36h default. No behavior change unless the variable is set.