### PR TITLE
chore(deps): bump bitnami/postgresql digest to fix CVE-2026-40469 and CVE-2026-40468 

### DIFF
--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -22,7 +22,7 @@ vars:
   # renovate: datasource=go depName=github.com/spiffe/spire versioning=semver
   SPIRE_VERSION: "1.15.2"
   # renovate: datasource=docker depName=docker.io/bitnami/postgresql
-  POSTGRESQL_VERSION: "latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163"
+  POSTGRESQL_VERSION: "latest@sha256:a727ea9d5ceb64beb404afeb62a4b757fe3c33c2a09af86dc391a3a0dfed6049"
 
   ## Container images for vulnerability scanning
   VULN_SCAN_IMAGES:

--- a/install/charts/dir/apiserver/values.yaml
+++ b/install/charts/dir/apiserver/values.yaml
@@ -666,7 +666,7 @@ postgresql:
     repository: bitnami/postgresql
     # renovate: datasource=docker depName=docker.io/bitnami/postgresql versioning=docker
     tag: latest
-    digest: "sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163"
+    digest: "sha256:a727ea9d5ceb64beb404afeb62a4b757fe3c33c2a09af86dc391a3a0dfed6049"
   auth:
     username: "dir"
     password: "dirpassword"

--- a/install/charts/dir/values.yaml
+++ b/install/charts/dir/values.yaml
@@ -591,7 +591,7 @@ apiserver:
       repository: bitnami/postgresql
       # renovate: datasource=docker depName=docker.io/bitnami/postgresql versioning=docker
       tag: latest
-      digest: "sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163"
+      digest: "sha256:a727ea9d5ceb64beb404afeb62a4b757fe3c33c2a09af86dc391a3a0dfed6049"
     auth:
       username: "dir"
       password: "password"  # Default password for development

--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         condition: on-failure
 
   postgres:
-    image: docker.io/bitnami/postgresql:latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163
+    image: docker.io/bitnami/postgresql:latest@sha256:a727ea9d5ceb64beb404afeb62a4b757fe3c33c2a09af86dc391a3a0dfed6049
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/tests/e2e/daemon/testenv/external/docker-compose.yaml
+++ b/tests/e2e/daemon/testenv/external/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         condition: on-failure
 
   postgres:
-    image: docker.io/bitnami/postgresql:latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163
+    image: docker.io/bitnami/postgresql:latest@sha256:a727ea9d5ceb64beb404afeb62a4b757fe3c33c2a09af86dc391a3a0dfed6049
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/tests/integration/server/testenv/docker-compose.yml
+++ b/tests/integration/server/testenv/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       restart_policy:
         condition: on-failure
   postgres:
-    image: docker.io/bitnami/postgresql:latest@sha256:cc46b91332b9e931019b8657fd046d9abab343c45f7c7616121e19006e027163
+    image: docker.io/bitnami/postgresql:latest@sha256:a727ea9d5ceb64beb404afeb62a4b757fe3c33c2a09af86dc391a3a0dfed6049
     environment:
       POSTGRES_USER: ditfs_user
       POSTGRES_PASSWORD: ditfs_pass


### PR DESCRIPTION
## Summary

Bump the pinned `bitnami/postgresql` image digest to remediate **CVE-2026-40469** and **CVE-2026-40468** (gawk in Photon OS).

The old digest was stale; the new `latest` image includes `gawk 5.3.2-5.ph5` and scans clean with Trivy 0.69.3 (`--ignore-unfixed`).

Closes #1944
Closes #1945