### PR TITLE
fix(routing): allow advertised routing addresses to be set via environment

### DIFF
--- a/cli/cmd/daemon/config.go
+++ b/cli/cmd/daemon/config.go
@@ -52,6 +52,15 @@ type RuntimeConfig struct {
 func registerServerDefaults(v *viper.Viper) {
 	v.SetDefault("server.store.oci.registry_address", storeconfig.DefaultRegistryAddress)
 	v.SetDefault("server.store.oci.repository_name", storeconfig.DefaultRepositoryName)
+
+	// The advertised routing endpoints have no default and are absent from
+	// daemon.config.yaml, so they must be registered here for AutomaticEnv to
+	// resolve them. Mirrors server/config.
+	_ = v.BindEnv("server.routing.directory_api_address")
+	v.SetDefault("server.routing.directory_api_address", "")
+
+	_ = v.BindEnv("server.routing.directory_oci_address")
+	v.SetDefault("server.routing.directory_oci_address", "")
 }
 
 func registerReconcilerDefaults(v *viper.Viper) {

--- a/cli/cmd/daemon/daemon.config.yaml
+++ b/cli/cmd/daemon/daemon.config.yaml
@@ -12,6 +12,8 @@
 #   DIRECTORY_DAEMON_SERVER_LISTEN_ADDRESS
 #   DIRECTORY_DAEMON_SERVER_ROUTING_LISTEN_ADDRESS
 #   DIRECTORY_DAEMON_SERVER_ROUTING_BOOTSTRAP_PEERS  (comma-separated)
+#   DIRECTORY_DAEMON_SERVER_ROUTING_DIRECTORY_API_ADDRESS
+#   DIRECTORY_DAEMON_SERVER_ROUTING_DIRECTORY_OCI_ADDRESS
 #   DIRECTORY_DAEMON_SERVER_DATABASE_POSTGRES_USERNAME
 #   DIRECTORY_DAEMON_SERVER_DATABASE_POSTGRES_PASSWORD
 #   DIRECTORY_DAEMON_SERVER_STORE_OCI_AUTH_CONFIG_USERNAME
@@ -40,6 +42,13 @@ server:
     datastore_dir: "routing"
     # bootstrap_peers:
     #   - "/dns4/remote-dir.example.com/tcp/8999/p2p/<peer-id>"
+
+    # Endpoints advertised to peers so they can sync records from this node.
+    # Both are optional; empty means the endpoint is not advertised. Set the
+    # publicly reachable addresses here, which may differ from listen_address
+    # and store.oci.registry_address.
+    # directory_api_address: "dir.example.com:8888"
+    # directory_oci_address: "ghcr.io/org/agents"
 
     # How often local CID provider announcements are republished. Lower values
     # let newly joined nodes converge on existing content sooner, at the cost of

--- a/cli/cmd/daemon/daemon_test.go
+++ b/cli/cmd/daemon/daemon_test.go
@@ -5,6 +5,8 @@ package daemon
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -46,6 +48,54 @@ func TestLoadConfigRepublishIntervalEnvOverride(t *testing.T) {
 	cfg, err = loadConfig()
 	require.NoError(t, err)
 	require.Equal(t, 10*time.Minute, cfg.Server.Routing.RepublishInterval)
+}
+
+// TestLoadConfigRoutingAddressEnvOverride asserts that the advertised routing
+// endpoints can be set by environment alone. They have no default and are absent
+// from the embedded daemon.config.yaml, so this depends on them being registered
+// in registerServerDefaults.
+func TestLoadConfigRoutingAddressEnvOverride(t *testing.T) {
+	originalOpts := opts
+	opts = &Options{DataDir: t.TempDir()}
+	t.Cleanup(func() {
+		opts = originalOpts
+	})
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	require.Empty(t, cfg.Server.Routing.DirectoryAPIAddress)
+	require.Empty(t, cfg.Server.Routing.DirectoryOCIAddress)
+
+	t.Setenv("DIRECTORY_DAEMON_SERVER_ROUTING_DIRECTORY_API_ADDRESS", "dir.example.com:8888")
+	t.Setenv("DIRECTORY_DAEMON_SERVER_ROUTING_DIRECTORY_OCI_ADDRESS", "ghcr.io/org/agents")
+
+	cfg, err = loadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "dir.example.com:8888", cfg.Server.Routing.DirectoryAPIAddress)
+	require.Equal(t, "ghcr.io/org/agents", cfg.Server.Routing.DirectoryOCIAddress)
+}
+
+// TestLoadConfigRoutingAddressEnvOverrideWithUserConfig asserts the same holds
+// for a user-supplied config file that does not declare the keys, since --config
+// is read as-is without merging the embedded defaults.
+func TestLoadConfigRoutingAddressEnvOverrideWithUserConfig(t *testing.T) {
+	originalOpts := opts
+	dataDir := t.TempDir()
+
+	configPath := filepath.Join(dataDir, DefaultConfigFile)
+	require.NoError(t, os.WriteFile(configPath, []byte(defaultConfigYAML), 0o600))
+
+	opts = &Options{DataDir: dataDir, ConfigFile: configPath}
+
+	t.Cleanup(func() {
+		opts = originalOpts
+	})
+
+	t.Setenv("DIRECTORY_DAEMON_SERVER_ROUTING_DIRECTORY_OCI_ADDRESS", "ghcr.io/org/agents")
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "ghcr.io/org/agents", cfg.Server.Routing.DirectoryOCIAddress)
 }
 
 // TestEmbeddedZot tests the embedded Zot server.


### PR DESCRIPTION
The daemon ignored `DIRECTORY_DAEMON_SERVER_ROUTING_DIRECTORY_API_ADDRESS` and
`DIRECTORY_DAEMON_SERVER_ROUTING_DIRECTORY_OCI_ADDRESS`. Viper's AutomaticEnv only resolves keys it already knows, and neither key has a default nor appears in `daemon.config.yaml`, so both were silently dropped. Register them in `registerServerDefaults`, mirroring server/config, so the endpoints a node advertises to peers can be configured without supplying a config file.
