### PR TITLE
fix(config): preserve unknown top-level config sections across writes

### DIFF
--- a/client/config/config.go
+++ b/client/config/config.go
@@ -5,10 +5,12 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -35,6 +37,22 @@ type File struct {
 	CurrentContext string             `yaml:"current_context"`
 	Contexts       map[string]Context `yaml:"contexts"`
 	Extractor      *Extractor         `yaml:"extractor,omitempty"`
+
+	// unknown holds top-level YAML sections this binary does not recognize,
+	// captured verbatim during a tolerant load so they survive a save. It keeps
+	// the file forward-compatible: an older dirctl must not silently drop
+	// sections written by a newer one. It is populated only by the tolerant load
+	// path (see loadFile); the strict LoadFile still rejects unknown keys. The
+	// field is unexported so yaml marshal/unmarshal ignore it, and SaveFile
+	// re-injects the sections explicitly.
+	unknown []unknownSection
+}
+
+// unknownSection is a top-level key/value pair captured verbatim as YAML nodes so
+// its value, nesting, and any comments are preserved across a write.
+type unknownSection struct {
+	key   *yaml.Node
+	value *yaml.Node
 }
 
 // Extractor is the machine-wide OASF taxonomy extractor provisioning record,
@@ -142,13 +160,12 @@ func loadFile(path string, allowUnknownFields bool) (*File, error) {
 		path = defaultPath
 	}
 
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open client config file %s: %w", path, err)
 	}
-	defer f.Close()
 
-	decoder := yaml.NewDecoder(f)
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(!allowUnknownFields)
 
 	file := &File{}
@@ -160,11 +177,85 @@ func loadFile(path string, allowUnknownFields bool) (*File, error) {
 		file.Contexts = map[string]Context{}
 	}
 
+	// When unknown fields are tolerated, capture any top-level sections not
+	// represented on File so SaveFile can write them back untouched. The strict
+	// path never reaches here with unknown keys (Decode already errored), so its
+	// rejection behavior is unchanged.
+	if allowUnknownFields {
+		if err := captureUnknownSections(data, file); err != nil {
+			return nil, fmt.Errorf("failed to parse client config file %s: %w", path, err)
+		}
+	}
+
 	if err := validateContextNames(file); err != nil {
 		return nil, fmt.Errorf("invalid client config file %s: %w", path, err)
 	}
 
 	return file, nil
+}
+
+// captureUnknownSections records every top-level mapping key of data that is not
+// a recognized File field, storing the original YAML nodes so a later SaveFile
+// re-emits them verbatim. Scope is deliberately top-level only: nested unknown
+// keys inside recognized sections are out of scope for this preservation.
+func captureUnknownSections(data []byte, file *File) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return err
+	}
+
+	if len(doc.Content) == 0 {
+		return nil
+	}
+
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	known := knownTopLevelKeys()
+
+	// Mapping content is a flat [key, value, key, value, ...] slice.
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		keyNode := root.Content[i]
+		valueNode := root.Content[i+1]
+
+		if _, ok := known[keyNode.Value]; ok {
+			continue
+		}
+
+		file.unknown = append(file.unknown, unknownSection{key: keyNode, value: valueNode})
+	}
+
+	return nil
+}
+
+// knownTopLevelKeys returns the set of YAML keys represented on File, derived
+// from struct tags so it stays correct as recognized sections are added.
+func knownTopLevelKeys() map[string]struct{} {
+	fileType := reflect.TypeOf(File{})
+	keys := make(map[string]struct{}, fileType.NumField())
+
+	for i := range fileType.NumField() {
+		field := fileType.Field(i)
+		if field.PkgPath != "" { // unexported field, e.g. unknown
+			continue
+		}
+
+		tag := field.Tag.Get("yaml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+
+		name := strings.Split(tag, ",")[0]
+		if name == "" {
+			continue
+		}
+
+		keys[name] = struct{}{}
+	}
+
+	return keys
 }
 
 // DefaultPath returns the default reusable client config file path.
@@ -365,7 +456,7 @@ func SaveFile(path string, file *File) error {
 		return fmt.Errorf("invalid client config file %s: %w", path, err)
 	}
 
-	data, err := yaml.Marshal(file)
+	data, err := marshalFile(file)
 	if err != nil {
 		return fmt.Errorf("failed to encode client config file %s: %w", path, err)
 	}
@@ -379,6 +470,26 @@ func SaveFile(path string, file *File) error {
 	}
 
 	return nil
+}
+
+// marshalFile encodes the recognized File fields and then re-appends any
+// unknown top-level sections captured on load, so a load→save cycle is lossless
+// for sections this binary does not model. Recognized sections keep their
+// declared order; preserved unknown sections follow them.
+func marshalFile(file *File) ([]byte, error) {
+	var root yaml.Node
+	if err := root.Encode(file); err != nil {
+		return nil, err
+	}
+
+	// root is a MappingNode; appending key/value node pairs preserves the
+	// original sections. Keys captured as unknown never collide with recognized
+	// keys (captureUnknownSections excludes them), so no duplicate keys arise.
+	for _, section := range file.unknown {
+		root.Content = append(root.Content, section.key, section.value)
+	}
+
+	return yaml.Marshal(&root)
 }
 
 // atomicWriteFile writes data to a temp file in the same directory and renames it

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -201,7 +201,7 @@ func loadFile(path string, allowUnknownFields bool) (*File, error) {
 func captureUnknownSections(data []byte, file *File) error {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return err
+		return fmt.Errorf("parse yaml document: %w", err)
 	}
 
 	if len(doc.Content) == 0 {
@@ -224,32 +224,86 @@ func captureUnknownSections(data []byte, file *File) error {
 			continue
 		}
 
-		file.unknown = append(file.unknown, unknownSection{key: keyNode, value: valueNode})
+		file.unknown = append(file.unknown, unknownSection{
+			key:   inlineAliases(keyNode, make(map[*yaml.Node]struct{})),
+			value: inlineAliases(valueNode, make(map[*yaml.Node]struct{})),
+		})
 	}
 
 	return nil
 }
 
+// inlineAliases returns node with every alias replaced by a copy of what it
+// points at.
+//
+// Preserving an alias verbatim is not safe here. Recognized sections are
+// re-encoded from the typed struct on write, which emits no anchors, so an
+// alias in an unknown section whose anchor was defined inside a recognized one
+// would be written out dangling. The result is a config no version of the
+// binary can load, which is worse than the dropped section this preservation
+// exists to prevent. Inlining is value-preserving, since an alias means exactly
+// the node it references; only the indirection is lost.
+//
+// visiting guards against an anchor that contains a reference to itself, which
+// would otherwise recurse forever.
+func inlineAliases(node *yaml.Node, visiting map[*yaml.Node]struct{}) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+
+	if _, cycle := visiting[node]; cycle {
+		return node
+	}
+
+	visiting[node] = struct{}{}
+	defer delete(visiting, node)
+
+	if node.Kind == yaml.AliasNode {
+		return inlineAliases(node.Alias, visiting)
+	}
+
+	clone := *node
+
+	// Anchors go too. Once aliases are inlined nothing refers to them, and a
+	// definition left behind would re-declare a name whose other uses, in the
+	// recognized sections, no longer exist.
+	clone.Anchor = ""
+
+	if len(node.Content) > 0 {
+		clone.Content = make([]*yaml.Node, len(node.Content))
+		for i, child := range node.Content {
+			clone.Content[i] = inlineAliases(child, visiting)
+		}
+	}
+
+	return &clone
+}
+
 // knownTopLevelKeys returns the set of YAML keys represented on File, derived
 // from struct tags so it stays correct as recognized sections are added.
+//
+// The derivation has to agree with what the yaml encoder actually emits, or a
+// key is both captured as unknown and written by the struct marshal, producing
+// a duplicate key that makes the file unloadable. That is why an untagged
+// field falls back to the lowercased field name, which is the encoder's own
+// default, rather than being skipped.
 func knownTopLevelKeys() map[string]struct{} {
-	fileType := reflect.TypeOf(File{})
+	fileType := reflect.TypeFor[File]()
 	keys := make(map[string]struct{}, fileType.NumField())
 
-	for i := range fileType.NumField() {
-		field := fileType.Field(i)
-		if field.PkgPath != "" { // unexported field, e.g. unknown
+	for field := range fileType.Fields() {
+		if !field.IsExported() { // e.g. unknown
 			continue
 		}
 
 		tag := field.Tag.Get("yaml")
-		if tag == "" || tag == "-" {
+		if tag == "-" {
 			continue
 		}
 
 		name := strings.Split(tag, ",")[0]
 		if name == "" {
-			continue
+			name = strings.ToLower(field.Name)
 		}
 
 		keys[name] = struct{}{}
@@ -438,6 +492,12 @@ func SetCurrentContext(path string, name string) (*ResolvedContext, error) {
 }
 
 // SaveFile writes a reusable client context config file.
+//
+// Preserving unrecognized top-level sections requires file to have come from
+// the tolerant load path, which is where they are captured; every writer in
+// this package does that. A File built by hand, or loaded through the strict
+// LoadFile, carries none, so saving it drops any section this binary does not
+// model. Only whole-document rewrites should do that deliberately.
 func SaveFile(path string, file *File) error {
 	if path == "" {
 		defaultPath, err := DefaultPath()
@@ -479,17 +539,24 @@ func SaveFile(path string, file *File) error {
 func marshalFile(file *File) ([]byte, error) {
 	var root yaml.Node
 	if err := root.Encode(file); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encode config fields: %w", err)
 	}
 
 	// root is a MappingNode; appending key/value node pairs preserves the
-	// original sections. Keys captured as unknown never collide with recognized
-	// keys (captureUnknownSections excludes them), so no duplicate keys arise.
+	// original sections. A captured key never collides with a recognized one
+	// so long as knownTopLevelKeys agrees with what this Encode emits, which
+	// is the reason it falls back to the encoder's own default naming rather
+	// than skipping untagged fields.
 	for _, section := range file.unknown {
 		root.Content = append(root.Content, section.key, section.value)
 	}
 
-	return yaml.Marshal(&root)
+	data, err := yaml.Marshal(&root)
+	if err != nil {
+		return nil, fmt.Errorf("encode config file: %w", err)
+	}
+
+	return data, nil
 }
 
 // atomicWriteFile writes data to a temp file in the same directory and renames it

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -11,6 +11,7 @@ import (
 	dirclient "github.com/agntcy/dir/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestDefaultPath(t *testing.T) {
@@ -807,4 +808,147 @@ func resetClientEnv(t *testing.T) {
 			_ = os.Setenv(key, original[key]) //nolint:usetesting // Restoring process env after manual unset.
 		}
 	})
+}
+
+// readRawConfig parses the on-disk config into an untyped map, bypassing the
+// strict/tolerant typed decoders so tests can assert on unknown top-level keys
+// that LoadFile would reject.
+func readRawConfig(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	out := map[string]any{}
+	require.NoError(t, yaml.Unmarshal(data, &out))
+
+	return out
+}
+
+func TestSaveContextPreservesUnknownTopLevelSections(t *testing.T) {
+	path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.example.com:443
+experimental:
+  feature_flags:
+    - alpha
+    - beta
+telemetry:
+  enabled: true
+`)
+
+	// A write through the tolerant save path must not drop top-level sections
+	// this binary does not recognize.
+	require.NoError(t, SaveContext(path, "prod", Context{ServerAddress: "prod:443"}, false))
+
+	raw := readRawConfig(t, path)
+
+	// Known sections are updated as requested.
+	assert.Equal(t, "dev", raw["current_context"])
+	contexts, ok := raw["contexts"].(map[string]any)
+	require.True(t, ok, "contexts must remain a mapping")
+	assert.Contains(t, contexts, "dev")
+	assert.Contains(t, contexts, "prod")
+
+	// Unknown sections survive intact, values and nesting preserved.
+	experimental, ok := raw["experimental"].(map[string]any)
+	require.True(t, ok, "experimental section must survive the write")
+	assert.Equal(t, []any{"alpha", "beta"}, experimental["feature_flags"])
+
+	telemetry, ok := raw["telemetry"].(map[string]any)
+	require.True(t, ok, "telemetry section must survive the write")
+	assert.Equal(t, true, telemetry["enabled"])
+}
+
+func TestSaveExtractorPreservesUnknownTopLevelSections(t *testing.T) {
+	path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.example.com:443
+future_section:
+  some_key: some_value
+`)
+
+	require.NoError(t, SaveExtractor(path, &Extractor{OASFURL: "https://x", AssetDir: "/a"}))
+
+	raw := readRawConfig(t, path)
+	assert.Contains(t, raw, "extractor")
+	future, ok := raw["future_section"].(map[string]any)
+	require.True(t, ok, "future_section must survive the write")
+	assert.Equal(t, "some_value", future["some_key"])
+}
+
+func TestSetCurrentContextPreservesUnknownTopLevelSections(t *testing.T) {
+	path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.example.com:443
+  prod:
+    server_address: prod.example.com:443
+future_section:
+  some_key: some_value
+`)
+
+	_, err := SetCurrentContext(path, "prod")
+	require.NoError(t, err)
+
+	raw := readRawConfig(t, path)
+	assert.Equal(t, "prod", raw["current_context"])
+	future, ok := raw["future_section"].(map[string]any)
+	require.True(t, ok, "future_section must survive the write")
+	assert.Equal(t, "some_value", future["some_key"])
+}
+
+func TestSaveContextPreservesFileWithOnlyUnknownSections(t *testing.T) {
+	path := writeConfig(t, `
+future_section:
+  some_key: some_value
+`)
+
+	require.NoError(t, SaveContext(path, "local", Context{ServerAddress: "localhost:8888"}, true))
+
+	raw := readRawConfig(t, path)
+	assert.Equal(t, "local", raw["current_context"])
+	contexts, ok := raw["contexts"].(map[string]any)
+	require.True(t, ok, "contexts must be written")
+	assert.Contains(t, contexts, "local")
+	future, ok := raw["future_section"].(map[string]any)
+	require.True(t, ok, "future_section must survive the write")
+	assert.Equal(t, "some_value", future["some_key"])
+}
+
+func TestSaveContextNoUnknownSectionsIsClean(t *testing.T) {
+	path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev:
+    server_address: dev.example.com:443
+`)
+
+	require.NoError(t, SaveContext(path, "prod", Context{ServerAddress: "prod:443"}, false))
+
+	// A file with no unknown sections round-trips through the strict loader,
+	// proving no stray keys were introduced by the preservation machinery.
+	file, err := LoadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "dev", file.CurrentContext)
+	require.Contains(t, file.Contexts, "dev")
+	require.Contains(t, file.Contexts, "prod")
+}
+
+func TestSaveContextOnEmptyMappingFile(t *testing.T) {
+	// An empty YAML mapping has no sections to preserve; the save path must not
+	// choke on it and must produce a clean, strictly-loadable file.
+	path := writeConfig(t, "{}\n")
+
+	require.NoError(t, SaveContext(path, "local", Context{ServerAddress: "localhost:8888"}, true))
+
+	file, err := LoadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "local", file.CurrentContext)
+	require.Contains(t, file.Contexts, "local")
 }

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -14,6 +14,10 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
+// testProdAddress is shared by the several save-path tests that write a
+// second context, so the literal does not repeat across the file.
+const testProdAddress = "prod:443"
+
 func TestDefaultPath(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
 
@@ -698,7 +702,7 @@ func TestSaveContextPreservesOtherConfigAndHonorsSetCurrentFalse(t *testing.T) {
 
 	// Seed an extractor section and a pre-existing current_context.
 	require.NoError(t, SaveExtractor("", &Extractor{OASFURL: "https://x", AssetDir: "/a"}))
-	require.NoError(t, SaveContext("", "prod", Context{ServerAddress: "prod:443"}, true))
+	require.NoError(t, SaveContext("", "prod", Context{ServerAddress: testProdAddress}, true))
 
 	// Adding another context with setCurrent=false must not change current_context
 	// and must preserve the extractor section and the existing context.
@@ -841,7 +845,7 @@ telemetry:
 
 	// A write through the tolerant save path must not drop top-level sections
 	// this binary does not recognize.
-	require.NoError(t, SaveContext(path, "prod", Context{ServerAddress: "prod:443"}, false))
+	require.NoError(t, SaveContext(path, "prod", Context{ServerAddress: testProdAddress}, false))
 
 	raw := readRawConfig(t, path)
 
@@ -916,6 +920,7 @@ future_section:
 	contexts, ok := raw["contexts"].(map[string]any)
 	require.True(t, ok, "contexts must be written")
 	assert.Contains(t, contexts, "local")
+
 	future, ok := raw["future_section"].(map[string]any)
 	require.True(t, ok, "future_section must survive the write")
 	assert.Equal(t, "some_value", future["some_key"])
@@ -929,7 +934,7 @@ contexts:
     server_address: dev.example.com:443
 `)
 
-	require.NoError(t, SaveContext(path, "prod", Context{ServerAddress: "prod:443"}, false))
+	require.NoError(t, SaveContext(path, "prod", Context{ServerAddress: testProdAddress}, false))
 
 	// A file with no unknown sections round-trips through the strict loader,
 	// proving no stray keys were introduced by the preservation machinery.
@@ -938,6 +943,41 @@ contexts:
 	assert.Equal(t, "dev", file.CurrentContext)
 	require.Contains(t, file.Contexts, "dev")
 	require.Contains(t, file.Contexts, "prod")
+}
+
+func TestSaveContextInlinesAliasesIntoUnknownSections(t *testing.T) {
+	// The anchor lives in a recognized section, the alias in an unknown one.
+	// Recognized sections are re-encoded from the struct and emit no anchors,
+	// so preserving the alias verbatim writes a dangling reference and leaves
+	// a config that no longer loads at all.
+	path := writeConfig(t, `
+current_context: dev
+contexts:
+  dev: &devctx
+    server_address: dev.example.com:443
+future:
+  copied_from: *devctx
+`)
+
+	require.NoError(t, SaveContext(path, "prod", Context{ServerAddress: testProdAddress}, false))
+
+	// Before aliases were inlined this failed with
+	// `yaml: unknown anchor 'devctx' referenced`.
+	raw := readRawConfig(t, path)
+
+	future, ok := raw["future"].(map[string]any)
+	require.True(t, ok, "future section must survive the write")
+
+	// The alias resolves to the value it referred to rather than being dropped.
+	copied, ok := future["copied_from"].(map[string]any)
+	require.True(t, ok, "aliased value must be inlined as a mapping")
+	assert.Equal(t, "dev.example.com:443", copied["server_address"])
+
+	// The tolerant path is the one the writers use. Strict LoadFile would
+	// reject "future" by design, which is a separate contract.
+	reloaded, err := loadFile(path, true)
+	require.NoError(t, err, "written config must remain loadable")
+	assert.Contains(t, reloaded.Contexts, "prod")
 }
 
 func TestSaveContextOnEmptyMappingFile(t *testing.T) {


### PR DESCRIPTION
Closes #1777.

`SaveFile` and its callers (`SaveContext`, `SaveExtractor`, `SetCurrentContext`, `ClearExtractor`) decode the config into the typed `File` struct and re-marshal it, so any top-level YAML key not modeled on `File` is dropped on write. An older `dirctl` silently discards a section a newer one wrote.

The issue notes why the obvious fix is wrong: an `,inline` catch-all on `File` would absorb unknown keys and break the strict-rejection contract `LoadFile` and `TestLoadFile` rely on. So this separates the two concerns instead, taking the `yaml.Node` approach the issue suggests.

## How it works

The tolerant load path (`loadFile` with `allowUnknownFields=true`) parses the raw bytes into a `yaml.Node` tree alongside the typed decode, and records every top-level key not represented on `File` as its original nodes. `SaveFile` re-appends them after encoding the known fields. Strict `LoadFile` is untouched and still rejects unknown keys — capture is gated on the tolerant flag and is unreachable from the strict path, since `Decode` has already errored.

Scope is top-level only, as the issue specifies. All four writers go through the tolerant path, so the preservation applies wherever it matters.

## Two hazards this had to handle

An adversarial review pass caught both, and each would have produced a config **no version of dirctl could load** — strictly worse than the dropped section this fixes. They're the reason for the second commit.

**Aliases.** Recognized sections are re-encoded from the struct and emit no anchors. An unknown section containing an alias to an anchor defined in a recognized section — `contexts: dev: &devctx` plus `future: {copied_from: *devctx}` — was written out dangling, and every later load failed with `yaml: unknown anchor 'devctx' referenced`. Captured nodes now have aliases inlined and anchors stripped. That's value-preserving: an alias means exactly the node it references, and only the indirection is lost. A `visiting` set guards the self-referential case.

**Key-set derivation.** `knownTopLevelKeys` read yaml struct tags but skipped untagged fields, while the encoder falls back to the lowercased field name. A future untagged field would therefore be captured as unknown *and* emitted by the struct marshal — a duplicate top-level key, which is a load error. Latent today since all three fields are tagged, but it's precisely the trap the next contributor would hit. The derivation now uses the encoder's own fallback.

## Verification

`go test ./config/...` passes. The alias fix has a regression test that reproduces the exact original failure when the inlining is removed, and the four preservation tests were mutation-checked — removing the re-append in `marshalFile`, or no-oping the capture, turns them red. `golangci-lint run ./config/...` is at the same baseline as `upstream/main` (10 goconst, plus 2 gci that are a local CRLF artifact): no new issues.

## Known limits, stated rather than implied

- **Single document.** A second YAML document after `---` was dropped before this change and still is; both the decoder and the capture pass see only the first.
- **A leading file comment** does not survive, since it attaches to the first known key, which is re-encoded. Comments attached to *unknown* sections do survive, including inline ones.
- **`SaveFile` is still lossy for a hand-built `File`.** Only a `File` from the tolerant load carries the sections. Every in-repo writer does; the doc comment now says so, since it's exported client API.

Happy to squash the two commits if you'd prefer a single one — I kept them separate because the second is a distinct set of fixes with its own reasoning.
