### PR TITLE
chore(deps): align and bump zot and postgresql across all environments

### DIFF
--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -19,7 +19,7 @@ vars:
   # renovate: datasource=go depName=github.com/spiffe/spire versioning=semver
   SPIRE_VERSION: "1.15.2"
   # renovate: datasource=docker depName=docker.io/bitnami/postgresql
-  POSTGRESQL_VERSION: "latest@sha256:91a6c3f4b4d687546c1d07c1ef7c27a5e85e2a0ce8a192fe94cad5bbde0a1aba"
+  POSTGRESQL_VERSION: "latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163"
 
   ## Container images for vulnerability scanning
   VULN_SCAN_IMAGES:

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -666,7 +666,7 @@ postgresql:
     repository: bitnami/postgresql
     # renovate: datasource=docker depName=docker.io/bitnami/postgresql versioning=docker
     tag: latest
-    digest: "sha256:91a6c3f4b4d687546c1d07c1ef7c27a5e85e2a0ce8a192fe94cad5bbde0a1aba"
+    digest: "sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163"
   auth:
     username: "dir"
     password: "dirpassword"

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -591,7 +591,7 @@ apiserver:
       repository: bitnami/postgresql
       # renovate: datasource=docker depName=docker.io/bitnami/postgresql versioning=docker
       tag: latest
-      digest: "sha256:91a6c3f4b4d687546c1d07c1ef7c27a5e85e2a0ce8a192fe94cad5bbde0a1aba"
+      digest: "sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163"
     auth:
       username: "dir"
       password: "password"  # Default password for development

--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         condition: on-failure
 
   zot:
-    image: ghcr.io/project-zot/zot:v2.1.17
+    image: ghcr.io/project-zot/zot:v2.1.18
     ports:
       - 5555:5000
     deploy:
@@ -55,7 +55,7 @@ services:
         condition: on-failure
 
   postgres:
-    image: docker.io/bitnami/postgresql:latest@sha256:91a6c3f4b4d687546c1d07c1ef7c27a5e85e2a0ce8a192fe94cad5bbde0a1aba
+    image: docker.io/bitnami/postgresql:latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/tests/e2e/daemon/testenv/external/docker-compose.yaml
+++ b/tests/e2e/daemon/testenv/external/docker-compose.yaml
@@ -2,7 +2,7 @@ name: daemon-external
 
 services:
   zot:
-    image: ghcr.io/project-zot/zot:v2.1.16
+    image: ghcr.io/project-zot/zot:v2.1.18
     ports:
       - "25555:5000"
     deploy:
@@ -10,7 +10,7 @@ services:
         condition: on-failure
 
   postgres:
-    image: docker.io/bitnami/postgresql:latest@sha256:c30c796dcf96a67a405b905bf6aaf8d6c957d5c2fe729db6e67e2760e21fd9f8
+    image: docker.io/bitnami/postgresql:latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/tests/integration/server/testenv/docker-compose.yml
+++ b/tests/integration/server/testenv/docker-compose.yml
@@ -1,7 +1,7 @@
 name: dir-integration-tests-for-server
 services:
   zot:
-    image: ghcr.io/project-zot/zot:v2.1.15
+    image: ghcr.io/project-zot/zot:v2.1.18
     ports:
       - 5556:5000
     deploy:
@@ -10,7 +10,7 @@ services:
       restart_policy:
         condition: on-failure
   postgres:
-    image: docker.io/bitnami/postgresql@sha256:e8b68936d05ee665974430bb4765fedcdc5c9ba399e133e120e2deed77f54dbf
+    image: docker.io/bitnami/postgresql:latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163
     environment:
       POSTGRES_USER: ditfs_user
       POSTGRES_PASSWORD: ditfs_pass


### PR DESCRIPTION
Zot and PostgreSQL image versions had drifted across Docker Compose files for install, integration tests, and e2e tests — each environment was pinned to a different, older version. This PR standardises all of them to the current latest: zot `v2.1.18` and `bitnami/postgresql` at digest `sha256:cc46b913...`, matching what the canonical Taskfile.vars.yml already declared as the target.