### PR TITLE
feat(helm): add configurable policy CronJobs to the dirctl chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,13 @@ jobs:
         run: |
           task lint
 
+      # `helm lint` only checks that a chart renders. The policy CronJob
+      # templates encode behaviour (predicate translation, pagination, the
+      # template-time rejections) that only these assertions cover.
+      - name: Run Helm chart tests
+        run: |
+          task test:helm
+
   license:
     name: License
     needs: changes

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -354,6 +354,13 @@ tasks:
           rm /tmp/total_report_results.txt
         if: '{{ eq .SHOW_TOTAL_ONLY "true" }}'
 
+  test:helm:
+    desc: Run Helm chart template tests
+    deps:
+      - task: deps:helm
+    cmds:
+      - cmd: HELM={{.HELM_BIN}} ./install/charts/dirctl/ci/test-policies.sh
+
 
   ##
   ## Linters

--- a/docs/content/dir/dir-deployment-kubernetes.md
+++ b/docs/content/dir/dir-deployment-kubernetes.md
@@ -296,6 +296,94 @@ The Agent Directory Service can be deployed using Helm or GitOps / Argo CD. Helm
     !!! important "Trust domain"
         This Quick Start uses `example.org` for local testing only. To federate with the public Directory network, you need a unique trust domain. See [Production Deployment](dir-prod-deployment.md) and [Running a Federated Directory Instance](dir-federation-setup.md).
 
+## Content Policies
+
+A content policy runs a scheduled "search, then act on the matches" pipeline against your node. Policies are declared in the `dirctl` chart's values — no forked chart and no hand-written manifests. Each enabled policy renders a CronJob named `<release>-dirctl-policy-<key>`.
+
+```yaml
+policies:
+  sync-netsec:
+    enabled: true
+    schedule: "0 3 * * *"
+    action: sync
+    match:
+      domain: [network_security]
+
+  prune-untrusted:
+    enabled: true
+    schedule: "*/30 * * * *"
+    action: prune
+    match:
+      trusted: false
+      scan-severity: MEDIUM
+```
+
+`sync-netsec` pulls every record peers advertise in the `network_security` domain into this node, nightly. `prune-untrusted` deletes local records whose signature is not trusted and that scan at MEDIUM severity or worse, every 30 minutes.
+
+### Actions
+
+| Action | What it does | Underlying pipeline |
+| --- | --- | --- |
+| `sync` | Pull matching records from network peers into this node | `dirctl routing search` → `dirctl sync create --stdin` |
+| `prune` | Delete matching records from this node's store | `dirctl search` → `dirctl delete --stdin` |
+| `publish` | Announce matching local records to the routing network | `dirctl search` → `dirctl routing publish --stdin` |
+| `unpublish` | Withdraw matching local records from the routing network | `dirctl search` → `dirctl routing unpublish --stdin` |
+
+### Predicates
+
+`match` keys are `dirctl` flag names with the leading `--` removed, so every filter the CLI supports is available without a chart change:
+
+| Value kind | Example | Rendered flag |
+| --- | --- | --- |
+| List | `domain: [a, b]` | `--domain 'a' --domain 'b'` |
+| Boolean | `trusted: false` | `--trusted=false` |
+| Scalar | `scan-severity: MEDIUM` | `--scan-severity 'MEDIUM'` |
+
+Boolean filters are tri-state. Omitting `trusted` does not filter on trust at all; `trusted: true` matches records with a trusted signature; `trusted: false` matches records without one. The same holds for `verified` and `safe`.
+
+Because keys are passed through mechanically, the `exclude-` filters work too — carving an exception out of a policy needs no chart change:
+
+```yaml
+policies:
+  prune-untrusted-except-cisco:
+    enabled: true
+    schedule: "@daily"
+    action: prune
+    match:
+      trusted: false
+      exclude-name: ["cisco.com/*"]
+```
+
+`limit`, `format` and `output` are set by the chart and are rejected inside `match`. An unknown `action` and a value containing a single quote also fail at `helm template` time rather than at run time.
+
+!!! note "`sync` searches the network, not your store"
+    `sync` queries the routing index to find records held by other peers, so its `match` keys are limited to those `dirctl routing search` accepts: `skill`, `domain`, `locator`, `module` and `min-score`. The other three actions search the local store and accept the full `dirctl search` filter set.
+
+### Other Fields
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Render the CronJob. |
+| `schedule` | required | Cron expression. |
+| `limit` | `100` | Maximum records processed per run. |
+| `dryRun` | `false` | Log the matches and exit without applying the action. |
+
+A run does not paginate: it processes at most `limit` records, and a policy converges over successive runs. `env`, `resources`, `volumes`, `volumeMounts`, `concurrencyPolicy`, `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` may be set per policy and behave exactly as they do for a `cronjobs` entry.
+
+!!! important "Preview a destructive policy before enabling it"
+    `prune` deletes records and `unpublish` withdraws them from the network. Set `dryRun: true` for the first few runs and read the CronJob logs — every run logs the match count and dumps the matched records before acting:
+
+    ```text
+    [prune-untrusted] matched 12 record(s)
+    [
+      "baeareib...",
+      ...
+    ]
+    [prune-untrusted] dry run: not applying action 'prune'
+    ```
+
+Both example policies ship disabled in `values.yaml`. Adding a policy of your own is a values change only.
+
 ## Security Scanning
 
 The reconciler image includes [`mcp-scanner`](https://cisco-ai-defense.github.io/docs/mcp-scanner) and [`skill-scanner`](https://cisco-ai-defense.github.io/docs/skill-scanner) pre-installed. The scan task is enabled by default and requires Azure OpenAI credentials to perform LLM-backed analysis.

--- a/docs/content/dir/dir-deployment-kubernetes.md
+++ b/docs/content/dir/dir-deployment-kubernetes.md
@@ -339,7 +339,10 @@ policies:
 | Boolean | `trusted: false` | `--trusted=false` |
 | Scalar | `scan-severity: MEDIUM` | `--scan-severity 'MEDIUM'` |
 
-Boolean filters are tri-state. Omitting `trusted` does not filter on trust at all; `trusted: true` matches records with a trusted signature; `trusted: false` matches records without one. The same holds for `verified` and `safe`.
+Boolean filters are tri-state. Omitting `trusted` does not filter on trust at all; `trusted: true` matches records with a trusted signature; `trusted: false` matches records without one. `verified` behaves the same way.
+
+!!! warning "`safe: false` is not the complement of `safe: true`"
+    `safe: true` matches records where every scanner reported `is_safe=true`, and `safe: false` matches records where at least one scanner reported unsafe. A record that was **never scanned** matches neither. A `prune` policy keyed on `safe: false` therefore deletes only records with a failing scan report, and silently leaves unscanned records untouched — which is likely the opposite of the intent. To act on "not known to be safe", combine `safe: false` with a separate policy for unscanned records, or gate on `scan-severity` instead.
 
 Because keys are passed through mechanically, the `exclude-` filters work too — carving an exception out of a policy needs no chart change:
 
@@ -368,7 +371,15 @@ policies:
 | `limit` | `100` | Maximum records processed per run. |
 | `dryRun` | `false` | Log the matches and exit without applying the action. |
 
-A run does not paginate: it processes at most `limit` records, and a policy converges over successive runs. `env`, `resources`, `volumes`, `volumeMounts`, `concurrencyPolicy`, `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` may be set per policy and behave exactly as they do for a `cronjobs` entry.
+`limit` is a page size, and how a run covers matches beyond it depends on the action:
+
+| Action | Coverage |
+| --- | --- |
+| `prune` | Deleting a record stops it matching, so the set shrinks and successive runs converge on the whole backlog. |
+| `publish`, `unpublish` | The run pages through `--offset` until it sees a short page, so a single run covers every match. |
+| `sync` | Processes only the first `limit` matches. `dirctl routing search` has no `--offset`, and syncing does not stop a peer advertising the record, so later matches are never reached — set `limit` above your expected match count. |
+
+`env`, `resources`, `volumes`, `volumeMounts`, `concurrencyPolicy`, `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` may be set per policy and behave exactly as they do for a `cronjobs` entry.
 
 !!! important "Preview a destructive policy before enabling it"
     `prune` deletes records and `unpublish` withdraws them from the network. Set `dryRun: true` for the first few runs and read the CronJob logs — every run logs the match count and dumps the matched records before acting:

--- a/install/charts/dirctl/.helmignore
+++ b/install/charts/dirctl/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Chart test fixtures
+ci/

--- a/install/charts/dirctl/ci/policies-values.yaml
+++ b/install/charts/dirctl/ci/policies-values.yaml
@@ -1,0 +1,48 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# Values for ci/test-policies.sh. Exercises every action, every match value kind,
+# the dry-run path, and the disabled path.
+
+cronjobs: {}
+
+policies:
+  sync-netsec:
+    enabled: true
+    schedule: '0 3 * * *'
+    action: sync
+    match:
+      domain:
+        - network_security
+
+  prune-untrusted:
+    enabled: true
+    schedule: '*/30 * * * *'
+    action: prune
+    match:
+      trusted: false
+      scan-severity: MEDIUM
+
+  publish-signed:
+    enabled: true
+    schedule: '@hourly'
+    action: publish
+    limit: 25
+    match:
+      name:
+        - 'cisco.com/*'
+        - 'agntcy.org/*'
+      trusted: true
+
+  unpublish-stale:
+    enabled: true
+    schedule: '@daily'
+    action: unpublish
+    dryRun: true
+    match:
+      created-at: '<2025-01-01'
+
+  never-enabled:
+    enabled: false
+    schedule: '@daily'
+    action: prune

--- a/install/charts/dirctl/ci/test-policies.sh
+++ b/install/charts/dirctl/ci/test-policies.sh
@@ -56,6 +56,16 @@ RENDERED="$("$HELM" template policy-test "$CHART" --values "$CHART/ci/policies-v
   exit 1
 }
 
+# policy_doc <policy name> prints just that policy's CronJob manifest, so a
+# per-policy assertion cannot accidentally match another policy's script.
+policy_doc() {
+  printf '%s' "$RENDERED" | awk -v want="  name: policy-test-dirctl-policy-$1" '
+    $0 == want { f = 1 }
+    f && /^---$/ { exit }
+    f { print }
+  '
+}
+
 assert_contains "$RENDERED" "name: policy-test-dirctl-policy-sync-netsec" \
   "sync policy renders a CronJob"
 assert_contains "$RENDERED" "dirctl routing search --output json --limit 100 --domain 'network_security'" \
@@ -68,10 +78,25 @@ assert_contains "$RENDERED" "dirctl search --format cid --output json --limit 10
 assert_contains "$RENDERED" "dirctl delete --stdin" \
   "prune pipes matches into delete"
 
-assert_contains "$RENDERED" "dirctl search --format cid --output json --limit 25 --name 'cisco.com/*' --name 'agntcy.org/*' --trusted=true" \
+assert_contains "$RENDERED" "dirctl search --format cid --output json --limit 25 --name 'cisco.com/*' --name 'agntcy.org/*' --trusted=true --offset \"\$offset\"" \
   "publish repeats a list match and honours the policy limit"
 assert_contains "$RENDERED" "dirctl routing publish --stdin" \
   "publish pipes matches into routing publish"
+
+# Pagination. publish/unpublish do not change whether a record matches, so they
+# must page; prune shrinks its own result set and sync cannot page at all
+# (dirctl routing search has no --offset).
+assert_contains "$RENDERED" 'offset=$((offset + 25))' \
+  "publish pages through offsets"
+assert_contains "$RENDERED" "processed \${total} record(s)" \
+  "publish reports a total across pages"
+assert_not_contains "$(policy_doc prune-untrusted)" "--offset" \
+  "prune does not paginate"
+assert_not_contains "$(policy_doc sync-netsec)" "--offset" \
+  "sync does not paginate"
+
+assert_contains "$RENDERED" 'if [ -z "$out" ]; then' \
+  "scripts fail loudly when the search prints nothing"
 
 assert_contains "$RENDERED" "dry run: not applying action 'unpublish'" \
   "dryRun replaces the sink with a log line"
@@ -103,6 +128,24 @@ assert_render_fails "is set by the chart" "a reserved match key fails the render
 assert_render_fails "cannot be safely shell-quoted" "a quote in a match value fails the render" \
   --set policies.bad.enabled=true --set policies.bad.schedule='@daily' \
   --set policies.bad.action=prune --set "policies.bad.match.name=o'brien"
+
+# Keys and limit are interpolated into the shell command unquoted, so both are
+# constrained at template time rather than trusted.
+assert_render_fails "is not a valid dirctl flag name" "a shell metacharacter in a match key fails the render" \
+  --set policies.bad.enabled=true --set policies.bad.schedule='@daily' \
+  --set policies.bad.action=prune --set 'policies.bad.match.name; echo pwned #=v'
+
+assert_render_fails "limit must be a positive integer" "a non-numeric limit fails the render" \
+  --set policies.bad.enabled=true --set policies.bad.schedule='@daily' \
+  --set policies.bad.action=prune --set-string 'policies.bad.limit=1; echo pwned'
+
+assert_render_fails "limit must be a positive integer" "a zero limit fails the render" \
+  --set policies.bad.enabled=true --set policies.bad.schedule='@daily' \
+  --set policies.bad.action=prune --set policies.bad.limit=0
+
+assert_render_fails "a sync policy needs at least one of" "a sync policy with no routing criterion fails the render" \
+  --set policies.bad.enabled=true --set policies.bad.schedule='@daily' \
+  --set policies.bad.action=sync --set policies.bad.match.trusted=false
 
 if [ "$FAILURES" -ne 0 ]; then
   echo

--- a/install/charts/dirctl/ci/test-policies.sh
+++ b/install/charts/dirctl/ci/test-policies.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts on the policy CronJobs the dirctl chart renders. `helm lint` only
+# checks that the chart renders at all, so none of this is covered by it.
+
+set -uo pipefail
+
+HELM="${HELM:-helm}"
+CHART="$(cd "$(dirname "$0")/.." && pwd)"
+FAILURES=0
+
+pass() { echo "ok   - $1"; }
+fail() {
+  echo "FAIL - $1"
+  shift
+  for detail in "$@"; do echo "       $detail"; done
+  FAILURES=$((FAILURES + 1))
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" what="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    pass "$what"
+  else
+    fail "$what" "expected to find: $needle"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" what="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    fail "$what" "did not expect to find: $needle"
+  else
+    pass "$what"
+  fi
+}
+
+# assert_render_fails <expected message fragment> <description> <helm args...>
+assert_render_fails() {
+  local needle="$1" what="$2"
+  shift 2
+  local output
+  if output="$("$HELM" template policy-test "$CHART" "$@" 2>&1)"; then
+    fail "$what" "render unexpectedly succeeded"
+  elif printf '%s' "$output" | grep -qF -- "$needle"; then
+    pass "$what"
+  else
+    fail "$what" "expected error to mention: $needle" "got: $output"
+  fi
+}
+
+RENDERED="$("$HELM" template policy-test "$CHART" --values "$CHART/ci/policies-values.yaml")" || {
+  echo "FAIL - chart failed to render with ci/policies-values.yaml"
+  exit 1
+}
+
+assert_contains "$RENDERED" "name: policy-test-dirctl-policy-sync-netsec" \
+  "sync policy renders a CronJob"
+assert_contains "$RENDERED" "dirctl routing search --output json --limit 100 --domain 'network_security'" \
+  "sync searches the routing index with the match flags"
+assert_contains "$RENDERED" "dirctl sync create --stdin" \
+  "sync pipes matches into sync create"
+
+assert_contains "$RENDERED" "dirctl search --format cid --output json --limit 100 --scan-severity 'MEDIUM' --trusted=false" \
+  "prune renders a negated bool and a scalar match"
+assert_contains "$RENDERED" "dirctl delete --stdin" \
+  "prune pipes matches into delete"
+
+assert_contains "$RENDERED" "dirctl search --format cid --output json --limit 25 --name 'cisco.com/*' --name 'agntcy.org/*' --trusted=true" \
+  "publish repeats a list match and honours the policy limit"
+assert_contains "$RENDERED" "dirctl routing publish --stdin" \
+  "publish pipes matches into routing publish"
+
+assert_contains "$RENDERED" "dry run: not applying action 'unpublish'" \
+  "dryRun replaces the sink with a log line"
+assert_not_contains "$RENDERED" "dirctl routing unpublish --stdin" \
+  "dryRun does not render the sink"
+
+assert_contains "$RENDERED" 'if [ "$count" -eq 0 ]; then' \
+  "generated scripts guard against an empty match set"
+assert_not_contains "$RENDERED" "pipefail" \
+  "generated scripts avoid pipefail (busybox ash)"
+
+assert_not_contains "$RENDERED" "policy-never-enabled" \
+  "a disabled policy renders nothing"
+
+DEFAULTS="$("$HELM" template policy-test "$CHART")" || {
+  echo "FAIL - chart failed to render with default values"
+  exit 1
+}
+assert_not_contains "$DEFAULTS" "-policy-" \
+  "the shipped example policies are disabled by default"
+
+assert_render_fails 'unknown action "nope"' "an unknown action fails the render" \
+  --set policies.bad.enabled=true --set policies.bad.schedule='@daily' --set policies.bad.action=nope
+
+assert_render_fails "is set by the chart" "a reserved match key fails the render" \
+  --set policies.bad.enabled=true --set policies.bad.schedule='@daily' \
+  --set policies.bad.action=prune --set policies.bad.match.limit=5
+
+assert_render_fails "cannot be safely shell-quoted" "a quote in a match value fails the render" \
+  --set policies.bad.enabled=true --set policies.bad.schedule='@daily' \
+  --set policies.bad.action=prune --set "policies.bad.match.name=o'brien"
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo
+  echo "$FAILURES assertion(s) failed"
+  exit 1
+fi
+
+echo
+echo "all policy template assertions passed"

--- a/install/charts/dirctl/templates/_policies.tpl
+++ b/install/charts/dirctl/templates/_policies.tpl
@@ -37,8 +37,16 @@ Input: dict with "name" (policy name) and "match" (the map).
 {{- $name := .name -}}
 {{- $rendered := list -}}
 {{- range $key, $value := .match -}}
-{{-   if has $key (list "limit" "format" "output") -}}
+{{-   if has $key (list "limit" "offset" "format" "output") -}}
 {{-     fail (printf "policy %q: match key %q is set by the chart; use the policy's own fields instead" $name $key) -}}
+{{-   end -}}
+{{/*
+  Keys are interpolated into the generated shell command unquoted, so they are
+  constrained to the CLI's flag-name grammar. Without this a key such as
+  "name; rm -rf /" would render as executable shell rather than a flag.
+*/}}
+{{-   if not (regexMatch "^[a-z0-9][a-z0-9-]*$" $key) -}}
+{{-     fail (printf "policy %q: match key %q is not a valid dirctl flag name (expected lowercase letters, digits and hyphens)" $name $key) -}}
 {{-   end -}}
 {{-   if kindIs "slice" $value -}}
 {{-     range $item := $value -}}
@@ -61,6 +69,22 @@ is taken before the sink runs because `dirctl delete`, `dirctl routing publish`
 and `dirctl routing unpublish` reject empty stdin ("at least one CID is
 required"), so a policy that matches nothing would otherwise fail every run.
 
+An empty search result is checked separately from a zero count. A search can exit
+0 while printing nothing (`dirctl routing search` does exactly that when given no
+criteria, reporting to stderr), which leaves `count` empty; `[ "" -eq 0 ]` then
+errors, and because that error is an `if` condition `set -e` does not stop the
+script, so it would fall through to the sink with empty input.
+
+Pagination differs by action, because only some of them change whether a record
+still matches:
+  prune            deleting a record stops it matching, so the set shrinks and
+                   offset 0 always sees the remaining work.
+  publish
+  unpublish        the action does not change the record, so the same first page
+                   would be reprocessed forever. These loop over --offset.
+  sync             `dirctl routing search` has no --offset, so it cannot page.
+                   `limit` must exceed the expected match count.
+
 There is no `set -o pipefail`: the container shell is busybox ash. Capturing the
 search output in a variable under `set -eu` surfaces a failing search just as
 well, and yields the count and the dry-run dump for free.
@@ -71,11 +95,35 @@ Input: dict with "name" (policy name) and "policy" (the policy map).
 {{- $name := .name -}}
 {{- $policy := .policy -}}
 {{- $action := $policy.action | default "" -}}
-{{- $limit := $policy.limit | default 100 -}}
-{{- $flags := include "chart.policy.matchFlags" (dict "name" $name "match" ($policy.match | default dict)) -}}
+{{/*
+  Not `$policy.limit | default 100`: sprig's default treats 0 as empty, which
+  would silently turn an explicit `limit: 0` into 100 instead of rejecting it.
+*/}}
+{{- $limit := 100 -}}
+{{- if hasKey $policy "limit" -}}
+{{-   $limit = $policy.limit -}}
+{{- end -}}
+{{- $match := $policy.match | default dict -}}
+{{/*
+  `limit` is interpolated into the shell command unquoted, so it is constrained to
+  a positive decimal rather than trusted verbatim.
+*/}}
+{{- if not (regexMatch "^[1-9][0-9]*$" (printf "%v" $limit)) -}}
+{{-   fail (printf "policy %q: limit must be a positive integer, got %v" $name $limit) -}}
+{{- end -}}
+{{- $flags := include "chart.policy.matchFlags" (dict "name" $name "match" $match) -}}
 {{- $source := "" -}}
 {{- $sink := "" -}}
+{{- $paginate := false -}}
 {{- if eq $action "sync" -}}
+{{/*
+    `dirctl routing search` needs at least one routing criterion; with none it
+    exits 0 having printed nothing, which is not a failure the script can report
+    usefully.
+  */}}
+{{-   if not (or (hasKey $match "skill") (hasKey $match "domain") (hasKey $match "locator") (hasKey $match "module")) -}}
+{{-     fail (printf "policy %q: a sync policy needs at least one of match.skill, match.domain, match.locator or match.module (dirctl routing search requires a criterion)" $name) -}}
+{{-   end -}}
 {{-   $source = printf "dirctl routing search --output json --limit %v %s" $limit $flags | trim -}}
 {{-   $sink = "dirctl sync create --stdin" -}}
 {{- else if eq $action "prune" -}}
@@ -84,14 +132,45 @@ Input: dict with "name" (policy name) and "policy" (the policy map).
 {{- else if eq $action "publish" -}}
 {{-   $source = printf "dirctl search --format cid --output json --limit %v %s" $limit $flags | trim -}}
 {{-   $sink = "dirctl routing publish --stdin" -}}
+{{-   $paginate = true -}}
 {{- else if eq $action "unpublish" -}}
 {{-   $source = printf "dirctl search --format cid --output json --limit %v %s" $limit $flags | trim -}}
 {{-   $sink = "dirctl routing unpublish --stdin" -}}
+{{-   $paginate = true -}}
 {{- else -}}
 {{-   fail (printf "policy %q: unknown action %q (must be one of: sync, prune, publish, unpublish)" $name $action) -}}
 {{- end -}}
+{{- if $paginate -}}
+set -eu
+offset=0
+total=0
+while :; do
+  out="$({{ $source }} --offset "$offset")"
+  if [ -z "$out" ]; then
+    echo "[{{ $name }}] search returned no output" >&2
+    exit 1
+  fi
+  count="$(printf '%s' "$out" | jq 'length')"
+  if [ "$count" -eq 0 ]; then
+    break
+  fi
+  echo "[{{ $name }}] matched ${count} record(s) at offset ${offset}"
+  printf '%s' "$out" | jq .
+  {{ if $policy.dryRun }}echo "[{{ $name }}] dry run: not applying action '{{ $action }}'"{{ else }}printf '%s' "$out" | {{ $sink }}{{ end }}
+  total=$((total + count))
+  if [ "$count" -lt {{ $limit }} ]; then
+    break
+  fi
+  offset=$((offset + {{ $limit }}))
+done
+echo "[{{ $name }}] processed ${total} record(s)"
+{{- else -}}
 set -eu
 out="$({{ $source }})"
+if [ -z "$out" ]; then
+  echo "[{{ $name }}] search returned no output" >&2
+  exit 1
+fi
 count="$(printf '%s' "$out" | jq 'length')"
 echo "[{{ $name }}] matched ${count} record(s)"
 if [ "$count" -eq 0 ]; then
@@ -99,4 +178,5 @@ if [ "$count" -eq 0 ]; then
 fi
 printf '%s' "$out" | jq .
 {{ if $policy.dryRun }}echo "[{{ $name }}] dry run: not applying action '{{ $action }}'"{{ else }}printf '%s' "$out" | {{ $sink }}{{ end }}
+{{- end -}}
 {{- end -}}

--- a/install/charts/dirctl/templates/_policies.tpl
+++ b/install/charts/dirctl/templates/_policies.tpl
@@ -1,0 +1,102 @@
+{{/*
+Copyright AGNTCY Contributors (https://github.com/agntcy)
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Single-quote a match value for the generated shell script.
+
+A value containing a single quote would break out of the quoting, so it is
+rejected at template time rather than producing a broken CronJob.
+
+Input: dict with "name" (policy name), "key" (match key) and "value".
+*/}}
+{{- define "chart.policy.shellQuote" -}}
+{{- $value := printf "%v" .value -}}
+{{- if contains "'" $value -}}
+{{- fail (printf "policy %q: match value for %q contains a single quote and cannot be safely shell-quoted: %s" .name .key $value) -}}
+{{- end -}}
+{{- printf "'%s'" $value -}}
+{{- end -}}
+
+{{/*
+Render a policy's `match` map into a dirctl flag string.
+
+Keys are dirctl flag names without the leading "--", so any filter the CLI grows
+works without a chart change. Values render by kind:
+  list   -> the flag repeated once per item
+  bool   -> --flag=true / --flag=false
+  scalar -> --flag 'value'
+
+`limit`, `format` and `output` are set by the chart itself and are rejected here
+so a policy cannot silently emit a duplicate flag.
+
+Input: dict with "name" (policy name) and "match" (the map).
+*/}}
+{{- define "chart.policy.matchFlags" -}}
+{{- $name := .name -}}
+{{- $rendered := list -}}
+{{- range $key, $value := .match -}}
+{{-   if has $key (list "limit" "format" "output") -}}
+{{-     fail (printf "policy %q: match key %q is set by the chart; use the policy's own fields instead" $name $key) -}}
+{{-   end -}}
+{{-   if kindIs "slice" $value -}}
+{{-     range $item := $value -}}
+{{-       $rendered = append $rendered (printf "--%s %s" $key (include "chart.policy.shellQuote" (dict "name" $name "key" $key "value" $item))) -}}
+{{-     end -}}
+{{-   else if kindIs "bool" $value -}}
+{{-     $rendered = append $rendered (printf "--%s=%t" $key $value) -}}
+{{-   else -}}
+{{-     $rendered = append $rendered (printf "--%s %s" $key (include "chart.policy.shellQuote" (dict "name" $name "key" $key "value" $value))) -}}
+{{-   end -}}
+{{- end -}}
+{{- join " " $rendered -}}
+{{- end -}}
+
+{{/*
+Render the shell script that implements a policy.
+
+Every action is the same shape: search, then act on the matches. The match count
+is taken before the sink runs because `dirctl delete`, `dirctl routing publish`
+and `dirctl routing unpublish` reject empty stdin ("at least one CID is
+required"), so a policy that matches nothing would otherwise fail every run.
+
+There is no `set -o pipefail`: the container shell is busybox ash. Capturing the
+search output in a variable under `set -eu` surfaces a failing search just as
+well, and yields the count and the dry-run dump for free.
+
+Input: dict with "name" (policy name) and "policy" (the policy map).
+*/}}
+{{- define "chart.policy.script" -}}
+{{- $name := .name -}}
+{{- $policy := .policy -}}
+{{- $action := $policy.action | default "" -}}
+{{- $limit := $policy.limit | default 100 -}}
+{{- $flags := include "chart.policy.matchFlags" (dict "name" $name "match" ($policy.match | default dict)) -}}
+{{- $source := "" -}}
+{{- $sink := "" -}}
+{{- if eq $action "sync" -}}
+{{-   $source = printf "dirctl routing search --output json --limit %v %s" $limit $flags | trim -}}
+{{-   $sink = "dirctl sync create --stdin" -}}
+{{- else if eq $action "prune" -}}
+{{-   $source = printf "dirctl search --format cid --output json --limit %v %s" $limit $flags | trim -}}
+{{-   $sink = "dirctl delete --stdin" -}}
+{{- else if eq $action "publish" -}}
+{{-   $source = printf "dirctl search --format cid --output json --limit %v %s" $limit $flags | trim -}}
+{{-   $sink = "dirctl routing publish --stdin" -}}
+{{- else if eq $action "unpublish" -}}
+{{-   $source = printf "dirctl search --format cid --output json --limit %v %s" $limit $flags | trim -}}
+{{-   $sink = "dirctl routing unpublish --stdin" -}}
+{{- else -}}
+{{-   fail (printf "policy %q: unknown action %q (must be one of: sync, prune, publish, unpublish)" $name $action) -}}
+{{- end -}}
+set -eu
+out="$({{ $source }})"
+count="$(printf '%s' "$out" | jq 'length')"
+echo "[{{ $name }}] matched ${count} record(s)"
+if [ "$count" -eq 0 ]; then
+  exit 0
+fi
+printf '%s' "$out" | jq .
+{{ if $policy.dryRun }}echo "[{{ $name }}] dry run: not applying action '{{ $action }}'"{{ else }}printf '%s' "$out" | {{ $sink }}{{ end }}
+{{- end -}}

--- a/install/charts/dirctl/templates/cronjob.yaml
+++ b/install/charts/dirctl/templates/cronjob.yaml
@@ -1,7 +1,21 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-{{- range $name, $cronjob := .Values.cronjobs }}
+{{/*
+Policies are rendered as ordinary cronjobs whose command is a generated script,
+so they inherit the SPIRE, env, volume, resource and security wiring below
+without duplicating the pod spec. The "policy-" key prefix keeps a policy and a
+cronjobs entry of the same name from colliding.
+*/}}
+{{- $jobs := deepCopy (.Values.cronjobs | default dict) }}
+{{- range $policyName, $policy := (.Values.policies | default dict) }}
+{{- if $policy.enabled }}
+{{-   $job := omit $policy "action" "match" "limit" "dryRun" }}
+{{-   $_ := set $job "command" (list "/bin/sh" "-c" (include "chart.policy.script" (dict "name" $policyName "policy" $policy))) }}
+{{-   $_ := set $jobs (printf "policy-%s" $policyName) $job }}
+{{- end }}
+{{- end }}
+{{- range $name, $cronjob := $jobs }}
 {{- if $cronjob.enabled }}
 ---
 apiVersion: batch/v1
@@ -50,9 +64,7 @@ spec:
             {{- end }}
             {{- with $cronjob.command }}
             command:
-            {{- range . }}
-            - {{ . | quote }}
-            {{- end }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- with $cronjob.args }}
             args:

--- a/install/charts/dirctl/values.yaml
+++ b/install/charts/dirctl/values.yaml
@@ -65,6 +65,51 @@ cronjobs:
       # - name: DIRECTORY_CLIENT_SERVER_ADDRESS
       #   value: dir-apiserver.dir-server.svc.cluster.local:8888
 
+# Content policies
+#
+# A policy runs a "search, then act on the matches" pipeline on a schedule. It
+# renders as a CronJob named <release>-dirctl-policy-<key>, and inherits the same
+# env, volumes, resources and SPIRE wiring as a `cronjobs` entry.
+#
+# action:  sync      pull matching records from network peers into this node
+#          prune     delete matching records from this node's store
+#          publish   announce matching local records to the routing network
+#          unpublish withdraw matching local records from the routing network
+#
+# match:   keys are `dirctl` flag names without the leading "--", so any filter
+#          the CLI supports works here with no chart change:
+#            list   -> the flag repeated per item, e.g. domain: [a, b]
+#            bool   -> --flag=true / --flag=false, e.g. trusted: false
+#            scalar -> --flag 'value', e.g. scan-severity: MEDIUM
+#          `limit`, `format` and `output` are set by the chart and rejected here.
+#          NOTE: `sync` searches the routing index rather than the local store,
+#          so it only accepts skill, domain, locator, module and min-score.
+#
+# limit:   maximum records processed per run (default 100). A run does not
+#          paginate; a policy converges over successive runs.
+#
+# dryRun:  log the matches and exit without applying the action.
+#
+# Both examples ship disabled. Enable them deliberately - `prune` deletes records.
+policies:
+  # Pull every record in the network_security domain from peers, nightly.
+  sync-netsec:
+    enabled: false
+    schedule: '0 3 * * *'
+    action: sync
+    match:
+      domain:
+        - network_security
+
+  # Drop records whose signature is not trusted and that scan at MEDIUM or worse.
+  prune-untrusted:
+    enabled: false
+    schedule: '*/30 * * * *'
+    action: prune
+    match:
+      trusted: false
+      scan-severity: MEDIUM
+
 # SPIRE configuration for workload identity
 spire:
   enabled: false


### PR DESCRIPTION
Closes #1977. Depends on #1987 (merged) for `--trusted=false`, and #1979 for a shell-capable image.

## What

A node-level content policy — "sync every record in a given domain", "drop records that aren't signed" — previously meant a forked chart or hand-written manifests. The `cronjobs` map runs a single `dirctl` call per entry, and a policy is a pipeline: search, then act on the result.

`policies` declares that pipeline from values alone:

```yaml
policies:
  sync-netsec:
    enabled: true
    schedule: "0 3 * * *"
    action: sync
    match:
      domain: [network_security]

  prune-untrusted:
    enabled: true
    schedule: "*/30 * * * *"
    action: prune
    match:
      trusted: false
      scan-severity: MEDIUM
```

Four actions, each pairing a search source with a `--stdin` sink:

| Action | Source | Sink |
| --- | --- | --- |
| `sync` | `dirctl routing search` | `dirctl sync create --stdin` |
| `prune` | `dirctl search` | `dirctl delete --stdin` |
| `publish` | `dirctl search` | `dirctl routing publish --stdin` |
| `unpublish` | `dirctl search` | `dirctl routing unpublish --stdin` |

## Rendered outcome

Both examples ship `enabled: false`. Enabling them produces exactly this — nothing elided:

<details open>
<summary><code>prune-untrusted</code> — full CronJob</summary>

```yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: dir-dirctl-policy-prune-untrusted
  labels:
    helm.sh/chart: dirctl-0.1.0
    app.kubernetes.io/name: dirctl
    app.kubernetes.io/instance: dir
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: dir-dirctl-policy-prune-untrusted
spec:
  schedule: "*/30 * * * *"
  successfulJobsHistoryLimit: 10
  failedJobsHistoryLimit: 10
  concurrencyPolicy: "Forbid"
  jobTemplate:
    spec:
      template:
        metadata:
          labels:
            app.kubernetes.io/name: dirctl
            app.kubernetes.io/instance: dir
            app.kubernetes.io/component: dir-dirctl-policy-prune-untrusted
        spec:
          restartPolicy: OnFailure
          containers:
          - name: dirctl
            image: "ghcr.io/agntcy/dir-ctl:latest"
            imagePullPolicy: IfNotPresent
            securityContext:
              readOnlyRootFilesystem: true
              runAsNonRoot: true
              runAsUser: 65532
            command:
            - /bin/sh
            - -c
            - |-
              set -eu
              out="$(dirctl search --format cid --output json --limit 100 --scan-severity 'MEDIUM' --trusted=false)"
              if [ -z "$out" ]; then
                echo "[prune-untrusted] search returned no output" >&2
                exit 1
              fi
              count="$(printf '%s' "$out" | jq 'length')"
              echo "[prune-untrusted] matched ${count} record(s)"
              if [ "$count" -eq 0 ]; then
                exit 0
              fi
              printf '%s' "$out" | jq .
              printf '%s' "$out" | dirctl delete --stdin
            env:
            - name: DIRECTORY_CLIENT_SERVER_ADDRESS
              value: dir-apiserver.dir-server.svc.cluster.local:8888
            - name: DIRECTORY_CLIENT_AUTH_MODE
              value: ""
            - name: DIRECTORY_CLIENT_JWT_AUDIENCE
              value: ""
            - name: DIRECTORY_CLIENT_SPIFFE_TOKEN
              value: ""
            resources:
              limits:
                cpu: 100m
                memory: 128Mi
              requests:
                cpu: 50m
                memory: 64Mi
            volumeMounts:
              - name: home-dir
                mountPath: /home/nonroot
          volumes:
            # Writable home directory for config files when root filesystem is read-only
            # Required for applications that create config files (e.g., MCP host)
            - name: home-dir
              emptyDir: {}
```

</details>

`sync-netsec`, schedule `0 3 * * *` — same resource shape, differing only in the script:

```sh
set -eu
out="$(dirctl routing search --output json --limit 100 --domain 'network_security')"
if [ -z "$out" ]; then
  echo "[sync-netsec] search returned no output" >&2
  exit 1
fi
count="$(printf '%s' "$out" | jq 'length')"
echo "[sync-netsec] matched ${count} record(s)"
if [ "$count" -eq 0 ]; then
  exit 0
fi
printf '%s' "$out" | jq .
printf '%s' "$out" | dirctl sync create --stdin
```

With `dryRun: true` the sink line is replaced by `echo "[prune-untrusted] dry run: not applying action 'prune'"` — inside the loop, for the paginated actions, so a dry run still reports every page.

## Design notes

**`match` keys are `dirctl` flag names, passed through mechanically** rather than mapped against a whitelist. List → flag repeated per item; bool → `--flag=true|false`; scalar → `--flag 'value'`. Any filter the CLI grows works with no chart change — including the `--exclude-*` flags from #1987, which did not exist when the template was written:

```yaml
match:
  trusted: false
  exclude-name: ["cisco.com/*"]
# -> dirctl search ... --exclude-name 'cisco.com/*' --trusted=false
```

The trade is that an unrecognised-but-well-formed key surfaces at run time. Anything that would be silent-wrong rather than loudly-wrong is rejected at `helm template` time:

| Rejected | Why |
| --- | --- |
| `limit`/`offset`/`format`/`output` inside `match` | the chart sets these; would emit a duplicate flag |
| an unknown `action` | |
| a value containing `'` | would break out of the shell quoting |
| a key outside `^[a-z0-9][a-z0-9-]*$` | keys are interpolated unquoted, so `name; rm -rf /` would be executable shell |
| a `limit` that is not a positive integer | also interpolated unquoted |
| a `sync` policy with no `skill`/`domain`/`locator`/`module` | `dirctl routing search` requires a criterion; without one it exits 0 printing nothing |

**Three details in the generated script are load-bearing:**

- *The count guard.* `cli/util/cids.Collect` returns `"at least one CID is required"` on empty stdin, so `dirctl delete|routing publish|routing unpublish --stdin` fail on an empty array. Without the guard, a policy matching nothing would fail on every run.
- *The empty-output guard, separate from the count.* A search can exit 0 while printing nothing — `dirctl routing search` does exactly that with no criteria, reporting to stderr. That leaves `count` empty, and `[ "" -eq 0 ]` errors; because it is an `if` condition, `set -e` does **not** stop the script, so it would fall through to the sink with empty input. `[ -z "$out" ]` turns that into a clear failure.
- *No `set -o pipefail`.* Capturing the search into a variable under `set -eu` surfaces a failing search without it, and yields the match count and dry-run dump for free. (busybox ash does support `pipefail`; this shape was preferred for the count, not out of necessity.)

**Pagination differs by action**, because only some of them change whether a record still matches:

| Action | Coverage |
| --- | --- |
| `prune` | Deleting stops a record matching, so the set shrinks and offset 0 always sees the remaining work. |
| `publish`, `unpublish` | The action does not change the record, so the same first page would be reprocessed forever. These loop over `--offset` until a short page comes back. |
| `sync` | Cannot page — `dirctl routing search` has no `--offset`. Processes the first `limit` matches only; documented as a constraint on `limit`. |

**Policies render through the existing `cronjobs` loop** as `policy-<name>` entries, inheriting the SPIRE, env, volume, resource and security wiring without duplicating the ~100-line pod spec. `env`, `resources`, `volumes`, `volumeMounts`, `concurrencyPolicy` and the history limits work per policy exactly as for a `cronjobs` entry. The `policy-` prefix keeps a policy and a `cronjobs` entry of the same name from colliding.

**`command:` now renders via `toYaml`**, giving the `|-` block above rather than one escaped line, so the script stays readable in `kubectl get cronjob -o yaml`. Verified byte-identical output for plain single-line command lists.

## Notes for reviewers

- **`sync` reads the routing index, not the local store**, so its usable `match` keys are only those `dirctl routing search` accepts: `skill`, `domain`, `locator`, `module`, `min-score`. The presence of at least one is enforced at template time; which *other* keys are valid is documented, not enforced, since enforcing that would mean the whitelist the passthrough design avoids.
- **Both examples ship disabled**, departing from the existing `cronjobs` examples which are `enabled: true`. A default-on `prune` that deletes untrusted records is not a default worth having.
- **Overriding a shipped example's `match` merges rather than replaces it** (Helm deep-merge). Setting `match: {trusted: false}` on `prune-untrusted` yields `--scan-severity 'MEDIUM' --trusted=false`. Use a new policy key to avoid this.
- **`safe: false` is not the complement of `safe: true`** — it matches records with an explicit unsafe scan report, while never-scanned records match neither. A `prune` keyed on it silently spares unscanned records. Called out in a warning admonition in the docs, since it is the kind of thing that makes a destructive policy act on the wrong population.
- **`limit: 0` is rejected** rather than silently becoming 100. Sprig's `default` treats `0` as empty, so the obvious `$policy.limit | default 100` would have swallowed it; the template uses `hasKey` instead.

## Testing

`install/charts/dirctl/ci/test-policies.sh` + `task test:helm`: 25 assertions over `helm template` output covering every action, every `match` value kind, per-action pagination, the dry-run path, the disabled path, both guards, the absence of `pipefail`, and all six template-time rejections. `helm lint` cannot check any of this — it only verifies the chart renders. **Wired into the `Lint` CI job**, which the path filter runs for chart changes. Mutation-tested: breaking `dirctl delete --stdin` in the template makes the suite fail and exit 1.

Beyond that:

- Default `helm template` output is byte-identical to before this PR.
- All four rendered `dirctl` invocations were extracted from the manifests and run against the CLI on this branch; each parses and fails only on TCP connect, confirming no unknown flags.
- The generated scripts were run inside a faithful replica of the #1979 alpine runtime image under the chart's own securityContext (`runAsUser: 65532`, `readOnlyRootFilesystem: true`, `emptyDir` at `/home/nonroot`): `/bin/sh` and `jq` present, `dirctl` resolves on `PATH` after the ENTRYPOINT override, empty match set exits 0, non-empty reaches the sink.
- The pagination loop was exercised in busybox `ash` against a stub returning two full pages then a short one: it iterates, stops on the short page, and reports the correct total.

**Not verified: no live-cluster run.** Everything above is rendering plus container-level execution, not a CronJob observed firing in a cluster. `sync` is the least covered — it reads the routing index, so a single-node environment can never make it match.

## Docs

`docs/content/dir/dir-deployment-kubernetes.md` gains a Content Policies section: the action table, `match` value kinds, the `exclude-` example, the `sync` caveat, the field reference, the per-action pagination table, a warning that `safe: false` is not the complement of `safe: true`, and a dry-run admonition showing real log output.
