### PR TITLE
fix(tests): start the runtime discovery workload after its record exists

### DIFF
--- a/.github/workflows/reusable-test-e2e.yaml
+++ b/.github/workflows/reusable-test-e2e.yaml
@@ -28,10 +28,8 @@ jobs:
             label: "Local"
           - task: e2e:test:network:local
             label: "Network"
-          # TODO: runtime tests disabled for now due to possible schema drift on the runtime side.
-          # TODO: investigate for details to reenable the test.
-          # - task: e2e:test:daemon:external
-          #   label: "Daemon External"
+          - task: e2e:test:daemon:external
+            label: "Daemon External"
           - task: e2e:test:integration-server:default
             label: "Integration Server"
     steps:

--- a/tests/e2e/daemon/01_daemon_test.go
+++ b/tests/e2e/daemon/01_daemon_test.go
@@ -5,9 +5,12 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	signv1 "github.com/agntcy/dir/api/sign/v1"
@@ -23,10 +26,60 @@ var (
 	sampleRuntimeRecordCID = "baeareiabbog2umgduqhlcb64fzt6adn34kblzvru3fdzkl75hjhwt6h3da"
 )
 
+// runtimeWorkloadService is the compose service holding the labelled container
+// the runtime discovery specs look for, and runtimeWorkloadProfile is the
+// profile keeping the testenv from starting it, so this suite controls when it
+// appears.
+const (
+	runtimeWorkloadService = "service-a2a"
+	runtimeWorkloadProfile = "runtime-discovery"
+)
+
 func cosignAvailable() bool {
 	_, err := exec.LookPath("cosign")
 
 	return err == nil
+}
+
+// composeWaitTimeout bounds the compose call below. It has to cover an image
+// pull on a cold runner, which moved into the suite when the service went
+// behind a profile. Without it a stalled pull is indistinguishable from a hung
+// suite until the two-hour go test timeout fires.
+const composeWaitTimeout = 90 * time.Second
+
+// startRuntimeWorkload brings up the labelled container.
+//
+// Ordering matters and is the substance of issue #1780. The daemon's OASF
+// resolver gives each workload a bounded retry budget, roughly 75s to 255s
+// depending on whether attempts fail fast or time out, and persists
+// `{"error": ...}` when the budget runs out. Nothing re-queues a workload
+// afterwards, so a workload discovered before its record exists can never
+// recover and the spec below is guaranteed to fail rather than merely be slow.
+//
+// Starting the container after the record has been pushed inverts that: the
+// docker start event is what queues the workload, and the record is already in
+// the store when the first resolve attempt runs.
+func startRuntimeWorkload(ctx context.Context, composeFile string) {
+	ginkgo.GinkgoHelper()
+
+	gomega.Expect(composeFile).NotTo(gomega.BeEmpty(),
+		"runtime_workload_compose_file must be set when runtime discovery tests are enabled")
+
+	cmdCtx, cancel := context.WithTimeout(ctx, composeWaitTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, "docker", "compose",
+		"-f", composeFile,
+		"--profile", runtimeWorkloadProfile,
+		"up", "--wait", "--wait-timeout", strconv.Itoa(int(composeWaitTimeout.Seconds())),
+		"-d", runtimeWorkloadService,
+	)
+
+	out, err := cmd.CombinedOutput()
+	ginkgo.GinkgoWriter.Printf("docker compose up %s:\n%s\n", runtimeWorkloadService, string(out))
+
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+		"failed to start %s: %s", runtimeWorkloadService, string(out))
 }
 
 var _ = ginkgo.Describe("Daemon e2e", ginkgo.Ordered, ginkgo.Serial, func() {
@@ -125,9 +178,9 @@ var _ = ginkgo.Describe("Daemon e2e", ginkgo.Ordered, ginkgo.Serial, func() {
 	})
 
 	ginkgo.Context("runtime workflow", ginkgo.Ordered, func() {
-		// Push the sample runtime record before the It block so the daemon's
-		// OASF resolver finds it within its bounded retry budget, instead of
-		// racing the resolver attempts from inside the spec.
+		// Push the record first, then start the workload that references it.
+		// Both halves matter: see startRuntimeWorkload for why the reverse
+		// order cannot recover.
 		ginkgo.BeforeAll(func(ctx context.Context) {
 			if !testEnv.Config.RunRuntimeDiscoveryTests {
 				ginkgo.Skip("skipping runtime tests")
@@ -140,39 +193,69 @@ var _ = ginkgo.Describe("Daemon e2e", ginkgo.Ordered, ginkgo.Serial, func() {
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(recordRef).NotTo(gomega.BeNil())
 			gomega.Expect(recordRef.GetCid()).To(gomega.Equal(sampleRuntimeRecordCID))
+
+			startRuntimeWorkload(ctx, testEnv.Config.RuntimeWorkloadComposeFile)
+		}, ginkgo.NodeTimeout(2*composeWaitTimeout))
+
+		// Registration is asserted separately from resolution so the two
+		// failure modes stay distinguishable. Registration depends only on the
+		// daemon receiving the docker start event; if the watcher was not
+		// listening yet the event is lost, because dir-runtime subscribes to
+		// the docker event stream without a `since` and only reconciles at
+		// boot. That failure should read as "the workload never appeared",
+		// not as a three-minute timeout that looks like a resolver problem.
+		ginkgo.It("runtime should register the docker workload", func(ctx context.Context) {
+			gomega.Eventually(func(g gomega.Gomega) {
+				discoverResp, err := testEnv.Client.ListWorkloads(ctx, nil)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(discoverResp).To(gomega.HaveLen(1))
+
+				workload := discoverResp[0]
+				g.Expect(workload.GetType()).To(gomega.Equal("container"))
+				g.Expect(workload.GetRuntime()).To(gomega.Equal("docker"))
+				g.Expect(workload.GetLabels()).To(gomega.HaveKeyWithValue("test.org.agntcy/agent-type", "a2a"))
+				g.Expect(workload.GetLabels()).To(gomega.HaveKeyWithValue("test.org.agntcy/agent-record", sampleRuntimeRecordCID))
+			}).
+				WithPolling(2 * time.Second).
+				WithTimeout(1 * time.Minute).
+				Should(gomega.Succeed())
 		})
 
-		// FIX Uncomment when https://github.com/agntcy/dir/issues/1780 is solved
-		// ginkgo.It("runtime should discover docker workloads", func(ctx context.Context) {
-		// 	gomega.Eventually(func(g gomega.Gomega) {
-		// 		// Discover runtimes workloads
-		// 		discoverResp, err := testEnv.Client.ListWorkloads(ctx, nil)
-		// 		g.Expect(err).NotTo(gomega.HaveOccurred())
-		// 		g.Expect(discoverResp).NotTo(gomega.BeNil())
-		// 		g.Expect(discoverResp).To(gomega.HaveLen(1))
+		// The resolver's own budget is minutes long, so this gets the longer
+		// timeout. It can only pass if the record was already in the store
+		// when the workload was queued, which the BeforeAll ordering ensures.
+		ginkgo.It("runtime should resolve the workload's OASF record", func(ctx context.Context) {
+			gomega.Eventually(func(g gomega.Gomega) {
+				discoverResp, err := testEnv.Client.ListWorkloads(ctx, nil)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(discoverResp).To(gomega.HaveLen(1))
 
-		// 		// Validate workload
-		// 		:= discoverResp[0]
-		// 		g.Expect(workload.GetType()).To(gomega.Equal("container"))
-		// 		g.Expect(workload.GetRuntime()).To(gomega.Equal("docker"))
-		// 		g.Expect(workload.GetLabels()).To(gomega.HaveKeyWithValue("test.org.agntcy/agent-type", "a2a"))
-		// 		g.Expect(workload.GetLabels()).To(gomega.HaveKeyWithValue("test.org.agntcy/agent-record", sampleRuntimeRecordCID))
-		// 		g.Expect(workload.GetServices()).To(gomega.Not(gomega.BeNil()))
+				workload := discoverResp[0]
+				g.Expect(workload.GetServices()).NotTo(gomega.BeNil())
 
-		// 		// Validate OASF service discovery data
-		// 		oasfService := workload.GetServices().GetOasf().AsMap()
-		// 		g.Expect(oasfService).NotTo(gomega.BeNil())
-		// 		g.Expect(oasfService).To(gomega.HaveKeyWithValue("cid", sampleRuntimeRecordCID))
-		// 		g.Expect(oasfService).To(gomega.HaveKey("record"))
+				// Validate OASF service discovery data. AsMap returns an empty
+				// non-nil map for an unset Oasf, so this starts empty rather
+				// than nil while the a2a resolver has run but the OASF one
+				// has not; the key assertions below are what gate on it.
+				oasfService := workload.GetServices().GetOasf().AsMap()
 
-		// 		// Validate discovered OASF record matches the original record
-		// 		oasfRecord, err := json.Marshal(oasfService["record"])
-		// 		g.Expect(err).NotTo(gomega.HaveOccurred())
-		// 		g.Expect(oasfRecord).To(gomega.MatchJSON(sampleRuntimeRecord))
-		// 	}).
-		// 		WithPolling(5 * time.Second).
-		// 		WithTimeout(3 * time.Minute).
-		// 		Should(gomega.Succeed())
-		// })
+				// A resolver that exhausted its retries persists an "error"
+				// key here instead of the record. Surface it rather than
+				// letting it fail as a missing "cid".
+				g.Expect(oasfService).NotTo(gomega.HaveKey("error"),
+					"resolver gave up before the record was reachable: %v", oasfService["error"])
+
+				g.Expect(oasfService).To(gomega.HaveKeyWithValue("cid", sampleRuntimeRecordCID))
+				g.Expect(oasfService).To(gomega.HaveKey("record"))
+
+				// Validate discovered OASF record matches the original record
+				oasfRecord, err := json.Marshal(oasfService["record"])
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(oasfRecord).To(gomega.MatchJSON(sampleRuntimeRecord))
+			}).
+				WithPolling(5 * time.Second).
+				WithTimeout(3 * time.Minute).
+				Should(gomega.Succeed())
+		})
 	})
 })

--- a/tests/e2e/daemon/config/config.go
+++ b/tests/e2e/daemon/config/config.go
@@ -9,6 +9,13 @@ type Config struct {
 	// Whether to run runtime tests.
 	RunRuntimeDiscoveryTests bool `json:"run_runtime_discovery_tests,omitempty" mapstructure:"run_runtime_discovery_tests"`
 
+	// Compose file holding the workload the runtime discovery tests start.
+	// Relative paths resolve against the test package directory, which is the
+	// working directory `go test -C` runs in. Only read when
+	// RunRuntimeDiscoveryTests is set: the testenvs share this package and
+	// only the external one defines such a workload.
+	RuntimeWorkloadComposeFile string `json:"runtime_workload_compose_file,omitempty" mapstructure:"runtime_workload_compose_file"`
+
 	// Client configuration for tests.
 	ClientOptions client.Config `json:"client_options" mapstructure:"client_options"`
 }

--- a/tests/e2e/daemon/testenv/external/Taskfile.testenv.yml
+++ b/tests/e2e/daemon/testenv/external/Taskfile.testenv.yml
@@ -17,11 +17,15 @@ tasks:
     vars:
       COMPOSE_PATH: "{{.ROOT_DIR}}/tests/e2e/daemon/testenv/external/docker-compose.yaml"
     cmds:
-      # Start the Docker Compose services
+      # Start the Docker Compose services.
+      #
+      # This deliberately does not start the discovery workload. It sits behind
+      # the "runtime-discovery" profile and is started by the suite itself,
+      # after its record has been pushed. See issue #1780.
       - |
         docker compose -f {{.COMPOSE_PATH}} up --wait -d
         sleep 10
-      
+
       # Start the directory node
       - task: setup-dir-node:up
 
@@ -32,6 +36,11 @@ tasks:
       # Stop the directory node
       - task: setup-dir-node:down
 
-      # Stop Docker Compose services
+      # Stop Docker Compose services.
+      #
+      # The profile is named so the discovery workload is torn down too,
+      # whether or not the suite got far enough to start it. Set through the
+      # environment rather than the top-level --profile flag, which Compose
+      # only grew in v2.24; this form works on every v2.
       - |
-        docker compose -f {{.COMPOSE_PATH}} down
+        COMPOSE_PROFILES=runtime-discovery docker compose -f {{.COMPOSE_PATH}} down

--- a/tests/e2e/daemon/testenv/external/docker-compose.yaml
+++ b/tests/e2e/daemon/testenv/external/docker-compose.yaml
@@ -26,8 +26,17 @@ services:
       retries: 30
       start_period: 5s
 
-  # Service used for runtime discovery
+  # Service used for runtime discovery.
+  #
+  # Held behind a profile so `docker compose up` does not start it with the
+  # rest of the stack. The daemon's OASF resolver gives each workload a bounded
+  # retry budget and never re-queues one whose budget ran out, so a workload
+  # that exists before its record does is unrecoverable. Starting this only
+  # after the record has been pushed makes the docker start event the trigger,
+  # with the record already in the store. Started by startRuntimeWorkload in
+  # tests/e2e/daemon/01_daemon_test.go. See issue #1780.
   service-a2a:
+    profiles: ["runtime-discovery"]
     image: nginx:latest@sha256:7f0adca1fc6c29c8dc49a2e90037a10ba20dc266baaed0988e9fb4d0d8b85ba0
     labels:
       - "test.org.agntcy/discover=true"

--- a/tests/e2e/daemon/testenv/external/test-config.yaml
+++ b/tests/e2e/daemon/testenv/external/test-config.yaml
@@ -1,5 +1,6 @@
 daemon:
   run_runtime_discovery_tests: true
+  runtime_workload_compose_file: "testenv/external/docker-compose.yaml"
   client_options:
     server_address: "localhost:19234"
     auth_mode: "insecure"


### PR DESCRIPTION
Closes #1780.

`docker compose up` started the labelled `service-a2a` container with the rest of the stack, ten seconds before the daemon. dir-runtime reconciles once at boot, queues every workload it finds, and gives each a bounded resolve budget: six attempts, 15s apart, 30s timeout each, so roughly 75s if attempts fail fast and 255s if they time out. The OASF record that workload's label references can only be pushed once the daemon is serving, from the suite's `BeforeAll`.

On a fast runner the record lands inside the budget and the spec passes. On a slow one the budget expires first, `resolveWorkload` persists `{"error": ...}` into the workload's OASF field, and nothing re-queues it â€” the only two writers to the work queue are boot reconciliation and new docker events. The three-minute `Eventually` cannot recover from that at any timeout, which fits the intermittency and fits why the earlier `BeforeAll` reordering reduced the flake without eliminating it.

## What changed

`service-a2a` moves behind a `runtime-discovery` compose profile, so the testenv no longer starts it. The suite starts it in `BeforeAll`, after the record push, which makes the docker start event the trigger with the record already in the store. The compose file path comes from `test-config.yaml` rather than being hardcoded, since the `default` and `external` testenvs share this Go package and only `external` has such a workload.

The spec is restored, split into registration and resolution. Registration depends only on the daemon seeing the start event; resolution depends on the record being reachable. Separating them means a lost event reads as "the workload never appeared" within a minute instead of a three-minute timeout that looks like a resolver fault. The resolution half asserts the absence of the `"error"` key directly, so an exhausted budget reports itself rather than surfacing as a missing `"cid"`.

It also did not compile as commented â€” `:= discoverResp[0]` had lost its variable name.

## What this does not fix, and what it costs

Registration previously had two independent triggers: boot reconciliation and the start event. The flake was that both fired too early. Deferring the container removes the reconciliation trigger outright, so registration now rests solely on the event stream, and that path is lossy â€” dir-runtime subscribes to docker events without a `since` and only starts watching after `reconcile` returns, so an event landing in that gap is gone. This trades a recoverable-looking flake for a rarer unrecoverable one. **A periodic re-reconcile in dir-runtime would make the ordering irrelevant, and is the real fix.** I'm happy to open that upstream if you agree it belongs there.

The mechanism above is derived from reading dir-runtime v1.3.4, not from logs of a failing run. Every step is in the source, but no failing run is cited.

## On re-enabling the CI job

The matrix entry is re-enabled here. Two caveats:

Its TODO gave a different reason from the flake â€” "possible schema drift on the runtime side." That is a real and separate risk this change does not touch: the resolution assertion compares the resolved record against the fixture with `MatchJSON`, and a serialization drift fails that regardless of ordering. I re-enabled it because a disabled job cannot tell us whether either problem is real, and dir-runtime has moved 1.3.3 â†’ 1.3.4 since it was turned off.

Also worth knowing: the job has been dark longer than the spec has been commented out, so `push`, `pull`, and the cosign sign/verify specs in this suite have not run in this environment either.

**If you would rather not have it back in the matrix yet, say so and I will drop that hunk â€” the ordering fix stands on its own.**

## Verification

Run locally, not just in CI. The bug is timing-dependent, so a single green run proves nothing; both orderings were given the same handicap, a 90s delay before the record push, standing in for a slow runner. That is longer than the resolver's ~75s minimum budget.

| | old ordering | with this change |
|---|---|---|
| boot reconcile | `workloads_registered=1` | `workloads_registered=0` |
| registration | at boot, before the record can exist | `event_type=added`, after the push |
| resolver | attempts 1&rarr;6, every one `record not found`, exhausted | resolves first try |
| suite | **FAIL** &mdash; 3 passed, 1 failed | **PASS** &mdash; 4 passed, 0 failed |
| exit code | **201** | 0 |

The old-ordering run exits **201**, the code #1780 reports. The resolver gave up about ten seconds before the record landed, and nothing re-queued it:

```
attempt=6 max_attempts=6 error="failed to pull OASF record baeareiabbog2...:
  rpc error: code = NotFound desc = failed to pull record: record not found"
```

The failure also lands exactly where the split puts it: under the old ordering the registration spec still passes, and only resolution fails. The workload was never undiscovered, it was discovered too early to resolve.

Unhandicapped, the suite passes locally as it does in CI: 4 of 6 specs, 0 failed. Two skip for want of cosign.

**No schema drift.** The `MatchJSON` comparison against the fixture passes at dir-runtime v1.3.4, locally and in CI, which answers the question the disabled job's TODO raised.

Environment: Docker 29.1.3, Compose 2.40.3, Go 1.26.5, Ubuntu 24.04. `go vet ./e2e/daemon/...` clean. The ordering claims were checked against the dir-runtime v1.3.4 source, then confirmed against its logs.
