### PR TITLE
feat(cli): support batch delete from stdin

### DIFF
--- a/cli/cmd/delete/delete.go
+++ b/cli/cmd/delete/delete.go
@@ -10,19 +10,25 @@ import (
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/dir/cli/presenter"
+	cidutil "github.com/agntcy/dir/cli/util/cids"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	// Add output format flags
 	presenter.AddOutputFlags(Command)
+	Command.Flags().BoolVar(&deleteOpts.FromStdin, "stdin", false,
+		"Read CIDs from standard input. Supports JSON array output from 'dirctl search --output json' and line-delimited CIDs.")
+}
+
+var deleteOpts struct {
+	FromStdin bool
 }
 
 var Command = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete record from Directory store",
-	Long: `This command deletes a record from the Directory store.
+	Use:   "delete <cid> [cid...]",
+	Short: "Delete records from Directory store",
+	Long: `This command deletes records from the Directory store.
 
 Usage examples:
 
@@ -30,39 +36,66 @@ Usage examples:
 
 	dirctl delete <cid>
 
-2. Output formats:
+2. Delete multiple records in a single request:
+
+	dirctl delete <cid1> <cid2> <cid3>
+
+3. Delete records from stdin (JSON array or line-delimited CIDs):
+
+	dirctl search --format cid --limit 100 --output json | dirctl delete --stdin
+
+4. Output formats:
 
 	# Delete with JSON confirmation
 	dirctl delete <cid> --output json
-	
+
 	# Delete with raw output for scripting
 	dirctl delete <cid> --output raw
 
 `,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("cid is a required argument")
+	Args: func(cmd *cobra.Command, args []string) error {
+		if deleteOpts.FromStdin {
+			return cobra.MaximumNArgs(0)(cmd, args)
 		}
-
-		return runCommand(cmd, args[0])
+		return cobra.MinimumNArgs(1)(cmd, args)
 	},
+	RunE: runCommand,
 }
 
-func runCommand(cmd *cobra.Command, cid string) error {
-	// Get the client from the context.
+func runCommand(cmd *cobra.Command, args []string) error {
 	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
 	if !ok {
 		return errors.New("failed to get client from context")
 	}
 
-	// Delete object from store
-	err := c.Delete(cmd.Context(), &corev1.RecordRef{
-		Cid: cid,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to delete record: %w", err)
+	cids := append([]string{}, args...)
+	if deleteOpts.FromStdin {
+		stdinCIDs, err := cidutil.ReadFrom(cmd.InOrStdin())
+		if err != nil {
+			return fmt.Errorf("failed to read CIDs from stdin: %w", err)
+		}
+		cids = append(cids, stdinCIDs...)
+	}
+	cids = cidutil.Deduplicate(cids)
+	if len(cids) == 0 {
+		return errors.New("at least one CID is required (pass arguments or use --stdin)")
 	}
 
-	// Output in the appropriate format
-	return presenter.PrintMessage(cmd, "record", "Deleted record with CID", cid)
+	recordRefs := make([]*corev1.RecordRef, 0, len(cids))
+	for _, cid := range cids {
+		recordRefs = append(recordRefs, &corev1.RecordRef{Cid: cid})
+	}
+	if err := c.DeleteBatch(cmd.Context(), recordRefs); err != nil {
+		return fmt.Errorf("failed to delete records: %w", err)
+	}
+
+	result := map[string]any{
+		"count":  len(cids),
+		"cids":   cids,
+		"status": "Successfully deleted records",
+	}
+	if len(cids) == 1 {
+		result["cid"] = cids[0]
+	}
+	return presenter.PrintMessage(cmd, "Delete", "Successfully deleted record(s)", result)
 }

--- a/cli/cmd/routing/publish.go
+++ b/cli/cmd/routing/publish.go
@@ -5,16 +5,14 @@
 package routing
 
 import (
-	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	routingv1 "github.com/agntcy/dir/api/routing/v1"
 	"github.com/agntcy/dir/cli/presenter"
+	cidutil "github.com/agntcy/dir/cli/util/cids"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/spf13/cobra"
 )
@@ -85,7 +83,7 @@ func runPublishCommand(cmd *cobra.Command, args []string) error {
 	cids := append([]string{}, args...)
 
 	if publishOpts.FromStdin {
-		stdinCIDs, err := readCIDsFromStdin(cmd.InOrStdin())
+		stdinCIDs, err := cidutil.ReadFrom(cmd.InOrStdin())
 		if err != nil {
 			return fmt.Errorf("failed to read CIDs from stdin: %w", err)
 		}
@@ -93,7 +91,7 @@ func runPublishCommand(cmd *cobra.Command, args []string) error {
 		cids = append(cids, stdinCIDs...)
 	}
 
-	cids = deduplicateCIDs(cids)
+	cids = cidutil.Deduplicate(cids)
 	if len(cids) == 0 {
 		return errors.New("at least one CID is required (pass arguments or use --stdin)")
 	}
@@ -137,64 +135,4 @@ func runPublishCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	return presenter.PrintMessage(cmd, "Publish", "Successfully submitted publication request", result)
-}
-
-func readCIDsFromStdin(reader io.Reader) ([]string, error) {
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stdin: %w", err)
-	}
-
-	input := strings.TrimSpace(string(data))
-	if input == "" {
-		return nil, nil
-	}
-
-	if strings.HasPrefix(input, "[") {
-		var cids []string
-		if err := json.Unmarshal([]byte(input), &cids); err != nil {
-			return nil, fmt.Errorf("failed to parse JSON array of CIDs: %w", err)
-		}
-
-		return cids, nil
-	}
-
-	cids := make([]string, 0)
-
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	for scanner.Scan() {
-		cid := strings.TrimSpace(scanner.Text())
-		if cid == "" {
-			continue
-		}
-
-		cids = append(cids, cid)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan stdin: %w", err)
-	}
-
-	return cids, nil
-}
-
-func deduplicateCIDs(cids []string) []string {
-	seen := make(map[string]struct{}, len(cids))
-	out := make([]string, 0, len(cids))
-
-	for _, cid := range cids {
-		cid = strings.TrimSpace(cid)
-		if cid == "" {
-			continue
-		}
-
-		if _, exists := seen[cid]; exists {
-			continue
-		}
-
-		seen[cid] = struct{}{}
-		out = append(out, cid)
-	}
-
-	return out
 }

--- a/cli/cmd/routing/unpublish.go
+++ b/cli/cmd/routing/unpublish.go
@@ -11,6 +11,7 @@ import (
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	routingv1 "github.com/agntcy/dir/api/routing/v1"
 	"github.com/agntcy/dir/cli/presenter"
+	cidutil "github.com/agntcy/dir/cli/util/cids"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/spf13/cobra"
 )
@@ -79,7 +80,7 @@ func runUnpublishCommand(cmd *cobra.Command, args []string) error {
 	cids := append([]string{}, args...)
 
 	if unpublishOpts.FromStdin {
-		stdinCIDs, err := readCIDsFromStdin(cmd.InOrStdin())
+		stdinCIDs, err := cidutil.ReadFrom(cmd.InOrStdin())
 		if err != nil {
 			return fmt.Errorf("failed to read CIDs from stdin: %w", err)
 		}
@@ -87,7 +88,7 @@ func runUnpublishCommand(cmd *cobra.Command, args []string) error {
 		cids = append(cids, stdinCIDs...)
 	}
 
-	cids = deduplicateCIDs(cids)
+	cids = cidutil.Deduplicate(cids)
 	if len(cids) == 0 {
 		return errors.New("at least one CID is required (pass arguments or use --stdin)")
 	}

--- a/cli/util/cids/cids.go
+++ b/cli/util/cids/cids.go
@@ -1,0 +1,63 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package cids
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ReadFrom reads a JSON array or newline-delimited CIDs from reader.
+func ReadFrom(reader io.Reader) ([]string, error) {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdin: %w", err)
+	}
+
+	input := strings.TrimSpace(string(data))
+	if input == "" {
+		return nil, nil
+	}
+
+	if strings.HasPrefix(input, "[") {
+		var values []string
+		if err := json.Unmarshal([]byte(input), &values); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON array of CIDs: %w", err)
+		}
+		return values, nil
+	}
+
+	values := make([]string, 0)
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for scanner.Scan() {
+		if cid := strings.TrimSpace(scanner.Text()); cid != "" {
+			values = append(values, cid)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan stdin: %w", err)
+	}
+	return values, nil
+}
+
+// Deduplicate removes blank and repeated CIDs while preserving input order.
+func Deduplicate(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/cli/util/cids/cids_test.go
+++ b/cli/util/cids/cids_test.go
@@ -1,0 +1,27 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package cids
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadFromJSONAndLines(t *testing.T) {
+	for name, input := range map[string]string{
+		"json":  `["bafy-one", "bafy-two"]`,
+		"lines": "bafy-one\n\n bafy-two \n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			values, err := ReadFrom(strings.NewReader(input))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := Deduplicate(values)
+			if len(got) != 2 || got[0] != "bafy-one" || got[1] != "bafy-two" {
+				t.Fatalf("unexpected CIDs: %#v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed\n\nIssue #1974 already has the client streaming API, but dirctl delete only accepted one CID. This PR brings the command in line with outing unpublish:\n\n- accepts variadic CIDs\n- accepts JSON-array or line-delimited CIDs with --stdin\n- deduplicates and sends one DeleteBatch stream\n- shares CID parsing with the existing publish and unpublish commands\n- updates help text and output for batch results\n\n## Validation\n\n- go test ./util/cids ./cmd/delete ./cmd/routing\n- git diff --check\n\nThe focused command tests pass in the CLI module. The repository's other modules are not needed for this change. Let me know what you think.