### PR TITLE
feat(cli): support batch delete via variadic CIDs and --stdin

### DIFF
--- a/cli/cmd/delete/delete.go
+++ b/cli/cmd/delete/delete.go
@@ -10,6 +10,7 @@ import (
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	"github.com/agntcy/dir/cli/presenter"
+	cidsUtils "github.com/agntcy/dir/cli/util/cids"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/spf13/cobra"
 )
@@ -17,12 +18,19 @@ import (
 func init() {
 	// Add output format flags
 	presenter.AddOutputFlags(Command)
+
+	Command.Flags().BoolVar(&opts.FromStdin, "stdin", false, cidsUtils.StdinFlagUsage)
+}
+
+var opts struct {
+	FromStdin bool
 }
 
 var Command = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete record from Directory store",
-	Long: `This command deletes a record from the Directory store.
+	Use:   "delete <cid> [cid...]",
+	Short: "Delete records from Directory store",
+	Long: `This command deletes one or more records from the Directory store.
+Records submitted together are deleted over a single stream.
 
 Usage examples:
 
@@ -30,7 +38,15 @@ Usage examples:
 
 	dirctl delete <cid>
 
-2. Output formats:
+2. Delete multiple records in a single request:
+
+	dirctl delete <cid1> <cid2> <cid3>
+
+3. Delete records from stdin (JSON array or line-delimited CIDs):
+
+	dirctl search --format cid --limit 100 --output json | dirctl delete --stdin
+
+4. Output formats:
 
 	# Delete with JSON confirmation
 	dirctl delete <cid> --output json
@@ -39,30 +55,36 @@ Usage examples:
 	dirctl delete <cid> --output raw
 
 `,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return errors.New("cid is a required argument")
-		}
-
-		return runCommand(cmd, args[0])
-	},
+	Args: cidsUtils.Args(&opts.FromStdin),
+	RunE: runCommand,
 }
 
-func runCommand(cmd *cobra.Command, cid string) error {
+func runCommand(cmd *cobra.Command, args []string) error {
 	// Get the client from the context.
 	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
 	if !ok {
 		return errors.New("failed to get client from context")
 	}
 
-	// Delete object from store
-	err := c.Delete(cmd.Context(), &corev1.RecordRef{
-		Cid: cid,
-	})
+	cids, err := cidsUtils.Collect(args, cmd.InOrStdin(), opts.FromStdin)
 	if err != nil {
-		return fmt.Errorf("failed to delete record: %w", err)
+		return err
+	}
+
+	recordRefs := make([]*corev1.RecordRef, 0, len(cids))
+	for _, cid := range cids {
+		recordRefs = append(recordRefs, &corev1.RecordRef{Cid: cid})
+	}
+
+	// Delete objects from store over a single stream
+	if err := c.DeleteBatch(cmd.Context(), recordRefs); err != nil {
+		return fmt.Errorf("failed to delete: %w", err)
 	}
 
 	// Output in the appropriate format
-	return presenter.PrintMessage(cmd, "record", "Deleted record with CID", cid)
+	if len(cids) == 1 {
+		return presenter.PrintMessage(cmd, "record", "Deleted record with CID", cids[0])
+	}
+
+	return presenter.PrintMessage(cmd, "records", "Deleted records with CIDs", cids)
 }

--- a/cli/cmd/routing/publish.go
+++ b/cli/cmd/routing/publish.go
@@ -5,16 +5,14 @@
 package routing
 
 import (
-	"bufio"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	routingv1 "github.com/agntcy/dir/api/routing/v1"
 	"github.com/agntcy/dir/cli/presenter"
+	cidsUtils "github.com/agntcy/dir/cli/util/cids"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/spf13/cobra"
 )
@@ -56,13 +54,7 @@ Usage examples:
 
 Note: The record must already be pushed to storage before publishing.
 `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if publishOpts.FromStdin {
-			return cobra.MaximumNArgs(0)(cmd, args)
-		}
-
-		return cobra.MinimumNArgs(1)(cmd, args)
-	},
+	Args: cidsUtils.Args(&publishOpts.FromStdin),
 	RunE: runPublishCommand,
 }
 
@@ -71,8 +63,7 @@ var publishOpts struct {
 }
 
 func init() {
-	publishCmd.Flags().BoolVar(&publishOpts.FromStdin, "stdin", false,
-		"Read CIDs from standard input. Supports JSON array output from 'dirctl search --output json' and line-delimited CIDs.")
+	publishCmd.Flags().BoolVar(&publishOpts.FromStdin, "stdin", false, cidsUtils.StdinFlagUsage)
 }
 
 func runPublishCommand(cmd *cobra.Command, args []string) error {
@@ -82,20 +73,9 @@ func runPublishCommand(cmd *cobra.Command, args []string) error {
 		return errors.New("failed to get client from context")
 	}
 
-	cids := append([]string{}, args...)
-
-	if publishOpts.FromStdin {
-		stdinCIDs, err := readCIDsFromStdin(cmd.InOrStdin())
-		if err != nil {
-			return fmt.Errorf("failed to read CIDs from stdin: %w", err)
-		}
-
-		cids = append(cids, stdinCIDs...)
-	}
-
-	cids = deduplicateCIDs(cids)
-	if len(cids) == 0 {
-		return errors.New("at least one CID is required (pass arguments or use --stdin)")
+	cids, err := cidsUtils.Collect(args, cmd.InOrStdin(), publishOpts.FromStdin)
+	if err != nil {
+		return err
 	}
 
 	recordRefs := make([]*corev1.RecordRef, 0, len(cids))
@@ -104,8 +84,7 @@ func runPublishCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Lookup metadata to verify records exist
-	_, err := c.LookupBatch(cmd.Context(), recordRefs)
-	if err != nil {
+	if _, err := c.LookupBatch(cmd.Context(), recordRefs); err != nil {
 		return fmt.Errorf("failed to lookup: %w", err)
 	}
 
@@ -137,64 +116,4 @@ func runPublishCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	return presenter.PrintMessage(cmd, "Publish", "Successfully submitted publication request", result)
-}
-
-func readCIDsFromStdin(reader io.Reader) ([]string, error) {
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read stdin: %w", err)
-	}
-
-	input := strings.TrimSpace(string(data))
-	if input == "" {
-		return nil, nil
-	}
-
-	if strings.HasPrefix(input, "[") {
-		var cids []string
-		if err := json.Unmarshal([]byte(input), &cids); err != nil {
-			return nil, fmt.Errorf("failed to parse JSON array of CIDs: %w", err)
-		}
-
-		return cids, nil
-	}
-
-	cids := make([]string, 0)
-
-	scanner := bufio.NewScanner(strings.NewReader(input))
-	for scanner.Scan() {
-		cid := strings.TrimSpace(scanner.Text())
-		if cid == "" {
-			continue
-		}
-
-		cids = append(cids, cid)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to scan stdin: %w", err)
-	}
-
-	return cids, nil
-}
-
-func deduplicateCIDs(cids []string) []string {
-	seen := make(map[string]struct{}, len(cids))
-	out := make([]string, 0, len(cids))
-
-	for _, cid := range cids {
-		cid = strings.TrimSpace(cid)
-		if cid == "" {
-			continue
-		}
-
-		if _, exists := seen[cid]; exists {
-			continue
-		}
-
-		seen[cid] = struct{}{}
-		out = append(out, cid)
-	}
-
-	return out
 }

--- a/cli/cmd/routing/unpublish.go
+++ b/cli/cmd/routing/unpublish.go
@@ -11,6 +11,7 @@ import (
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	routingv1 "github.com/agntcy/dir/api/routing/v1"
 	"github.com/agntcy/dir/cli/presenter"
+	cidsUtils "github.com/agntcy/dir/cli/util/cids"
 	ctxUtils "github.com/agntcy/dir/cli/util/context"
 	"github.com/spf13/cobra"
 )
@@ -48,15 +49,10 @@ Usage examples:
    # Unpublish with raw output for scripting
    dirctl routing unpublish <cid> --output raw
 
-Note: This only removes network announcements. Use 'dirctl delete' to remove the record entirely.
+Note: This only removes network announcements. The records stay in local storage; pipe the
+same CIDs into 'dirctl delete --stdin' to remove them entirely.
 `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if unpublishOpts.FromStdin {
-			return cobra.MaximumNArgs(0)(cmd, args)
-		}
-
-		return cobra.MinimumNArgs(1)(cmd, args)
-	},
+	Args: cidsUtils.Args(&unpublishOpts.FromStdin),
 	RunE: runUnpublishCommand,
 }
 
@@ -65,8 +61,7 @@ var unpublishOpts struct {
 }
 
 func init() {
-	unpublishCmd.Flags().BoolVar(&unpublishOpts.FromStdin, "stdin", false,
-		"Read CIDs from standard input. Supports JSON array output from 'dirctl search --output json' and line-delimited CIDs.")
+	unpublishCmd.Flags().BoolVar(&unpublishOpts.FromStdin, "stdin", false, cidsUtils.StdinFlagUsage)
 }
 
 func runUnpublishCommand(cmd *cobra.Command, args []string) error {
@@ -76,20 +71,9 @@ func runUnpublishCommand(cmd *cobra.Command, args []string) error {
 		return errors.New("failed to get client from context")
 	}
 
-	cids := append([]string{}, args...)
-
-	if unpublishOpts.FromStdin {
-		stdinCIDs, err := readCIDsFromStdin(cmd.InOrStdin())
-		if err != nil {
-			return fmt.Errorf("failed to read CIDs from stdin: %w", err)
-		}
-
-		cids = append(cids, stdinCIDs...)
-	}
-
-	cids = deduplicateCIDs(cids)
-	if len(cids) == 0 {
-		return errors.New("at least one CID is required (pass arguments or use --stdin)")
+	cids, err := cidsUtils.Collect(args, cmd.InOrStdin(), unpublishOpts.FromStdin)
+	if err != nil {
+		return err
 	}
 
 	recordRefs := make([]*corev1.RecordRef, 0, len(cids))
@@ -98,8 +82,7 @@ func runUnpublishCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	// Lookup metadata to verify records exist
-	_, err := c.LookupBatch(cmd.Context(), recordRefs)
-	if err != nil {
+	if _, err := c.LookupBatch(cmd.Context(), recordRefs); err != nil {
 		return fmt.Errorf("failed to lookup: %w", err)
 	}
 

--- a/cli/util/cids/cids.go
+++ b/cli/util/cids/cids.go
@@ -20,7 +20,7 @@ import (
 
 // StdinFlagUsage is the help text for the --stdin flag of every command that
 // accepts a batch of CIDs.
-const StdinFlagUsage = "Read CIDs from standard input. Supports JSON array output from 'dirctl search --output json' and line-delimited CIDs."
+const StdinFlagUsage = "Read CIDs from standard input. Accepts a JSON array of CIDs, as produced by 'dirctl search --format cid --output json', or line-delimited CIDs."
 
 // Args validates positional arguments for a command that accepts CIDs either as
 // arguments or, when fromStdin points at a set --stdin flag, on stdin.

--- a/cli/util/cids/cids.go
+++ b/cli/util/cids/cids.go
@@ -1,0 +1,124 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cids holds helpers shared by the commands that operate on a batch of
+// record CIDs supplied as variadic arguments or on stdin (delete, routing
+// publish, routing unpublish), so that the output of `dirctl search` can be
+// piped into any of them.
+package cids
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// StdinFlagUsage is the help text for the --stdin flag of every command that
+// accepts a batch of CIDs.
+const StdinFlagUsage = "Read CIDs from standard input. Supports JSON array output from 'dirctl search --output json' and line-delimited CIDs."
+
+// Args validates positional arguments for a command that accepts CIDs either as
+// arguments or, when fromStdin points at a set --stdin flag, on stdin.
+func Args(fromStdin *bool) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		if *fromStdin {
+			//nolint:wrapcheck
+			return cobra.MaximumNArgs(0)(cmd, args)
+		}
+
+		//nolint:wrapcheck
+		return cobra.MinimumNArgs(1)(cmd, args)
+	}
+}
+
+// Collect gathers the CIDs to operate on from the positional arguments and,
+// when fromStdin is set, from reader. The result is deduplicated and guaranteed
+// to be non-empty.
+func Collect(args []string, reader io.Reader, fromStdin bool) ([]string, error) {
+	cids := append([]string{}, args...)
+
+	if fromStdin {
+		stdinCIDs, err := ReadFromStdin(reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CIDs from stdin: %w", err)
+		}
+
+		cids = append(cids, stdinCIDs...)
+	}
+
+	cids = Deduplicate(cids)
+	if len(cids) == 0 {
+		return nil, errors.New("at least one CID is required (pass arguments or use --stdin)")
+	}
+
+	return cids, nil
+}
+
+// ReadFromStdin reads CIDs from reader, accepting either a JSON array as
+// produced by `dirctl search --format cid --output json` or line-delimited CIDs.
+func ReadFromStdin(reader io.Reader) ([]string, error) {
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read stdin: %w", err)
+	}
+
+	input := strings.TrimSpace(string(data))
+	if input == "" {
+		return nil, nil
+	}
+
+	if strings.HasPrefix(input, "[") {
+		var cids []string
+		if err := json.Unmarshal([]byte(input), &cids); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON array of CIDs: %w", err)
+		}
+
+		return cids, nil
+	}
+
+	cids := make([]string, 0)
+
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	for scanner.Scan() {
+		cid := strings.TrimSpace(scanner.Text())
+		if cid == "" {
+			continue
+		}
+
+		cids = append(cids, cid)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to scan stdin: %w", err)
+	}
+
+	return cids, nil
+}
+
+// Deduplicate trims each CID and drops empty and repeated entries, preserving
+// first-seen order.
+func Deduplicate(cids []string) []string {
+	seen := make(map[string]struct{}, len(cids))
+	out := make([]string, 0, len(cids))
+
+	for _, cid := range cids {
+		cid = strings.TrimSpace(cid)
+		if cid == "" {
+			continue
+		}
+
+		if _, exists := seen[cid]; exists {
+			continue
+		}
+
+		seen[cid] = struct{}{}
+		out = append(out, cid)
+	}
+
+	return out
+}

--- a/cli/util/cids/cids_test.go
+++ b/cli/util/cids/cids_test.go
@@ -1,0 +1,75 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package cids
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFromStdinJSONArray(t *testing.T) {
+	cids, err := ReadFromStdin(strings.NewReader("[\"bafy1\", \"bafy2\"]\n"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bafy1", "bafy2"}, cids)
+}
+
+func TestReadFromStdinLineDelimited(t *testing.T) {
+	cids, err := ReadFromStdin(strings.NewReader("bafy1\n  bafy2  \n\nbafy3\n"))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bafy1", "bafy2", "bafy3"}, cids)
+}
+
+func TestReadFromStdinEmpty(t *testing.T) {
+	cids, err := ReadFromStdin(strings.NewReader("   \n"))
+	require.NoError(t, err)
+	assert.Empty(t, cids)
+}
+
+func TestReadFromStdinInvalidJSON(t *testing.T) {
+	_, err := ReadFromStdin(strings.NewReader(`[{"cid": "bafy1"}]`))
+	require.Error(t, err)
+}
+
+func TestDeduplicate(t *testing.T) {
+	assert.Equal(t,
+		[]string{"bafy1", "bafy2"},
+		Deduplicate([]string{" bafy1 ", "bafy2", "bafy1", "", "  "}),
+	)
+}
+
+func TestCollectMergesArgsAndStdin(t *testing.T) {
+	cids, err := Collect([]string{"bafy1", "bafy2"}, strings.NewReader("bafy2\nbafy3\n"), true)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bafy1", "bafy2", "bafy3"}, cids)
+}
+
+func TestCollectIgnoresStdinWhenNotRequested(t *testing.T) {
+	cids, err := Collect([]string{"bafy1"}, strings.NewReader("bafy2\n"), false)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bafy1"}, cids)
+}
+
+func TestCollectRequiresAtLeastOneCID(t *testing.T) {
+	_, err := Collect(nil, strings.NewReader("\n"), true)
+	require.ErrorContains(t, err, "at least one CID is required")
+}
+
+func TestArgs(t *testing.T) {
+	fromStdin := false
+	cmd := &cobra.Command{Use: "delete"}
+	validate := Args(&fromStdin)
+
+	require.Error(t, validate(cmd, nil))
+	require.NoError(t, validate(cmd, []string{"bafy1"}))
+	require.NoError(t, validate(cmd, []string{"bafy1", "bafy2"}))
+
+	fromStdin = true
+
+	require.NoError(t, validate(cmd, nil))
+	require.Error(t, validate(cmd, []string{"bafy1"}))
+}

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -702,7 +702,7 @@ with `--stdin`, in which case they are deleted over a single stream.
 
 The following flags are available:
 
-- `--stdin` - Read CIDs from standard input, either as a JSON array produced by `dirctl search --output json` or as line-delimited CIDs
+- `--stdin` - Read CIDs from standard input, either as a JSON array produced by `dirctl search --format cid --output json` or as line-delimited CIDs
 
 ??? example
 

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -695,15 +695,26 @@ dirctl pull cisco.com/agent@wrong-cid
 
 When no version is specified, commands return the most recently created record (by record's `created_at` field). This allows non-semver tags like `latest`, `dev`, or `stable`.
 
-### `dirctl delete <cid>`
+### `dirctl delete <cid> [cid...]`
 
-Removes records from storage.
+Removes records from storage. Multiple CIDs can be passed as arguments or piped in
+with `--stdin`, in which case they are deleted over a single stream.
+
+The following flags are available:
+
+- `--stdin` - Read CIDs from standard input, either as a JSON array produced by `dirctl search --output json` or as line-delimited CIDs
 
 ??? example
 
     ```bash
     # Delete a record
     dirctl delete baeareihdr6t7s6sr2q4zo456sza66eewqc7huzatyfgvoupaqyjw23ilvi
+
+    # Delete several records in one request
+    dirctl delete baeareihdr6t7... baeareiabc123...
+
+    # Delete every record matching a search
+    dirctl search --format cid --limit 100 --output json | dirctl delete --stdin
     ```
 
 ### `dirctl info <reference>`

--- a/tests/e2e/local/17_delete_test.go
+++ b/tests/e2e/local/17_delete_test.go
@@ -1,0 +1,118 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agntcy/dir/tests/e2e/shared/testdata"
+	"github.com/agntcy/dir/tests/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// pushUniqueRecord pushes a copy of the sample record renamed with suffix, so
+// that every record in this suite has a CID that no other suite touches.
+func pushUniqueRecord(tempDir, suffix string) string {
+	var record map[string]any
+
+	gomega.Expect(json.Unmarshal(testdata.ExpectedRecordV100JSON, &record)).To(gomega.Succeed())
+
+	record["name"] = fmt.Sprintf("delete_e2e_%s_agent", suffix)
+
+	data, err := json.Marshal(record)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	path := filepath.Join(tempDir, "record_"+suffix+".json")
+	gomega.Expect(os.WriteFile(path, data, 0o600)).To(gomega.Succeed())
+
+	cid := testEnv.CLI.Push(path).WithArgs("--output", "raw").ShouldSucceed()
+	gomega.Expect(cid).NotTo(gomega.BeEmpty())
+
+	return cid
+}
+
+var _ = ginkgo.Describe("Running dirctl end-to-end tests for the delete command", func() {
+	ginkgo.BeforeEach(func() {
+		utils.ResetCLIState()
+	})
+
+	ginkgo.Context("Batch delete", ginkgo.Ordered, ginkgo.Serial, func() {
+		var (
+			tempDir string
+			cids    map[string]string
+		)
+
+		ginkgo.BeforeAll(func() {
+			var err error
+
+			tempDir, err = os.MkdirTemp("", "delete-e2e-*")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			cids = map[string]string{}
+			for _, suffix := range []string{"single", "args_a", "args_b", "json_a", "json_b", "lines_a", "lines_b"} {
+				cids[suffix] = pushUniqueRecord(tempDir, suffix)
+			}
+		})
+
+		ginkgo.AfterAll(func() {
+			for _, cid := range cids {
+				_, _ = testEnv.CLI.Delete(cid).SuppressStderr().Execute()
+			}
+
+			if tempDir != "" {
+				_ = os.RemoveAll(tempDir)
+			}
+		})
+
+		ginkgo.It("should delete a single record and echo its CID in raw output", func() {
+			output := testEnv.CLI.Delete(cids["single"]).WithArgs("--output", "raw").ShouldSucceed()
+			gomega.Expect(strings.TrimSpace(output)).To(gomega.Equal(cids["single"]))
+
+			_ = testEnv.CLI.Pull(cids["single"]).ShouldFail()
+		})
+
+		ginkgo.It("should delete multiple records passed as arguments", func() {
+			output := testEnv.CLI.Delete(cids["args_a"], cids["args_b"]).ShouldSucceed()
+			gomega.Expect(output).To(gomega.ContainSubstring(cids["args_a"]))
+			gomega.Expect(output).To(gomega.ContainSubstring(cids["args_b"]))
+
+			_ = testEnv.CLI.Pull(cids["args_a"]).ShouldFail()
+			_ = testEnv.CLI.Pull(cids["args_b"]).ShouldFail()
+		})
+
+		ginkgo.It("should delete records from a JSON array on stdin", func() {
+			input, err := json.Marshal([]string{cids["json_a"], cids["json_b"]})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			testEnv.CLI.DeleteFromStdin(string(input)).ShouldSucceed()
+
+			_ = testEnv.CLI.Pull(cids["json_a"]).ShouldFail()
+			_ = testEnv.CLI.Pull(cids["json_b"]).ShouldFail()
+		})
+
+		ginkgo.It("should delete records from line-delimited CIDs on stdin", func() {
+			input := cids["lines_a"] + "\n" + cids["lines_b"] + "\n"
+
+			testEnv.CLI.DeleteFromStdin(input).ShouldSucceed()
+
+			_ = testEnv.CLI.Pull(cids["lines_a"]).ShouldFail()
+			_ = testEnv.CLI.Pull(cids["lines_b"]).ShouldFail()
+		})
+
+		ginkgo.It("should fail when no CID is provided", func() {
+			err := testEnv.CLI.Command("delete").ShouldFail()
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("requires at least 1 arg"))
+		})
+
+		ginkgo.It("should fail when arguments are combined with --stdin", func() {
+			err := testEnv.CLI.Delete(cids["single"]).WithArgs("--stdin").ShouldFail()
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("accepts at most 0 arg"))
+		})
+	})
+})

--- a/tests/e2e/shared/utils/cli.go
+++ b/tests/e2e/shared/utils/cli.go
@@ -77,8 +77,15 @@ func (c *CLI) Info(cidOrName string) *CommandBuilder {
 	return c.Command("info").WithArgs(cidOrName)
 }
 
-func (c *CLI) Delete(cid string) *CommandBuilder {
-	return c.Command("delete").WithArgs(cid)
+func (c *CLI) Delete(cids ...string) *CommandBuilder {
+	return c.Command("delete").WithArgs(cids...)
+}
+
+func (c *CLI) DeleteFromStdin(input string) *StdinCommandBuilder {
+	return &StdinCommandBuilder{
+		CommandBuilder: c.Command("delete").WithArgs("--stdin"),
+		stdinInput:     input,
+	}
 }
 
 func (c *CLI) Search() *SearchBuilder {


### PR DESCRIPTION
`dirctl delete` accepted exactly one CID even though the RPC is client-streaming and the SDK already exposes `DeleteBatch`, so cleanup workflows needed a shell loop spawning a process per record. Delete now takes variadic CIDs and a `--stdin` flag reading either a JSON array from `dirctl search --output json` or line-delimited CIDs, sending the batch over a single stream.

- Single-CID output is unchanged — `--output raw` still emits just the CID, since delete's help advertises that for scripting. Only batches get the new array shape.
- Stdin parsing, deduplication, and argument validation shared with `routing publish`/`unpublish` moved into a shared package instead of being copied a third time.
- `sync create --stdin` is left alone: same flag name, but it reads routing search responses for the peer multiaddrs a CID list can't provide.