### PR TITLE
feat(dir): add configurable OIDC scopes

### DIFF
--- a/cli/cmd/auth/login.go
+++ b/cli/cmd/auth/login.go
@@ -32,6 +32,7 @@ Device flow: --device flag (no browser needed; authorize on any device).
 Configuration (flags or environment):
   --oidc-issuer, DIRECTORY_CLIENT_OIDC_ISSUER        OIDC issuer URL (e.g. https://dex.example.com)
   --oidc-client-id, DIRECTORY_CLIENT_OIDC_CLIENT_ID  OIDC client ID
+  --oidc-scopes, DIRECTORY_CLIENT_OIDC_SCOPES        OIDC scopes (comma-separated); include groups for IdP group claims
 
 Examples:
   # Interactive login (opens browser)
@@ -118,6 +119,7 @@ func runPKCELogin(cmd *cobra.Command, cfg *client.Config, cache *client.TokenCac
 	result, err := client.OIDC.RunPKCEFlow(ctx, &client.PKCEConfig{
 		Issuer:          cfg.OIDCIssuer,
 		ClientID:        cfg.OIDCClientID,
+		Scopes:          cfg.OIDCScopes,
 		RedirectURI:     redirectURI,
 		CallbackPort:    callbackPort,
 		SkipBrowserOpen: skipBrowserOpen,
@@ -141,6 +143,7 @@ func runDeviceLogin(cmd *cobra.Command, cfg *client.Config, cache *client.TokenC
 	result, err := client.OIDC.RunDeviceFlow(ctx, &client.DeviceFlowConfig{
 		Issuer:   cfg.OIDCIssuer,
 		ClientID: cfg.OIDCClientID,
+		Scopes:   cfg.OIDCScopes,
 		Timeout:  timeout,
 		Output:   cmd.OutOrStdout(),
 	})

--- a/cli/cmd/context/show.go
+++ b/cli/cmd/context/show.go
@@ -110,6 +110,7 @@ func resolvedConfigValues(cfg *client.Config) map[string]string {
 		"jwt_audience":       cfg.JWTAudience,
 		"oidc_client_id":     cfg.OIDCClientID,
 		"oidc_issuer":        cfg.OIDCIssuer,
+		"oidc_scopes":        strings.Join(cfg.OIDCScopes, " "),
 		"server_address":     cfg.ServerAddress,
 		"spiffe_socket_path": cfg.SpiffeSocketPath,
 		"spiffe_token":       redact(cfg.SpiffeToken),

--- a/cli/cmd/init/agents.go
+++ b/cli/cmd/init/agents.go
@@ -117,6 +117,10 @@ func mcpServerEnv() map[string]string {
 		}
 	}
 
+	if len(cfg.OIDCScopes) > 0 {
+		env["DIRECTORY_CLIENT_OIDC_SCOPES"] = strings.Join(cfg.OIDCScopes, ",")
+	}
+
 	if cfg.TlsSkipVerify {
 		env["DIRECTORY_CLIENT_TLS_SKIP_VERIFY"] = "true"
 	}

--- a/cli/cmd/options.go
+++ b/cli/cmd/options.go
@@ -28,5 +28,6 @@ func init() {
 	flags.StringVar(&config.Client.TlsKeyFile, "tls-key-file", config.Client.TlsKeyFile, "Path to TLS key file (for TLS authentication mode)")
 	flags.StringVar(&config.Client.OIDCIssuer, "oidc-issuer", config.Client.OIDCIssuer, "OIDC issuer URL (e.g. https://dex.example.com) for interactive login")
 	flags.StringVar(&config.Client.OIDCClientID, "oidc-client-id", config.Client.OIDCClientID, "OIDC client ID for interactive login (PKCE)")
+	flags.StringSliceVar(&config.Client.OIDCScopes, "oidc-scopes", config.Client.OIDCScopes, "OIDC scopes for login (e.g. openid,email,groups); default when unset")
 	flags.StringVar(&config.Client.AuthToken, "auth-token", config.Client.AuthToken, "Pre-issued Bearer token (JWT). Useful for CI and non-interactive workflows; no login needed")
 }

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -291,6 +291,7 @@ func resetClientConfig() {
 	config.Client.TlsKeyFile = ""
 	config.Client.OIDCIssuer = ""
 	config.Client.OIDCClientID = ""
+	config.Client.OIDCScopes = nil
 	config.Client.AuthToken = ""
 }
 
@@ -352,6 +353,7 @@ func newResolveTestCommand(t *testing.T) *cobra.Command {
 	flags.StringVar(&config.Client.TlsKeyFile, "tls-key-file", config.Client.TlsKeyFile, "Path to TLS key file")
 	flags.StringVar(&config.Client.OIDCIssuer, "oidc-issuer", config.Client.OIDCIssuer, "OIDC issuer URL")
 	flags.StringVar(&config.Client.OIDCClientID, "oidc-client-id", config.Client.OIDCClientID, "OIDC client ID")
+	flags.StringSliceVar(&config.Client.OIDCScopes, "oidc-scopes", config.Client.OIDCScopes, "OIDC scopes for login")
 	flags.StringVar(&config.Client.AuthToken, "auth-token", config.Client.AuthToken, "Pre-issued Bearer token")
 
 	return cmd

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -30,6 +30,7 @@ func ChangedClientConfigFields(cmd *cobra.Command) []string {
 		"tls-key-file":       "tls_key_file",
 		"oidc-issuer":        "oidc_issuer",
 		"oidc-client-id":     "oidc_client_id",
+		"oidc-scopes":        "oidc_scopes",
 		"auth-token":         "auth_token",
 	}
 

--- a/client/config.go
+++ b/client/config.go
@@ -37,8 +37,9 @@ type Config struct {
 	JWTAudience      string `json:"jwt_audience,omitempty"       mapstructure:"jwt_audience"`
 
 	// OIDC configuration (for interactive login)
-	OIDCIssuer   string `json:"oidc_issuer,omitempty"    mapstructure:"oidc_issuer"`
-	OIDCClientID string `json:"oidc_client_id,omitempty" mapstructure:"oidc_client_id"`
+	OIDCIssuer   string   `json:"oidc_issuer,omitempty"    mapstructure:"oidc_issuer"`
+	OIDCClientID string   `json:"oidc_client_id,omitempty" mapstructure:"oidc_client_id"`
+	OIDCScopes   []string `json:"oidc_scopes,omitempty"    mapstructure:"oidc_scopes"`
 
 	// Pre-issued Bearer token for CI/scripts (skips interactive login)
 	AuthToken string `json:"auth_token,omitempty" mapstructure:"auth_token"`
@@ -77,6 +78,9 @@ func LoadConfig() (*Config, error) {
 
 	_ = v.BindEnv("oidc_client_id")
 	v.SetDefault("oidc_client_id", "")
+
+	_ = v.BindEnv("oidc_scopes")
+	v.SetDefault("oidc_scopes", []string{})
 
 	_ = v.BindEnv("auth_token")
 	v.SetDefault("auth_token", "")

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -69,19 +69,20 @@ type Extractor struct {
 
 // Context is a named client configuration block.
 type Context struct {
-	ServerAddress    string `yaml:"server_address"`
-	TlsSkipVerify    bool   `yaml:"tls_skip_verify"`
-	TlsCertFile      string `yaml:"tls_cert_file"`
-	TlsKeyFile       string `yaml:"tls_key_file"`
-	TlsCAFile        string `yaml:"tls_ca_file"`
-	SpiffeSocketPath string `yaml:"spiffe_socket_path"`
-	SpiffeToken      string `yaml:"spiffe_token"`
-	AuthMode         string `yaml:"auth_mode"`
-	JWTAudience      string `yaml:"jwt_audience"`
-	OIDCIssuer       string `yaml:"oidc_issuer"`
-	OIDCClientID     string `yaml:"oidc_client_id"`
-	AuthToken        string `yaml:"auth_token"`
-	Doctor           Doctor `yaml:"doctor"`
+	ServerAddress    string   `yaml:"server_address"`
+	TlsSkipVerify    bool     `yaml:"tls_skip_verify"`
+	TlsCertFile      string   `yaml:"tls_cert_file"`
+	TlsKeyFile       string   `yaml:"tls_key_file"`
+	TlsCAFile        string   `yaml:"tls_ca_file"`
+	SpiffeSocketPath string   `yaml:"spiffe_socket_path"`
+	SpiffeToken      string   `yaml:"spiffe_token"`
+	AuthMode         string   `yaml:"auth_mode"`
+	JWTAudience      string   `yaml:"jwt_audience"`
+	OIDCIssuer       string   `yaml:"oidc_issuer"`
+	OIDCClientID     string   `yaml:"oidc_client_id"`
+	OIDCScopes       []string `yaml:"oidc_scopes"`
+	AuthToken        string   `yaml:"auth_token"`
+	Doctor           Doctor   `yaml:"doctor"`
 }
 
 // Doctor holds diagnostic-only settings for dirctl doctor.
@@ -789,6 +790,10 @@ func applyEnv(cfg *dirclient.Config, prefix string) error {
 		"auth_token":         &cfg.AuthToken,
 	}
 
+	if value, ok := os.LookupEnv(envVarName(prefix, "oidc_scopes")); ok {
+		cfg.OIDCScopes = parseEnvScopeList(value)
+	}
+
 	for key, target := range stringEnv {
 		if value, ok := os.LookupEnv(envVarName(prefix, key)); ok {
 			*target = value
@@ -872,6 +877,10 @@ func applyNonZeroOverrides(cfg *dirclient.Config, overrides *dirclient.Config) {
 		cfg.OIDCClientID = overrides.OIDCClientID
 	}
 
+	if len(overrides.OIDCScopes) > 0 {
+		cfg.OIDCScopes = append([]string(nil), overrides.OIDCScopes...)
+	}
+
 	if overrides.AuthToken != "" {
 		cfg.AuthToken = overrides.AuthToken
 	}
@@ -901,6 +910,8 @@ func applyOverrideField(cfg *dirclient.Config, overrides *dirclient.Config, fiel
 		cfg.OIDCIssuer = overrides.OIDCIssuer
 	case "oidc_client_id":
 		cfg.OIDCClientID = overrides.OIDCClientID
+	case "oidc_scopes":
+		cfg.OIDCScopes = append([]string(nil), overrides.OIDCScopes...)
 	case "auth_token":
 		cfg.AuthToken = overrides.AuthToken
 	default:
@@ -984,6 +995,22 @@ func envVarName(prefix string, key string) string {
 	return prefix + "_" + strings.ToUpper(replaced)
 }
 
+func parseEnvScopeList(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+
+	out := make([]string, 0, strings.Count(value, ",")+1)
+	for part := range strings.SplitSeq(value, ",") {
+		if scope := strings.TrimSpace(part); scope != "" {
+			out = append(out, scope)
+		}
+	}
+
+	return out
+}
+
 func (c Context) toClientConfig() dirclient.Config {
 	return dirclient.Config{
 		ServerAddress:    c.ServerAddress,
@@ -997,6 +1024,7 @@ func (c Context) toClientConfig() dirclient.Config {
 		JWTAudience:      c.JWTAudience,
 		OIDCIssuer:       c.OIDCIssuer,
 		OIDCClientID:     c.OIDCClientID,
+		OIDCScopes:       append([]string(nil), c.OIDCScopes...),
 		AuthToken:        c.AuthToken,
 	}
 }

--- a/client/config/config_test.go
+++ b/client/config/config_test.go
@@ -338,6 +338,32 @@ contexts:
 		assert.Equal(t, path, resolved.Path)
 	})
 
+	t.Run("resolves oidc_scopes from context", func(t *testing.T) {
+		resetClientEnv(t)
+		path := writeConfig(t, `
+contexts:
+  dex:
+    server_address: gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://dex.example.com
+    oidc_client_id: dirctl
+    oidc_scopes:
+      - openid
+      - email
+      - profile
+      - offline_access
+      - groups
+`)
+
+		cfg, _, err := Resolve(ResolveOptions{
+			Path:    path,
+			Context: "dex",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"openid", "email", "profile", "offline_access", "groups"}, cfg.OIDCScopes)
+	})
+
 	t.Run("resolves current context", func(t *testing.T) {
 		resetClientEnv(t)
 		path := writeConfig(t, `
@@ -808,6 +834,7 @@ func resetClientEnv(t *testing.T) {
 		"DIRECTORY_CLIENT_JWT_AUDIENCE",
 		"DIRECTORY_CLIENT_OIDC_ISSUER",
 		"DIRECTORY_CLIENT_OIDC_CLIENT_ID",
+		"DIRECTORY_CLIENT_OIDC_SCOPES",
 		"DIRECTORY_CLIENT_AUTH_TOKEN",
 	}
 

--- a/client/oidc.go
+++ b/client/oidc.go
@@ -27,7 +27,7 @@ import (
 )
 
 // DefaultOIDCScopes are the OIDC scopes requested for interactive login.
-const DefaultOIDCScopes = "openid email profile offline_access"
+const DefaultOIDCScopes = "openid email profile offline_access groups"
 
 const (
 	serverShutdownTimeout          = 2 * time.Second

--- a/client/oidc_grpc_test.go
+++ b/client/oidc_grpc_test.go
@@ -94,9 +94,10 @@ func TestSetupOIDCAuth_ExpiredCachedTokenReturnsAuthError(t *testing.T) {
 	assert.Contains(t, err.Error(), "dirctl auth login")
 }
 
-func TestDefaultOIDCScopesIncludesOfflineAccess(t *testing.T) {
+func TestDefaultOIDCScopes(t *testing.T) {
 	scopes := resolveScopes(nil)
 	assert.Contains(t, scopes, "offline_access")
+	assert.Contains(t, scopes, "groups")
 }
 
 func TestSetupOIDCAuth_ExpiredCachedTokenRefreshSuccess(t *testing.T) {

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -47,6 +47,8 @@ gateway endpoints, and SPIFFE/SPIRE integration are documented in
 
 ```bash
 dirctl auth login --oidc-issuer "https://idp.ads.outshift.io" --oidc-client-id "dirctl"
+
+Set `oidc_scopes` in the context (or `DIRECTORY_CLIENT_OIDC_SCOPES` / `--oidc-scopes`) to request extra claims. After changing scopes, run `dirctl auth login --force` so the cached token is re-minted.
 dirctl --auth-mode=oidc --server-addr ads.outshift.io:443 search --skill "AI"
 ```
 
@@ -444,6 +446,12 @@ contexts:
     auth_mode: oidc
     oidc_issuer: https://idp.example.com
     oidc_client_id: dirctl
+    oidc_scopes:
+      - openid
+      - email
+      - profile
+      - offline_access
+      - groups
   staging:
     server_address: staging.gateway.example.com:443
     auth_mode: oidc


### PR DESCRIPTION
https://github.com/agntcy/oidc-gateway/issues/75

this PR adds the "groups" scope to the default OIDC scopes

it also makes OIDC scopes configurable - just in case "groups" or any other scope is not supported