### PR TITLE
feat(cli): expose RecordQuery negation as exclude filters

### DIFF
--- a/cli/cmd/search/filters.go
+++ b/cli/cmd/search/filters.go
@@ -4,31 +4,170 @@
 package search
 
 import (
+	"strconv"
+
 	searchv1 "github.com/agntcy/dir/api/search/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
+// FilterValues holds one filter's include and exclude values.
+//
+// The two are kept apart rather than sharing a slice because the server treats
+// them differently: values of one filter are OR'd together, while each excluded
+// value becomes its own NOT EXISTS condition, and those are AND'd. Splitting at
+// the flag means "--skill python --exclude-skill nlp" needs no parsing to
+// separate the two intents.
+type FilterValues struct {
+	Include []string
+	Exclude []string
+}
+
 // Filters holds the values for all record-search filter flags.
 // Embed this in any command's options struct to reuse the standard filter set.
 type Filters struct {
-	Names          []string
-	Versions       []string
-	SkillIDs       []string
-	SkillNames     []string
-	Locators       []string
-	Modules        []string
-	DomainIDs      []string
-	DomainNames    []string
-	CreatedAts     []string
-	Authors        []string
-	SchemaVersions []string
-	ModuleIDs      []string
-	Verified       bool
-	Trusted        bool
-	Safe           bool
-	ScanSeverity   string
-	Annotations    []string
+	Names          FilterValues
+	Versions       FilterValues
+	SkillIDs       FilterValues
+	SkillNames     FilterValues
+	Locators       FilterValues
+	Modules        FilterValues
+	DomainIDs      FilterValues
+	DomainNames    FilterValues
+	CreatedAts     FilterValues
+	Authors        FilterValues
+	SchemaVersions FilterValues
+	ModuleIDs      FilterValues
+	Annotations    FilterValues
+
+	// ScanSeverity is a single threshold rather than a repeatable match, so it
+	// sits outside valueFilters.
+	ScanSeverity        string
+	ExcludeScanSeverity string
+
+	Verified bool
+	Trusted  bool
+	Safe     bool
+
+	// flags is the flag set the filter flags were registered on. It tells
+	// "--trusted=false" (filter for records that failed the check) apart from
+	// the flag being absent (do not filter on trust at all). Nil when Filters
+	// is populated programmatically rather than from flags.
+	flags *pflag.FlagSet
+}
+
+// changed reports whether the named filter flag was explicitly set.
+func (f *Filters) changed(name string) bool {
+	return f.flags != nil && f.flags.Changed(name)
+}
+
+// valueFilter describes one repeatable filter: the flag pair it registers, the
+// help text for each, and the query type both build. It is the single source of
+// truth for flag registration and query building alike, so adding a filter is
+// one entry rather than three edits.
+type valueFilter struct {
+	flag         string
+	usage        string
+	excludeUsage string
+	queryType    searchv1.RecordQueryType
+	values       *FilterValues
+}
+
+// valueFilters returns the filter table bound to f's fields.
+func (f *Filters) valueFilters() []valueFilter {
+	return []valueFilter{
+		{
+			flag:         "name",
+			usage:        "Search for records with specific name (e.g., --name 'my-agent' --name 'web-*')",
+			excludeUsage: "Exclude records with specific name (e.g., --exclude-name 'test-*')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_NAME,
+			values:       &f.Names,
+		},
+		{
+			flag:         "version",
+			usage:        "Search for records with specific version (e.g., --version 'v1.0.0' --version 'v1.*')",
+			excludeUsage: "Exclude records with specific version (e.g., --exclude-version '>=2.0.0')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERSION,
+			values:       &f.Versions,
+		},
+		{
+			flag:         "skill-id",
+			usage:        "Search for records with specific skill ID (e.g., --skill-id '10201')",
+			excludeUsage: "Exclude records with specific skill ID (e.g., --exclude-skill-id '10201')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_ID,
+			values:       &f.SkillIDs,
+		},
+		{
+			flag:         "skill",
+			usage:        "Search for records with specific skill name (e.g., --skill 'natural_language_processing')",
+			excludeUsage: "Exclude records with specific skill name (e.g., --exclude-skill 'natural_language_processing')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_NAME,
+			values:       &f.SkillNames,
+		},
+		{
+			flag:         "locator",
+			usage:        "Search for records with specific locator type (e.g., --locator 'docker-image')",
+			excludeUsage: "Exclude records with specific locator type (e.g., --exclude-locator 'docker-image')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_LOCATOR,
+			values:       &f.Locators,
+		},
+		{
+			flag:         "module",
+			usage:        "Search for records with specific module (e.g., --module 'core/llm/model')",
+			excludeUsage: "Exclude records with specific module (e.g., --exclude-module 'core/llm/model')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_NAME,
+			values:       &f.Modules,
+		},
+		{
+			flag:         "domain-id",
+			usage:        "Search for records with specific domain ID (e.g., --domain-id '604')",
+			excludeUsage: "Exclude records with specific domain ID (e.g., --exclude-domain-id '604')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_ID,
+			values:       &f.DomainIDs,
+		},
+		{
+			flag:         "domain",
+			usage:        "Search for records with specific domain name (e.g., --domain '*education*')",
+			excludeUsage: "Exclude records with specific domain name (e.g., --exclude-domain '*education*')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_NAME,
+			values:       &f.DomainNames,
+		},
+		{
+			flag:         "created-at",
+			usage:        "Search for records with specific created_at timestamp (e.g., --created-at '2024-*')",
+			excludeUsage: "Exclude records with specific created_at timestamp (e.g., --exclude-created-at '<2024-01-01')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_CREATED_AT,
+			values:       &f.CreatedAts,
+		},
+		{
+			flag:         "author",
+			usage:        "Search for records with specific author (e.g., --author 'john*')",
+			excludeUsage: "Exclude records with specific author (e.g., --exclude-author 'bot*')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_AUTHOR,
+			values:       &f.Authors,
+		},
+		{
+			flag:         "schema-version",
+			usage:        "Filter records by OASF schema version (e.g., --schema-version '0.8.*'); in natural-language search mode, also restricts the extractor to that taxonomy version (repeatable)",
+			excludeUsage: "Exclude records with specific OASF schema version (e.g., --exclude-schema-version '0.7.*')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCHEMA_VERSION,
+			values:       &f.SchemaVersions,
+		},
+		{
+			flag:         "module-id",
+			usage:        "Search for records with specific module ID (e.g., --module-id '201')",
+			excludeUsage: "Exclude records with specific module ID (e.g., --exclude-module-id '201')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_ID,
+			values:       &f.ModuleIDs,
+		},
+		{
+			flag:         "annotation",
+			usage:        "Search for records with specific annotation in key:value format (e.g., --annotation 'manager:alice' --annotation 'team:*')",
+			excludeUsage: "Exclude records with specific annotation in key:value format (e.g., --exclude-annotation 'env:test')",
+			queryType:    searchv1.RecordQueryType_RECORD_QUERY_TYPE_ANNOTATION,
+			values:       &f.Annotations,
+		},
+	}
 }
 
 // RegisterFilterFlags binds the standard search-filter flags to cmd, storing
@@ -44,100 +183,52 @@ func RegisterPersistentFilterFlags(cmd *cobra.Command, f *Filters) {
 }
 
 func registerFilterFlags(flags *pflag.FlagSet, f *Filters) {
-	flags.StringArrayVar(&f.Names, "name", nil,
-		"Search for records with specific name (e.g., --name 'my-agent' --name 'web-*')")
-	flags.StringArrayVar(&f.Versions, "version", nil,
-		"Search for records with specific version (e.g., --version 'v1.0.0' --version 'v1.*')")
-	flags.StringArrayVar(&f.SkillIDs, "skill-id", nil,
-		"Search for records with specific skill ID (e.g., --skill-id '10201')")
-	flags.StringArrayVar(&f.SkillNames, "skill", nil,
-		"Search for records with specific skill name (e.g., --skill 'natural_language_processing')")
-	flags.StringArrayVar(&f.Locators, "locator", nil,
-		"Search for records with specific locator type (e.g., --locator 'docker-image')")
-	flags.StringArrayVar(&f.Modules, "module", nil,
-		"Search for records with specific module (e.g., --module 'core/llm/model')")
-	flags.StringArrayVar(&f.DomainIDs, "domain-id", nil,
-		"Search for records with specific domain ID (e.g., --domain-id '604')")
-	flags.StringArrayVar(&f.DomainNames, "domain", nil,
-		"Search for records with specific domain name (e.g., --domain '*education*')")
-	flags.StringArrayVar(&f.CreatedAts, "created-at", nil,
-		"Search for records with specific created_at timestamp (e.g., --created-at '2024-*')")
-	flags.StringArrayVar(&f.Authors, "author", nil,
-		"Search for records with specific author (e.g., --author 'john*')")
-	flags.StringArrayVar(&f.SchemaVersions, "schema-version", nil,
-		"Filter records by OASF schema version (e.g., --schema-version '0.8.*'); in natural-language search mode, also restricts the extractor to that taxonomy version (repeatable)")
-	flags.StringArrayVar(&f.ModuleIDs, "module-id", nil,
-		"Search for records with specific module ID (e.g., --module-id '201')")
-	flags.BoolVar(&f.Verified, "verified", false,
-		"Filter for records with verified name ownership only")
-	flags.BoolVar(&f.Trusted, "trusted", false,
-		"Filter for records with trusted signature only (signature verification passed)")
-	flags.BoolVar(&f.Safe, "safe", false,
-		"Filter for records where all security scanners reported is_safe=true")
+	f.flags = flags
+
+	for _, filter := range f.valueFilters() {
+		flags.StringArrayVar(&filter.values.Include, filter.flag, nil, filter.usage)
+		flags.StringArrayVar(&filter.values.Exclude, "exclude-"+filter.flag, nil, filter.excludeUsage)
+	}
+
 	flags.StringVar(&f.ScanSeverity, "scan-severity", "",
 		"Filter for records whose highest scan severity meets or exceeds a threshold (NONE, INFO, LOW, MEDIUM, HIGH, CRITICAL)")
-	flags.StringArrayVar(&f.Annotations, "annotation", nil,
-		"Search for records with specific annotation in key:value format (e.g., --annotation 'manager:alice' --annotation 'team:*')")
-}
+	flags.StringVar(&f.ExcludeScanSeverity, "exclude-scan-severity", "",
+		"Exclude records with a scan report at or above a threshold (NONE, INFO, LOW, MEDIUM, HIGH, CRITICAL); never-scanned records are kept")
 
-// queryMapping maps a Filters field accessor to its RecordQueryType.
-type queryMapping struct {
-	values    []string
-	queryType searchv1.RecordQueryType
+	flags.BoolVar(&f.Verified, "verified", false,
+		"Filter for records with verified name ownership (--verified) or without it (--verified=false)")
+	flags.BoolVar(&f.Trusted, "trusted", false,
+		"Filter for records with a trusted signature (--trusted) or without one (--trusted=false)")
+	flags.BoolVar(&f.Safe, "safe", false,
+		"Filter for records where every security scanner reported is_safe=true (--safe), or where at least one did not (--safe=false)")
 }
 
 // BuildQueries converts populated filter fields into API query objects.
 func BuildQueries(f *Filters) []*searchv1.RecordQuery {
-	mappings := []queryMapping{
-		{f.Names, searchv1.RecordQueryType_RECORD_QUERY_TYPE_NAME},
-		{f.Versions, searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERSION},
-		{f.SkillIDs, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_ID},
-		{f.SkillNames, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_NAME},
-		{f.Locators, searchv1.RecordQueryType_RECORD_QUERY_TYPE_LOCATOR},
-		{f.Modules, searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_NAME},
-		{f.DomainIDs, searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_ID},
-		{f.DomainNames, searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_NAME},
-		{f.CreatedAts, searchv1.RecordQueryType_RECORD_QUERY_TYPE_CREATED_AT},
-		{f.Authors, searchv1.RecordQueryType_RECORD_QUERY_TYPE_AUTHOR},
-		{f.SchemaVersions, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCHEMA_VERSION},
-		{f.ModuleIDs, searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_ID},
-	}
+	filters := f.valueFilters()
 
 	var size int
-	for _, m := range mappings {
-		size += len(m.values)
+	for _, filter := range filters {
+		size += len(filter.values.Include) + len(filter.values.Exclude)
 	}
 
 	queries := make([]*searchv1.RecordQuery, 0, size)
 
-	for _, m := range mappings {
-		for _, v := range m.values {
+	for _, filter := range filters {
+		for _, value := range filter.values.Include {
 			queries = append(queries, &searchv1.RecordQuery{
-				Type:  m.queryType,
-				Value: v,
+				Type:  filter.queryType,
+				Value: value,
 			})
 		}
-	}
 
-	if f.Verified {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERIFIED,
-			Value: "true",
-		})
-	}
-
-	if f.Trusted {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED,
-			Value: "true",
-		})
-	}
-
-	if f.Safe {
-		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SAFE,
-			Value: "true",
-		})
+		for _, value := range filter.values.Exclude {
+			queries = append(queries, &searchv1.RecordQuery{
+				Type:   filter.queryType,
+				Value:  value,
+				Negate: true,
+			})
+		}
 	}
 
 	if f.ScanSeverity != "" {
@@ -147,11 +238,36 @@ func BuildQueries(f *Filters) []*searchv1.RecordQuery {
 		})
 	}
 
-	// Add annotation queries
-	for _, annotation := range f.Annotations {
+	if f.ExcludeScanSeverity != "" {
 		queries = append(queries, &searchv1.RecordQuery{
-			Type:  searchv1.RecordQueryType_RECORD_QUERY_TYPE_ANNOTATION,
-			Value: annotation,
+			Type:   searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SEVERITY,
+			Value:  f.ExcludeScanSeverity,
+			Negate: true,
+		})
+	}
+
+	// Boolean filters are tri-state: an absent flag does not filter at all,
+	// while an explicit --trusted=false filters for records that failed the
+	// check. Filters populated in code have no flag set and keep the original
+	// "emit only when true" behaviour.
+	boolFilters := []struct {
+		flag      string
+		value     bool
+		queryType searchv1.RecordQueryType
+	}{
+		{"verified", f.Verified, searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERIFIED},
+		{"trusted", f.Trusted, searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED},
+		{"safe", f.Safe, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SAFE},
+	}
+
+	for _, boolFilter := range boolFilters {
+		if !boolFilter.value && !f.changed(boolFilter.flag) {
+			continue
+		}
+
+		queries = append(queries, &searchv1.RecordQuery{
+			Type:  boolFilter.queryType,
+			Value: strconv.FormatBool(boolFilter.value),
 		})
 	}
 

--- a/cli/cmd/search/filters_test.go
+++ b/cli/cmd/search/filters_test.go
@@ -1,0 +1,254 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package search
+
+import (
+	"testing"
+
+	searchv1 "github.com/agntcy/dir/api/search/v1"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// parseFilters binds the standard filter flags to a fresh Filters value on a
+// throwaway command and parses args into it, so tests never touch the
+// package-level opts singleton.
+func parseFilters(t *testing.T, args ...string) *Filters {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "search", RunE: func(*cobra.Command, []string) error { return nil }}
+	filters := &Filters{}
+	RegisterFilterFlags(cmd, filters)
+
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+
+	return filters
+}
+
+// queryValue returns the value of the first query of the given type, or "" when
+// no such query was built.
+func queryValue(queries []*searchv1.RecordQuery, queryType searchv1.RecordQueryType) string {
+	for _, query := range queries {
+		if query.GetType() == queryType {
+			return query.GetValue()
+		}
+	}
+
+	return ""
+}
+
+// valueFilterFlags pairs every repeatable filter's flag name with the query type
+// it builds. Both the include and the exclude case are driven from this table.
+var valueFilterFlags = []struct {
+	flag      string
+	queryType searchv1.RecordQueryType
+}{
+	{"name", searchv1.RecordQueryType_RECORD_QUERY_TYPE_NAME},
+	{"version", searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERSION},
+	{"skill-id", searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_ID},
+	{"skill", searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_NAME},
+	{"locator", searchv1.RecordQueryType_RECORD_QUERY_TYPE_LOCATOR},
+	{"module", searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_NAME},
+	{"domain-id", searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_ID},
+	{"domain", searchv1.RecordQueryType_RECORD_QUERY_TYPE_DOMAIN_NAME},
+	{"created-at", searchv1.RecordQueryType_RECORD_QUERY_TYPE_CREATED_AT},
+	{"author", searchv1.RecordQueryType_RECORD_QUERY_TYPE_AUTHOR},
+	{"schema-version", searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCHEMA_VERSION},
+	{"module-id", searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_ID},
+	{"annotation", searchv1.RecordQueryType_RECORD_QUERY_TYPE_ANNOTATION},
+}
+
+func TestBuildQueriesIncludeFlags(t *testing.T) {
+	for _, test := range valueFilterFlags {
+		t.Run(test.flag, func(t *testing.T) {
+			queries := BuildQueries(parseFilters(t, "--"+test.flag, "someValue"))
+
+			require.Len(t, queries, 1)
+			assert.Equal(t, test.queryType, queries[0].GetType())
+			assert.Equal(t, "someValue", queries[0].GetValue())
+			assert.False(t, queries[0].GetNegate(), "include flags must not negate")
+		})
+	}
+}
+
+func TestBuildQueriesExcludeFlags(t *testing.T) {
+	for _, test := range valueFilterFlags {
+		t.Run(test.flag, func(t *testing.T) {
+			queries := BuildQueries(parseFilters(t, "--exclude-"+test.flag, "someValue"))
+
+			require.Len(t, queries, 1)
+			assert.Equal(t, test.queryType, queries[0].GetType())
+			assert.Equal(t, "someValue", queries[0].GetValue())
+			assert.True(t, queries[0].GetNegate(), "exclude flags must negate")
+		})
+	}
+}
+
+// Include and exclude of the same filter must land in separate queries rather
+// than sharing one slice, since the server OR's includes but AND's exclusions.
+func TestBuildQueriesCombinesIncludeAndExcludeOnSameFilter(t *testing.T) {
+	queries := BuildQueries(parseFilters(t, "--skill", "python", "--exclude-skill", "nlp"))
+
+	require.Len(t, queries, 2)
+
+	for _, query := range queries {
+		assert.Equal(t, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SKILL_NAME, query.GetType())
+	}
+
+	assert.Equal(t, "python", queries[0].GetValue())
+	assert.False(t, queries[0].GetNegate())
+	assert.Equal(t, "nlp", queries[1].GetValue())
+	assert.True(t, queries[1].GetNegate())
+}
+
+func TestBuildQueriesExcludeFlagsAreRepeatable(t *testing.T) {
+	queries := BuildQueries(parseFilters(t, "--exclude-domain", "a", "--exclude-domain", "b"))
+
+	require.Len(t, queries, 2)
+	assert.Equal(t, "a", queries[0].GetValue())
+	assert.Equal(t, "b", queries[1].GetValue())
+
+	for _, query := range queries {
+		assert.True(t, query.GetNegate())
+	}
+}
+
+// Exclusion adds no grammar: wildcards, comparison operators and a leading '!'
+// all reach the server verbatim.
+func TestBuildQueriesExcludePassesValuesThroughVerbatim(t *testing.T) {
+	tests := []struct {
+		name  string
+		flag  string
+		value string
+	}{
+		{"comparison operator", "exclude-version", ">=2.0.0"},
+		{"wildcard", "exclude-name", "*bot*"},
+		{"literal exclamation mark", "exclude-annotation", "!urgent:true"},
+		{"colon separated locator", "exclude-locator", "docker-image:https://*"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queries := BuildQueries(parseFilters(t, "--"+test.flag, test.value))
+
+			require.Len(t, queries, 1)
+			assert.Equal(t, test.value, queries[0].GetValue())
+			assert.True(t, queries[0].GetNegate())
+		})
+	}
+}
+
+func TestBuildQueriesScanSeverity(t *testing.T) {
+	t.Run("include", func(t *testing.T) {
+		queries := BuildQueries(parseFilters(t, "--scan-severity", "MEDIUM"))
+
+		require.Len(t, queries, 1)
+		assert.Equal(t, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SEVERITY, queries[0].GetType())
+		assert.Equal(t, "MEDIUM", queries[0].GetValue())
+		assert.False(t, queries[0].GetNegate())
+	})
+
+	t.Run("exclude", func(t *testing.T) {
+		queries := BuildQueries(parseFilters(t, "--exclude-scan-severity", "MEDIUM"))
+
+		require.Len(t, queries, 1)
+		assert.Equal(t, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SEVERITY, queries[0].GetType())
+		assert.Equal(t, "MEDIUM", queries[0].GetValue())
+		assert.True(t, queries[0].GetNegate())
+	})
+}
+
+func TestBuildQueriesOmitsUnsetBooleanFilters(t *testing.T) {
+	queries := BuildQueries(parseFilters(t))
+
+	assert.Empty(t, queries)
+}
+
+func TestBuildQueriesBooleanFiltersAreTriState(t *testing.T) {
+	tests := []struct {
+		name      string
+		arg       string
+		queryType searchv1.RecordQueryType
+		want      string
+	}{
+		{"verified true", "--verified", searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERIFIED, "true"},
+		{"verified false", "--verified=false", searchv1.RecordQueryType_RECORD_QUERY_TYPE_VERIFIED, "false"},
+		{"trusted true", "--trusted", searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED, "true"},
+		{"trusted false", "--trusted=false", searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED, "false"},
+		{"safe true", "--safe", searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SAFE, "true"},
+		{"safe false", "--safe=false", searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SAFE, "false"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			queries := BuildQueries(parseFilters(t, test.arg))
+
+			require.Len(t, queries, 1)
+			assert.Equal(t, test.want, queryValue(queries, test.queryType))
+			assert.False(t, queries[0].GetNegate(), "tri-state booleans carry the value, not a negate flag")
+		})
+	}
+}
+
+func TestBuildQueriesCombinesNegatedTrustWithScanSeverity(t *testing.T) {
+	queries := BuildQueries(parseFilters(t, "--trusted=false", "--scan-severity", "MEDIUM"))
+
+	assert.Equal(t, "false", queryValue(queries, searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED))
+	assert.Equal(t, "MEDIUM", queryValue(queries, searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCAN_SEVERITY))
+}
+
+// dirctl install registers the filters as persistent flags on a parent command,
+// so tri-state detection has to see a flag set on a subcommand's invocation.
+// Cobra shares the *pflag.Flag pointer between the two flag sets, which is what
+// makes PersistentFlags().Changed() report it.
+func TestBuildQueriesTriStateThroughPersistentFlags(t *testing.T) {
+	newParentWithSub := func(t *testing.T, args ...string) *Filters {
+		t.Helper()
+
+		parent := &cobra.Command{Use: "install"}
+		sub := &cobra.Command{Use: "run", RunE: func(*cobra.Command, []string) error { return nil }}
+		parent.AddCommand(sub)
+
+		filters := &Filters{}
+		RegisterPersistentFilterFlags(parent, filters)
+
+		parent.SetArgs(append([]string{"run"}, args...))
+		require.NoError(t, parent.Execute())
+
+		return filters
+	}
+
+	t.Run("unset", func(t *testing.T) {
+		assert.Empty(t, BuildQueries(newParentWithSub(t)))
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		queries := BuildQueries(newParentWithSub(t, "--trusted=false"))
+
+		require.Len(t, queries, 1)
+		assert.Equal(t, "false", queryValue(queries, searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED))
+	})
+
+	t.Run("exclude flag", func(t *testing.T) {
+		queries := BuildQueries(newParentWithSub(t, "--exclude-skill", "nlp"))
+
+		require.Len(t, queries, 1)
+		assert.Equal(t, "nlp", queries[0].GetValue())
+		assert.True(t, queries[0].GetNegate())
+	})
+}
+
+// Filters populated in code rather than from flags keep the original
+// "emit only when true" behaviour, so callers that never register flags are
+// unaffected.
+func TestBuildQueriesWithoutFlagSetEmitsOnlyTrueBooleans(t *testing.T) {
+	assert.Empty(t, BuildQueries(&Filters{}))
+
+	queries := BuildQueries(&Filters{Trusted: true})
+
+	require.Len(t, queries, 1)
+	assert.Equal(t, "true", queryValue(queries, searchv1.RecordQueryType_RECORD_QUERY_TYPE_TRUSTED))
+}

--- a/cli/cmd/search/filters_test.go
+++ b/cli/cmd/search/filters_test.go
@@ -4,10 +4,12 @@
 package search
 
 import (
+	"strings"
 	"testing"
 
 	searchv1 "github.com/agntcy/dir/api/search/v1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -59,6 +61,31 @@ var valueFilterFlags = []struct {
 	{"schema-version", searchv1.RecordQueryType_RECORD_QUERY_TYPE_SCHEMA_VERSION},
 	{"module-id", searchv1.RecordQueryType_RECORD_QUERY_TYPE_MODULE_ID},
 	{"annotation", searchv1.RecordQueryType_RECORD_QUERY_TYPE_ANNOTATION},
+}
+
+// Every value filter must register an --exclude- twin. This walks the real flag
+// set rather than the table above, so a filter added to valueFilters without its
+// exclude counterpart fails here even if nobody updates the test table.
+func TestEveryValueFilterHasAnExcludeTwin(t *testing.T) {
+	cmd := &cobra.Command{Use: "search"}
+	RegisterFilterFlags(cmd, &Filters{})
+
+	// Booleans are negated with the tri-state =false form, not an exclude flag.
+	triState := map[string]bool{"verified": true, "trusted": true, "safe": true, "help": true}
+
+	var missing []string
+
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if strings.HasPrefix(flag.Name, "exclude-") || triState[flag.Name] {
+			return
+		}
+
+		if cmd.Flags().Lookup("exclude-"+flag.Name) == nil {
+			missing = append(missing, flag.Name)
+		}
+	})
+
+	assert.Empty(t, missing, "value filters registered without an --exclude- twin")
 }
 
 func TestBuildQueriesIncludeFlags(t *testing.T) {

--- a/cli/cmd/search/nlsearch.go
+++ b/cli/cmd/search/nlsearch.go
@@ -50,7 +50,9 @@ func runNLSearch(cmd *cobra.Command, query string, c *client.Client) error {
 
 	defer func() { _ = ext.Close() }()
 
-	signals, err := nlsearch.Decompose(cmd.Context(), query, ext, extractor.ExtractOptions{Versions: opts.Filters.SchemaVersions})
+	// Only the included schema versions restrict the extractor; --exclude-schema-version
+	// filters results and has no taxonomy to point the extractor at.
+	signals, err := nlsearch.Decompose(cmd.Context(), query, ext, extractor.ExtractOptions{Versions: opts.Filters.SchemaVersions.Include})
 	if err != nil {
 		return fmt.Errorf("decompose query: %w", err)
 	}

--- a/cli/cmd/search/search.go
+++ b/cli/cmd/search/search.go
@@ -54,13 +54,15 @@ Examples:
    dirctl search --verified
    dirctl search --name "cisco.com/*" --verified
 
-7. Search for trusted records only (signature verification passed):
+7. Search by signature trust (each boolean filter also takes an explicit =false):
    dirctl search --trusted
    dirctl search --name "web*" --trusted
+   dirctl search --trusted=false            # records whose signature is not trusted
 
-8. Search for security-scanned records where all scanners reported safe:
+8. Search by security scan outcome:
    dirctl search --safe
    dirctl search --name "web*" --safe
+   dirctl search --safe=false               # at least one scanner reported unsafe
 
 9. Search for records whose highest scan severity meets or exceeds a threshold:
    dirctl search --scan-severity HIGH
@@ -70,6 +72,17 @@ Examples:
     dirctl search --annotation 'manager:alice'
     dirctl search --annotation 'team:*'
     dirctl search --annotation 'env:prod' --annotation 'region:us-*'
+
+11. Exclude matches with the --exclude-* form of any value filter:
+    dirctl search --exclude-skill 'natural_language_processing'
+    dirctl search --domain 'life_science/*' --exclude-author 'bot*'
+    dirctl search --exclude-scan-severity MEDIUM
+
+Every value filter has an --exclude- twin. Values of one filter are combined
+with OR, while every excluded value must not match, so
+"--skill python --exclude-skill nlp" means "has python and does not have nlp".
+Exclusion adds no syntax: wildcards, comparison operators and ':' behave
+exactly as they do on the including flag.
 
 Supported wildcards:
   * - matches zero or more characters

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -1314,10 +1314,41 @@ Omit the positional argument and use filter flags to query specific fields. All 
 | `--schema-version` | OASF schema version |
 | `--module-id` | Module ID |
 | `--annotation` | Annotation key=value |
-| `--verified` | Only verified records |
-| `--trusted` | Only trusted records (signature verification passed) |
-| `--safe` | Only records where all security scanners reported `is_safe=true` |
+| `--verified` | Only verified records; `--verified=false` for records without verified name ownership |
+| `--trusted` | Only trusted records (signature verification passed); `--trusted=false` for records without a trusted signature |
+| `--safe` | Only records where all security scanners reported `is_safe=true`; `--safe=false` for records where at least one scanner did not |
 | `--scan-severity` | Only records whose highest scan severity meets or exceeds a threshold (`NONE`, `INFO`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`) |
+
+`--verified`, `--trusted` and `--safe` are tri-state: omitting the flag does not filter on that property at all, while an explicit `=false` filters for records that failed the check.
+
+**Exclude flags:**
+
+Every filter above except the three booleans has an `--exclude-` twin —
+`--exclude-name`, `--exclude-version`, `--exclude-skill-id`, `--exclude-skill`,
+`--exclude-locator`, `--exclude-module`, `--exclude-domain-id`, `--exclude-domain`,
+`--exclude-author`, `--exclude-schema-version`, `--exclude-module-id`,
+`--exclude-annotation` and `--exclude-scan-severity`. Each is repeatable and takes
+the same values as the flag it mirrors; wildcards, comparison operators and `:`
+behave identically, and `!` is an ordinary character.
+
+```bash
+dirctl search --exclude-skill "natural_language_processing"
+dirctl search --domain "life_science/*" --exclude-author "bot*"
+dirctl search --skill python --exclude-skill nlp   # has python, does not have nlp
+```
+
+Values of one filter are combined with **OR**, while every excluded value must
+**not** match. Excluding a multi-valued field drops the record if *any* of its
+values match, so `--exclude-skill nlp` drops a record whose skills are
+`[nlp, python]`.
+
+To exclude on a boolean, use the tri-state `=false` form (`--trusted=false`) rather
+than an `--exclude-` flag.
+
+!!! note "`--exclude-scan-severity` also keeps never-scanned records"
+    It excludes records that have a scan report at or above the given threshold.
+    A record that was never scanned has no such report, so it is kept. Combine it
+    with `--safe` when you want scanned-and-clean only.
 
 **Output and pagination flags:**
 

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -1310,6 +1310,7 @@ Omit the positional argument and use filter flags to query specific fields. All 
 | `--module` | Module path (e.g. `core/llm/model`) |
 | `--domain-id` | Domain ID |
 | `--domain` | Domain name |
+| `--created-at` | Record creation timestamp (e.g. `2024-*`, `>=2024-01-01`) |
 | `--author` | Author name |
 | `--schema-version` | OASF schema version |
 | `--module-id` | Module ID |
@@ -1326,10 +1327,10 @@ Omit the positional argument and use filter flags to query specific fields. All 
 Every filter above except the three booleans has an `--exclude-` twin —
 `--exclude-name`, `--exclude-version`, `--exclude-skill-id`, `--exclude-skill`,
 `--exclude-locator`, `--exclude-module`, `--exclude-domain-id`, `--exclude-domain`,
-`--exclude-author`, `--exclude-schema-version`, `--exclude-module-id`,
-`--exclude-annotation` and `--exclude-scan-severity`. Each is repeatable and takes
-the same values as the flag it mirrors; wildcards, comparison operators and `:`
-behave identically, and `!` is an ordinary character.
+`--exclude-created-at`, `--exclude-author`, `--exclude-schema-version`,
+`--exclude-module-id`, `--exclude-annotation` and `--exclude-scan-severity`. Each is
+repeatable and takes the same values as the flag it mirrors; wildcards, comparison
+operators and `:` behave identically, and `!` is an ordinary character.
 
 ```bash
 dirctl search --exclude-skill "natural_language_processing"

--- a/tests/e2e/local/02_search_test.go
+++ b/tests/e2e/local/02_search_test.go
@@ -147,6 +147,74 @@ var _ = ginkgo.Describe("Search functionality for OASF 0.8.0 records", func() {
 			})
 		})
 
+		// Exclude filters. These exercise the RecordQuery.negate path end to end:
+		// the CLI flag, the negated query, and the server's NOT EXISTS compilation.
+		ginkgo.Context("exclude filters", func() {
+			ginkgo.It("excludes record by a skill it has", func() {
+				output := testEnv.CLI.Search().
+					WithArgs("--exclude-skill-id", "10201").
+					ShouldSucceed()
+				gomega.Expect(output).NotTo(gomega.ContainSubstring(recordCID))
+			})
+
+			// A record with skills [10201, 10702] must not survive
+			// --exclude-skill-id 10201 via its other skill row.
+			ginkgo.It("excludes on a multi-valued field if any value matches", func() {
+				output := testEnv.CLI.Search().
+					WithSkillID("10702").
+					WithArgs("--exclude-skill-id", "10201").
+					ShouldSucceed()
+				gomega.Expect(output).NotTo(gomega.ContainSubstring(recordCID))
+			})
+
+			ginkgo.It("keeps record when the excluded value does not match", func() {
+				output := testEnv.CLI.Search().
+					WithName("*research-assistant*").
+					WithArgs("--exclude-skill-id", "99999").
+					ShouldSucceed()
+				gomega.Expect(output).To(gomega.ContainSubstring(recordCID))
+			})
+
+			ginkgo.It("combines an include and an exclude on the same field", func() {
+				output := testEnv.CLI.Search().
+					WithVersion("v4.0.0").
+					WithArgs("--exclude-version", "v1.0.0").
+					ShouldSucceed()
+				gomega.Expect(output).To(gomega.ContainSubstring(recordCID))
+			})
+
+			ginkgo.It("excludes by wildcard name", func() {
+				output := testEnv.CLI.Search().
+					WithArgs("--exclude-name", "*research-assistant*").
+					ShouldSucceed()
+				gomega.Expect(output).NotTo(gomega.ContainSubstring(recordCID))
+			})
+
+			ginkgo.It("excludes by author", func() {
+				output := testEnv.CLI.Search().
+					WithArgs("--exclude-author", "AGNTCY*").
+					ShouldSucceed()
+				gomega.Expect(output).NotTo(gomega.ContainSubstring(recordCID))
+			})
+
+			ginkgo.It("excludes by domain", func() {
+				output := testEnv.CLI.Search().
+					WithArgs("--exclude-domain", "life_science/*").
+					ShouldSucceed()
+				gomega.Expect(output).NotTo(gomega.ContainSubstring(recordCID))
+			})
+
+			// The record carries no scan report, so nothing is at or above the
+			// threshold and it survives the exclusion.
+			ginkgo.It("keeps a never-scanned record when excluding by scan severity", func() {
+				output := testEnv.CLI.Search().
+					WithName("*research-assistant*").
+					WithArgs("--exclude-scan-severity", "MEDIUM").
+					ShouldSucceed()
+				gomega.Expect(output).To(gomega.ContainSubstring(recordCID))
+			})
+		})
+
 		// Negative tests
 		ginkgo.Context("negative tests", func() {
 			ginkgo.It("returns no results for non-matching query", func() {


### PR DESCRIPTION
Closes #1986.

## What

`RecordQuery.negate` landed in #1983 and the server compiles exclusion for every filter type — 17 `Without*` options in `server/types/search.go`, with the correct `NOT EXISTS` shape for joined, multi-valued fields. None of it was reachable from `dirctl`: `BuildQueries` only ever built inclusion queries, so negation was usable only by hand-rolled SDK callers.

This adds an `--exclude-` twin for every value filter, plus tri-state booleans.

| Include | Exclude |
| --- | --- |
| `--name` | `--exclude-name` |
| `--version` | `--exclude-version` |
| `--skill` / `--skill-id` | `--exclude-skill` / `--exclude-skill-id` |
| `--domain` / `--domain-id` | `--exclude-domain` / `--exclude-domain-id` |
| `--module` / `--module-id` | `--exclude-module` / `--exclude-module-id` |
| `--locator` | `--exclude-locator` |
| `--author` | `--exclude-author` |
| `--created-at` | `--exclude-created-at` |
| `--schema-version` | `--exclude-schema-version` |
| `--annotation` | `--exclude-annotation` |
| `--scan-severity` | `--exclude-scan-severity` |

```bash
dirctl search --exclude-skill "natural_language_processing"
dirctl search --domain "life_science/*" --exclude-author "bot*"
dirctl search --skill python --exclude-skill nlp   # has python, does not have nlp
dirctl search --trusted=false                      # signature not trusted
```

`--verified`, `--trusted` and `--safe` become tri-state. Cobra already parsed `--trusted=false`; it just silently meant "do not filter". It now emits a query with value `"false"`, which `QueryToFilters` has understood since #1983. An absent flag still does not filter, so nothing changes for existing invocations.

## Design notes

**Separate flags rather than an inline `!` marker.** `!` composes cleanly with wildcards (`!nlp*`) but awkwardly with comparison operators (`!>=1.0.0`, and `!=1.0.0` means different things on a field that supports comparisons versus one that does not) and ambiguously with `:` — `--annotation '!urgent:true'` cannot be told apart from a key legitimately named `!urgent` without an escape. Separate flags leave the value grammar untouched: `!` stays an ordinary character.

**`FilterValues{Include, Exclude}`.** The server ORs a filter's included values but ANDs each exclusion as its own `NOT EXISTS`, so the two cannot share a slice — called out in #1940's own write-up. Splitting at the flag means pflag does the separation and `BuildQueries` needs no parsing.

`Filters` is now driven by one `valueFilters()` table carrying flag name, both help strings and the query type, so registration and query building are a single loop each and a future filter is one entry instead of three edits. Nothing outside the package read the old fields; the only follow-through was `nlsearch.go`, where the extractor takes `SchemaVersions.Include` (an excluded version has no taxonomy to point at).

**Booleans keep the `=false` form** rather than gaining `--exclude-trusted` — it costs no new flag surface.

## Notes for reviewers

- The flags land on `pull`, `export` and `install` too, since all four share `registerFilterFlags`. Verified: 14 exclude flags on each.
- `dirctl install` registers the filters as *persistent* flags, so tri-state detection depends on cobra sharing the `*pflag.Flag` pointer between a parent's persistent set and a subcommand's merged set. Covered by `TestBuildQueriesTriStateThroughPersistentFlags`.
- `--exclude-scan-severity` **keeps never-scanned records**: it excludes records that have a report at or above the threshold, and an unscanned record has none. This matches the server's existing `applyExcludedScanSeverities`, and is documented next to the flag and in the CLI reference.
- `--safe=false` is likewise **not** the complement of `--safe` — it compiles to `EXISTS (scan_reports … is_safe = false)`, so a never-scanned record matches neither. `--trusted=false` and `--verified=false` *are* true complements.
- Exclusion on a multi-valued field drops the record if *any* value matches, so `--exclude-skill nlp` drops a record whose skills are `[nlp, python]`.

## Testing

- `cli/cmd/search/filters_test.go` (new): every include flag, every exclude flag, include+exclude on one field, repeatability, verbatim pass-through of `>=`, `*`, `!` and `:`, tri-state booleans, the persistent-flag path, and the programmatic `Filters` fallback.
- `tests/e2e/local/02_search_test.go`: 8 specs exercising the CLI → server → `NOT EXISTS` path, including the multi-valued case and the never-scanned severity case. **These have not had a passing local run** — the local e2e suite was cut short — so they are unproven until CI runs them.
- `task lint:go` clean across all 7 modules; docs markdown and spelling clean.

## Unblocks

#1977 — the policy CronJob Helm templates, whose `prune-untrusted` example renders `--trusted=false`.
