### PR TITLE
fix(dir): fix ListAgent's tags filter

### DIFF
--- a/server/controller/ai_finder_filter.go
+++ b/server/controller/ai_finder_filter.go
@@ -31,18 +31,15 @@ const filterMaxLen = 2048
 
 // agentFilter is the parsed representation of the ListAgents filter query.
 type agentFilter struct {
-	DisplayName    string
-	Types          []string
-	PublisherIDs   []string
-	CreatedAfter   time.Time
-	UpdatedAfter   time.Time
-	Verified       *bool
-	Trusted        *bool
-	Safe           *bool
-	SkillNames     []string
-	DomainNames    []string
-	Annotations    []types.Annotation
-	AnnotationKeys []string
+	DisplayName  string
+	Types        []string
+	PublisherIDs []string
+	CreatedAfter time.Time
+	UpdatedAfter time.Time
+	Verified     *bool
+	Trusted      *bool
+	Safe         *bool
+	TagFilters   []types.TagFilter
 }
 
 func mediaTypeFilterForType(mediaType string) *types.MediaTypeFilter {
@@ -190,20 +187,8 @@ func buildCatalogFilterOptions(f agentFilter, order []orderByClause, pageSize, o
 		opts = append(opts, types.WithScanSafe(*f.Safe))
 	}
 
-	if len(f.SkillNames) > 0 {
-		opts = append(opts, types.WithSkillNames(f.SkillNames...))
-	}
-
-	if len(f.DomainNames) > 0 {
-		opts = append(opts, types.WithDomainNames(f.DomainNames...))
-	}
-
-	if len(f.Annotations) > 0 {
-		opts = append(opts, types.WithAnnotations(f.Annotations...))
-	}
-
-	if len(f.AnnotationKeys) > 0 {
-		opts = append(opts, types.WithAnnotationKeys(f.AnnotationKeys...))
+	if len(f.TagFilters) > 0 {
+		opts = append(opts, types.WithTagFilters(f.TagFilters...))
 	}
 
 	if len(order) > 0 {
@@ -467,12 +452,14 @@ func applyClause(out *agentFilter, field string, values []string) error {
 		return nil
 
 	case "tags":
-		skillNames, domainNames, annotations, annotationKeys := parseTags(values)
+		filters := make([]types.TagFilter, 0, len(values))
+		for _, tag := range values {
+			if filter := tagFilterForTag(tag); filter != nil {
+				filters = append(filters, *filter)
+			}
+		}
 
-		out.SkillNames = skillNames
-		out.DomainNames = domainNames
-		out.Annotations = annotations
-		out.AnnotationKeys = annotationKeys
+		out.TagFilters = filters
 
 		return nil
 
@@ -511,28 +498,19 @@ func singleTimestamp(field string, values []string) (time.Time, error) {
 	return ts.UTC(), nil
 }
 
-func parseTags(tags []string) ([]string, []string, []types.Annotation, []string) {
-	var (
-		skillNames     []string
-		domainNames    []string
-		annotations    []types.Annotation
-		annotationKeys []string
-	)
+func tagFilterForTag(tag string) *types.TagFilter {
+	switch {
+	case isSkillTag(tag):
+		return &types.TagFilter{SkillName: parseSkillName(tag)}
+	case isDomainTag(tag):
+		return &types.TagFilter{DomainName: parseDomainName(tag)}
+	case isAnnotationTag(tag):
+		annotation := parseAnnotation(tag)
 
-	for _, tag := range tags {
-		switch {
-		case isSkillTag(tag):
-			skillNames = append(skillNames, parseSkillName(tag))
-		case isDomainTag(tag):
-			domainNames = append(domainNames, parseDomainName(tag))
-		case isAnnotationTag(tag):
-			annotations = append(annotations, parseAnnotation(tag))
-		default:
-			annotationKeys = append(annotationKeys, tag)
-		}
+		return &types.TagFilter{Annotation: &annotation}
+	default:
+		return &types.TagFilter{AnnotationKey: tag}
 	}
-
-	return skillNames, domainNames, annotations, annotationKeys
 }
 
 func isSkillTag(tag string) bool {

--- a/server/controller/ai_finder_test.go
+++ b/server/controller/ai_finder_test.go
@@ -251,49 +251,53 @@ func TestParseAgentFilter(t *testing.T) {
 	t.Run("tags skill tag", func(t *testing.T) {
 		f, err := parseAgentFilter(`tags=oasf:*:skills:natural_language_processing/*`)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"natural_language_processing/*"}, f.SkillNames)
-		assert.Empty(t, f.DomainNames)
+		assert.Equal(t, []types.TagFilter{{SkillName: "natural_language_processing/*"}}, f.TagFilters)
 	})
 
 	t.Run("tags comma-OR", func(t *testing.T) {
 		f, err := parseAgentFilter(`tags=oasf:*:skills:foo/*,oasf:*:skills:bar`)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"foo/*", "bar"}, f.SkillNames)
-		assert.Empty(t, f.DomainNames)
+		assert.Equal(t, []types.TagFilter{
+			{SkillName: "foo/*"},
+			{SkillName: "bar"},
+		}, f.TagFilters)
 	})
 
 	t.Run("tags domain tag", func(t *testing.T) {
 		f, err := parseAgentFilter(`tags=oasf:*:domains:healthcare/*`)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"healthcare/*"}, f.DomainNames)
-		assert.Empty(t, f.SkillNames)
+		assert.Equal(t, []types.TagFilter{{DomainName: "healthcare/*"}}, f.TagFilters)
 	})
 
 	t.Run("tags mixed skill and domain", func(t *testing.T) {
 		f, err := parseAgentFilter(`tags=oasf:*:skills:foo,oasf:*:domains:bar`)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"foo"}, f.SkillNames)
-		assert.Equal(t, []string{"bar"}, f.DomainNames)
+		assert.Equal(t, []types.TagFilter{
+			{SkillName: "foo"},
+			{DomainName: "bar"},
+		}, f.TagFilters)
 	})
 
 	t.Run("tags annotation pair", func(t *testing.T) {
 		f, err := parseAgentFilter(`tags="owner=alice"`)
 		require.NoError(t, err)
-		assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, f.Annotations)
+		assert.Equal(t, []types.TagFilter{{Annotation: &types.Annotation{Key: "owner", Value: "alice"}}}, f.TagFilters)
 	})
 
 	t.Run("tags annotation key only", func(t *testing.T) {
 		f, err := parseAgentFilter(`tags=owner`)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"owner"}, f.AnnotationKeys)
+		assert.Equal(t, []types.TagFilter{{AnnotationKey: "owner"}}, f.TagFilters)
 	})
 
 	t.Run("tags mixed catalog tag kinds", func(t *testing.T) {
 		f, err := parseAgentFilter(`tags=oasf:*:skills:foo,"owner=alice",env`)
 		require.NoError(t, err)
-		assert.Equal(t, []string{"foo"}, f.SkillNames)
-		assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, f.Annotations)
-		assert.Equal(t, []string{"env"}, f.AnnotationKeys)
+		assert.Equal(t, []types.TagFilter{
+			{SkillName: "foo"},
+			{Annotation: &types.Annotation{Key: "owner", Value: "alice"}},
+			{AnnotationKey: "env"},
+		}, f.TagFilters)
 	})
 
 	invalid := []struct {
@@ -371,10 +375,13 @@ func TestBuildCatalogFilterOptionsSafe(t *testing.T) {
 
 func TestBuildCatalogFilterOptionsTags(t *testing.T) {
 	f := agentFilter{
-		SkillNames:     []string{"natural_language_processing/*", "coding/*"},
-		DomainNames:    []string{"healthcare/*"},
-		Annotations:    []types.Annotation{{Key: "owner", Value: "alice"}},
-		AnnotationKeys: []string{"env"},
+		TagFilters: []types.TagFilter{
+			{SkillName: "natural_language_processing/*"},
+			{SkillName: "coding/*"},
+			{DomainName: "healthcare/*"},
+			{Annotation: &types.Annotation{Key: "owner", Value: "alice"}},
+			{AnnotationKey: "env"},
+		},
 	}
 
 	opts, ok := buildCatalogFilterOptions(f, nil, 20, 0)
@@ -385,23 +392,31 @@ func TestBuildCatalogFilterOptionsTags(t *testing.T) {
 		opt.ApplyCatalog(&cfg)
 	}
 
-	assert.Equal(t, []string{"natural_language_processing/*", "coding/*"}, cfg.SkillNames)
-	assert.Equal(t, []string{"healthcare/*"}, cfg.DomainNames)
-	assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, cfg.Annotations)
-	assert.Equal(t, []string{"env"}, cfg.AnnotationKeys)
+	assert.Equal(t, []types.TagFilter{
+		{SkillName: "natural_language_processing/*"},
+		{SkillName: "coding/*"},
+		{DomainName: "healthcare/*"},
+		{Annotation: &types.Annotation{Key: "owner", Value: "alice"}},
+		{AnnotationKey: "env"},
+	}, cfg.TagFilters)
 }
 
-func TestParseTags(t *testing.T) {
-	skillNames, domainNames, annotations, annotationKeys := parseTags([]string{
-		"oasf:*:skills:retrieval_augmented_generation/*",
-		"oasf:*:domains:healthcare/*",
-		"owner=alice",
-		"env",
-	})
-	assert.Equal(t, []string{"retrieval_augmented_generation/*"}, skillNames)
-	assert.Equal(t, []string{"healthcare/*"}, domainNames)
-	assert.Equal(t, []types.Annotation{{Key: "owner", Value: "alice"}}, annotations)
-	assert.Equal(t, []string{"env"}, annotationKeys)
+func TestTagFilterForTag(t *testing.T) {
+	filter := tagFilterForTag("oasf:*:skills:retrieval_augmented_generation/*")
+	require.NotNil(t, filter)
+	assert.Equal(t, "retrieval_augmented_generation/*", filter.SkillName)
+
+	filter = tagFilterForTag("oasf:*:domains:healthcare/*")
+	require.NotNil(t, filter)
+	assert.Equal(t, "healthcare/*", filter.DomainName)
+
+	filter = tagFilterForTag("owner=alice")
+	require.NotNil(t, filter)
+	assert.Equal(t, &types.Annotation{Key: "owner", Value: "alice"}, filter.Annotation)
+
+	filter = tagFilterForTag("env")
+	require.NotNil(t, filter)
+	assert.Equal(t, "env", filter.AnnotationKey)
 }
 
 func TestParseOrderBy(t *testing.T) {

--- a/server/database/catalog_test.go
+++ b/server/database/catalog_test.go
@@ -35,6 +35,16 @@ func (m *catalogModuleFixture) GetData() map[string]any           { return m.dat
 func (m *catalogModuleFixture) GetArtifactMediaType() string      { return m.artifactMediaType }
 
 func catalogRecord(cid, name, createdAt string, modules []coretypes.Module) coretypes.Record {
+	return catalogRecordWithTags(cid, name, createdAt, modules, []coretypes.Skill{&testSkill{id: 1, name: "test_skill"}}, nil, nil)
+}
+
+func catalogRecordWithTags(
+	cid, name, createdAt string,
+	modules []coretypes.Module,
+	skills []coretypes.Skill,
+	domains []coretypes.Domain,
+	annotations map[string]string,
+) coretypes.Record {
 	return &testRecord{
 		cid:           cid,
 		name:          name,
@@ -42,7 +52,9 @@ func catalogRecord(cid, name, createdAt string, modules []coretypes.Module) core
 		description:   "a " + name + " agent",
 		schemaVersion: "0.5.0",
 		createdAt:     createdAt,
-		skills:        []coretypes.Skill{&testSkill{id: 1, name: "test_skill"}},
+		skills:        skills,
+		domains:       domains,
+		annotations:   annotations,
 		modules:       modules,
 	}
 }
@@ -199,6 +211,51 @@ func TestCountCatalogEntries_AgentSkillsMediaType(t *testing.T) {
 	))
 	require.NoError(t, err)
 	assert.Equal(t, uint32(2), count)
+}
+
+func TestCountCatalogEntries_TagFilters(t *testing.T) {
+	db := setupTestDB(t)
+
+	a2aModule := []coretypes.Module{
+		&catalogModuleFixture{id: 1, name: translator.A2AModuleName, data: map[string]any{"protocol_version": "1.0"}},
+	}
+
+	skillTagged := catalogRecordWithTags(
+		"cid-tag-skill", "tag-skill", "2024-06-01T00:00:00Z", a2aModule,
+		[]coretypes.Skill{&testSkill{id: 11, name: "natural_language_processing/text_completion"}}, nil, nil,
+	)
+	domainTagged := catalogRecordWithTags(
+		"cid-tag-domain", "tag-domain", "2024-06-02T00:00:00Z", a2aModule,
+		nil, []coretypes.Domain{&testDomain{id: 21, name: "healthcare/clinical"}}, nil,
+	)
+	annotationTagged := catalogRecordWithTags(
+		"cid-tag-annotation", "tag-annotation", "2024-06-03T00:00:00Z", a2aModule,
+		nil, nil, map[string]string{"owner": "alice"},
+	)
+
+	for _, r := range []coretypes.Record{skillTagged, domainTagged, annotationTagged} {
+		require.NoError(t, db.AddRecord(r))
+	}
+
+	count, err := db.CountCatalogEntries(types.WithTagFilters(types.TagFilter{SkillName: "natural_language_processing/*"}))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), count)
+
+	count, err = db.CountCatalogEntries(types.WithTagFilters(
+		types.TagFilter{SkillName: "natural_language_processing/*"},
+		types.TagFilter{DomainName: "healthcare/*"},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), count)
+
+	count, err = db.CountCatalogEntries(types.WithTagFilters(
+		types.TagFilter{SkillName: "natural_language_processing/*"},
+		types.TagFilter{DomainName: "healthcare/*"},
+		types.TagFilter{Annotation: &types.Annotation{Key: "owner", Value: "alice"}},
+		types.TagFilter{AnnotationKey: "env"},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, uint32(3), count)
 }
 
 func TestCountCatalogEntries(t *testing.T) {

--- a/server/database/gorm/catalog.go
+++ b/server/database/gorm/catalog.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
+	"github.com/agntcy/dir/server/database/utils"
 	"github.com/agntcy/dir/server/types"
 	"gorm.io/gorm"
 )
@@ -46,6 +47,7 @@ func (d *DB) CountCatalogEntries(opts ...types.CatalogQueryOption) (uint32, erro
 	query = d.handleFilterOptions(query, &recordCfg)
 	query = applyKnownCatalogModuleFilter(query)
 	query = applyMediaTypeFilter(query, cfg.MediaTypeFilters)
+	query = applyTagFilter(query, cfg.TagFilters)
 	query = query.Distinct("records.record_cid")
 
 	var count int64
@@ -161,6 +163,7 @@ func (d *DB) GetCatalogEntries(opts ...types.CatalogQueryOption) ([]*catalogv1.C
 	query = d.handleFilterOptions(query, &recordCfg)
 	query = applyKnownCatalogModuleFilter(query)
 	query = applyMediaTypeFilter(query, cfg.MediaTypeFilters)
+	query = applyTagFilter(query, cfg.TagFilters)
 
 	query, err = applyCatalogOrder(query, &recordCfg)
 	if err != nil {
@@ -284,6 +287,84 @@ EXISTS (
 )`
 
 	return clause, args, nil
+}
+
+func applyTagFilter(query *gorm.DB, filters []types.TagFilter) *gorm.DB {
+	if len(filters) == 0 {
+		return query
+	}
+
+	conditions := make([]string, 0, len(filters))
+	args := make([]any, 0, len(filters))
+
+	for _, filter := range filters {
+		condition, filterArgs, err := tagExistsCondition(filter)
+		if err != nil {
+			logger.Error("unsupported tag filter", "error", err)
+
+			return query.Where("1 = 0")
+		}
+
+		if condition == "" {
+			continue
+		}
+
+		conditions = append(conditions, condition)
+		args = append(args, filterArgs...)
+	}
+
+	if len(conditions) == 0 {
+		return query
+	}
+
+	condition := strings.Join(conditions, " OR ")
+	if len(conditions) > 1 {
+		condition = "(" + condition + ")"
+	}
+
+	return query.Where(condition, args...)
+}
+
+func tagExistsCondition(filter types.TagFilter) (string, []any, error) {
+	switch {
+	case filter.SkillName != "":
+		condition, arg := utils.BuildSingleWildcardCondition("tag_skills.name", filter.SkillName)
+
+		return fmt.Sprintf(`
+EXISTS (
+	SELECT 1 FROM skills tag_skills
+	WHERE tag_skills.record_cid = records.record_cid
+	AND %s
+)`, condition), []any{arg}, nil
+	case filter.DomainName != "":
+		condition, arg := utils.BuildSingleWildcardCondition("tag_domains.name", filter.DomainName)
+
+		return fmt.Sprintf(`
+EXISTS (
+	SELECT 1 FROM domains tag_domains
+	WHERE tag_domains.record_cid = records.record_cid
+	AND %s
+)`, condition), []any{arg}, nil
+	case filter.Annotation != nil:
+		return `
+EXISTS (
+	SELECT 1 FROM annotations tag_annotations
+	WHERE tag_annotations.record_cid = records.record_cid
+	AND tag_annotations.key = ?
+	AND tag_annotations.value = ?
+)`, []any{filter.Annotation.Key, filter.Annotation.Value}, nil
+	case filter.AnnotationKey != "":
+		condition, arg := utils.BuildSingleWildcardCondition("tag_annotations.key", filter.AnnotationKey)
+
+		return fmt.Sprintf(`
+EXISTS (
+	SELECT 1 FROM annotations tag_annotations
+	WHERE tag_annotations.record_cid = records.record_cid
+	AND %s
+)`, condition), []any{arg}, nil
+	default:
+		return "", nil, fmt.Errorf("tag filter has no match criteria")
+	}
 }
 
 func convertScanReports(reports []ScanReport) []catalogv1.ScanReportSummary {

--- a/server/types/catalog.go
+++ b/server/types/catalog.go
@@ -8,11 +8,19 @@ import "fmt"
 type CatalogFilters struct {
 	RecordFilters
 	MediaTypeFilters []MediaTypeFilter
+	TagFilters       []TagFilter
 }
 
 type MediaTypeFilter struct {
 	ModuleName        string
 	ArtifactMediaType string
+}
+
+type TagFilter struct {
+	SkillName     string
+	DomainName    string
+	Annotation    *Annotation
+	AnnotationKey string
 }
 
 type CatalogQueryOption interface {
@@ -50,5 +58,11 @@ func CatalogFiltersFromOptions(opts ...CatalogQueryOption) (*CatalogFilters, err
 func WithMediaTypeFilters(filters ...MediaTypeFilter) CatalogFilterOption {
 	return func(cfg *CatalogFilters) {
 		cfg.MediaTypeFilters = append(cfg.MediaTypeFilters, filters...)
+	}
+}
+
+func WithTagFilters(filters ...TagFilter) CatalogFilterOption {
+	return func(cfg *CatalogFilters) {
+		cfg.TagFilters = append(cfg.TagFilters, filters...)
 	}
 }


### PR DESCRIPTION
right now, the ListAgent's endpoint's `tags` filter is not working correctly

<img width="413" height="707" alt="Screenshot 2026-07-29 at 10 47 29" src="https://github.com/user-attachments/assets/af22a418-e3f9-4ca0-9ecd-b3cc9c47297a" />

for example, if filtering for both a domain and a skill, it will "AND" the two conditions together. so it will show records that have both the domain and the skill

instead, what we want is to "OR" the two conditions together. so it should show records that have the domain, but also show records that have the skill
