### PR TITLE
feat(skill): fix and update dir skills

### DIFF
--- a/.skill/SKILL.md
+++ b/.skill/SKILL.md
@@ -23,6 +23,7 @@ and publish" → authoring + publishing).
 | User intent (examples)                                                                                      | Read first                                               |
 | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
 | "install dirctl", "set up a local directory", "start the daemon", "configure contexts", "connection issues" | [references/setup.md](references/setup.md)               |
+| "log in", "am I authenticated?", "switch to another directory node", "permission denied / forbidden"        | [references/setup.md](references/setup.md)               |
 | "create a record", "validate my record", "import MCP servers / A2A cards / skills into DIR"                 | [references/authoring.md](references/authoring.md)       |
 | "push", "publish to the network", "sign my record", "prove name ownership"                                  | [references/publishing.md](references/publishing.md)     |
 | "find/search/suggest agents, MCP servers, skills", "browse the directory", "pull a record"                  | [references/discovery.md](references/discovery.md)       |
@@ -68,6 +69,13 @@ daemon). Server selection order: `--context <name>` flag →
 - **Auth**: never invent auth flags. On an auth error, surface the raw error
   and ask the user how to authenticate (see setup reference: `auth login`,
   `--auth-mode`, `--auth-token`).
+- **Authentication is not authorization**: a valid token from `auth status`
+  says nothing about what the user may *do*. Gateways enforce per-method
+  access control, so `PermissionDenied` / `Forbidden` on `push`, `sign`,
+  `routing publish`, `delete`, or `sync` is an entitlement problem — logging in
+  again cannot fix it. Name the denied method, say it needs elevated rights on
+  that deployment, and stop; only `Unauthenticated` and expired-token errors
+  are login problems.
 - **Destructive ops** (`delete`, `uninstall`, `sync delete`, `--force`):
   always confirm with the user first.
 - **Never fabricate** CIDs, names, versions, scores, or scan results — every

--- a/.skill/references/authoring.md
+++ b/.skill/references/authoring.md
@@ -65,9 +65,10 @@ fix ERRORs before pushing.
 | `a2a` | Local A2A AgentCard JSON | `--file-path` |
 | `agent-skill` | Local directory containing `SKILL.md` | `--file-path` |
 
-Useful flags: `--limit N`, `--filter key=value` (registry: `search`,
-`version`, `updated_since`), `--output-cids <file>`, `--force` (skip
-name+version dedup), `--debug`, `--sign` (+ `--key` / `--oidc-token`).
+Useful flags: `--config <yaml>` (see config reference below), `--limit N`,
+`--filter key=value` (registry: `search`, `version`, `updated_since`),
+`--output-cids <file>`, `--force` (skip name+version dedup), `--debug`,
+`--sign` (+ `--key` / `--oidc-token`).
 
 ### Recommended workflow: dry-run → review → push
 
@@ -96,25 +97,90 @@ only when they explicitly ask for it.
 
 ### Enrichment
 
-By default import enriches records with OASF skills/domains using an LLM
-(tool-calling against `dirctl mcp serve`; built-in default `azure:gpt-4o`).
-This requires LLM credentials (e.g. `AZURE_OPENAI_API_KEY`). Two alternatives
-via `--config <yaml>`:
+Import assigns OASF skills/domains to every record it builds. Exactly one of
+three methods is used, selected by the `enricher:` block of `--config <yaml>`.
+**When no valid block is present, import falls back to the LLM enricher**,
+which needs credentials — so a malformed `enricher:` block fails as a missing
+API key, not as a config error.
+
+| Block                | Needs                                       | Use when                                     |
+| -------------------- | ------------------------------------------- | -------------------------------------------- |
+| `enricher.extractor` | `dirctl init` (local assets); no credentials | **Default choice** — per-record, LLM-free     |
+| `enricher.static`    | nothing                                      | Stamp one fixed skill/domain set on every record |
+| `enricher.llm`       | LLM credentials (e.g. `AZURE_OPENAI_API_KEY`) | An LLM is available and per-record quality matters |
 
 ```yaml
-# Static taxonomy — no LLM needed:
+# Local OASF taxonomy model — no LLM, no credentials. Requires `dirctl init`.
 enricher:
-  skip_enricher: true
-  skills:
-    - name: natural_language_processing/text_completion
-      id: 10201
-  domains:
-    - name: technology
-      id: 1
+  extractor:
+    oasf_url: https://schema.oasf.outshift.com
+    asset_dir: /absolute/path/to/.agntcy/oasf-sdk/extractor
 ```
 
-If an import fails on enrichment, offer `skip_enricher` with skills/domains
-derived from the artifact description as the no-credentials path.
+```yaml
+# Fixed taxonomy stamped on every imported record — no LLM, no init.
+enricher:
+  static:
+    skills:
+      - name: natural_language_processing/text_completion
+        id: 10201
+    domains:
+      - name: technology
+        id: 1
+```
+
+Two traps, both of which surface as the LLM credential error rather than as a
+complaint about the config:
+
+- **Unknown keys are silently ignored** (unlike the client config, the import
+  config parser is not strict). A misplaced key — `skills:` directly under
+  `enricher:`, or a `skip_enricher:` flag, which does not exist — leaves no
+  recognised enricher and triggers the LLM fallback.
+- **A bare `enricher.extractor:` with no fields parses as null**, which is also
+  no enricher. Write `extractor: {}` to inherit the endpoint and asset
+  directory saved by `dirctl init`, or set both fields explicitly.
+
+`asset_dir` must be an **absolute path** — `~` is not expanded.
+
+When an import fails with `AZURE_OPENAI_API_KEY is required`, do not go looking
+for credentials first: check the `enricher:` block spelling, then offer
+`extractor` (if `dirctl init` has been run) or `static` as the no-credentials
+path.
+
+### Config file reference
+
+Everything below can live in `--config <yaml>` instead of on the command line.
+**Flags override the file**, so one file can drive several runs:
+
+```yaml
+type: mcp-registry            # mcp | mcp-registry | a2a | agent-skill
+url: https://registry.modelcontextprotocol.io/v0.1   # required for mcp-registry
+# file_path: ./servers.json   # required for mcp | a2a | agent-skill
+
+filters:
+  search: github              # registry filters: search, version, updated_since
+limit: 100                    # 0 = no limit
+
+# authors:                    # overrides authors derived from the source
+#   - "Example Corp"
+
+enricher:                     # see above — extractor | static | llm
+  extractor: {}
+
+schema_version: "1.1.0"       # OASF version stamped on imported records
+
+output_dir: ./import-out      # where --dry-run writes <cid>.record.json
+dry_run: true
+force: false                  # true = skip name+version dedup
+debug: false
+```
+
+`dry_run: true` in the file means a bare `dirctl import --config <file>` is
+**already** a dry run — say so rather than implying records were pushed. Flip
+it with `--dry-run=false` when the user wants the real import.
+
+Note that `import` opens a client connection even for a dry run, so the
+selected context still has to resolve.
 
 ## Common pitfalls
 

--- a/.skill/references/setup.md
+++ b/.skill/references/setup.md
@@ -106,10 +106,75 @@ dirctl daemon stop                   # graceful shutdown via PID file, waits, cl
 - Manage the lifecycle only through `daemon start`/`stop`/`status` — never
   kill the process by signal directly: semantics differ across platforms and
   `stop` also cleans up the PID file.
-- Custom config: `--config <yaml>` (relative paths resolve against
-  `--data-dir`); env overrides use the `DIRECTORY_DAEMON_` prefix. Without
-  `--config`, embedded defaults are used — see the sync reference for when a
-  config file is required (e.g. P2P autosync).
+- `--data-dir` and `--config` are persistent flags on the **`daemon` parent**,
+  not on `start`. The PID file is `<data-dir>/daemon.pid`, so **`status` and
+  `stop` need the same `--data-dir` as `start`** — without it they inspect the
+  default directory and report "Daemon is not running" for a daemon that is
+  running fine.
+
+### Daemon configuration
+
+Start from the generated reference config — never hand-write one:
+
+```bash
+dirctl daemon config init                      # writes <data-dir>/daemon.config.yaml
+dirctl daemon config init --output ./daemon.config.yaml
+dirctl daemon config init --force              # overwrite an existing file
+dirctl daemon start --config ./daemon.config.yaml
+```
+
+`config init` emits a fully commented file covering `server` (listen address,
+OASF validation URL, OCI store, routing/DHT, database, publication, HTTP
+gateway, naming), `reconciler` (regsync, metrics, indexer, signature, name,
+scan — including scanner CLI paths and endpoint-scan safety toggles), and
+`runtime`.
+
+Three behaviours to get right, none of which produce an error when you get
+them wrong:
+
+- **The config is not auto-discovered.** `<data-dir>/daemon.config.yaml` is
+  only where `config init` writes by default; `daemon start` ignores it unless
+  you pass `--config` explicitly. A daemon started without `--config` runs the
+  embedded defaults even when that file exists — so never report a config as
+  applied without checking the startup log.
+- **`--config` replaces the defaults, it does not merge with them.** The file
+  is read as the complete configuration, so a partial hand-written config
+  silently loses everything it omits. Edit a `config init` copy instead.
+- **Relative paths inside the config resolve against `--data-dir`** (`store`,
+  `dir.db`, `routing`, `node.key`). Use absolute paths to pin a location.
+
+Any setting can also be overridden by environment variable: `DIRECTORY_DAEMON_`
+followed by the uppercased, underscore-delimited path, e.g.
+`server.routing.republish_interval` →
+`DIRECTORY_DAEMON_SERVER_ROUTING_REPUBLISH_INTERVAL`. List values such as
+`..._BOOTSTRAP_PEERS` are comma-separated. This is the quickest way to tweak
+one knob without touching a file. See the sync reference for when a config
+file is genuinely required (e.g. P2P autosync).
+
+### Throwaway test setups
+
+To try a config, reproduce an issue, or demo a flow without touching the
+user's real directory, give the daemon its own data directory and keep that
+flag on **every** daemon command:
+
+```bash
+dirctl daemon config init --output /tmp/dirtest/daemon.config.yaml
+# edit /tmp/dirtest/daemon.config.yaml
+dirctl daemon start  --data-dir /tmp/dirtest --config /tmp/dirtest/daemon.config.yaml   # own terminal
+dirctl daemon status --data-dir /tmp/dirtest                                            # another terminal
+dirctl daemon stop   --data-dir /tmp/dirtest
+```
+
+- **Confirm the config actually took effect** by reading the startup log
+  (`Server starting … address=…`), not by the fact that `start` did not error.
+- **Change the ports when the user may already run a daemon**: the default
+  `8888` (gRPC), `8889` (HTTP gateway), and `5555` (OCI registry) collide with
+  a running instance and startup fails with `address already in use`. Check
+  with `dirctl daemon status` first and never stop a daemon you did not start.
+- Point clients at the test instance per-command with `--server-addr
+  localhost:<port>`; do not repoint the user's current context.
+- Tear down with `daemon stop --data-dir <dir>`, then delete the directory —
+  it holds the whole state (`dir.db`, `store/`, `routing/`, `daemon.pid`).
 
 ## 5. Remote directories: contexts
 
@@ -129,16 +194,61 @@ contexts:
 ```
 
 ```bash
-dirctl context list          # sorted; * marks current_context
-dirctl context current       # persisted current context
-dirctl context set <name>    # switch persisted context
-dirctl context show [name]   # effective config, secrets redacted
-dirctl context validate      # catch config mistakes before use
+dirctl context list           # sorted; * marks current_context
+dirctl context current        # persisted current context
+dirctl context current --quiet  # name only, nothing when unset (shell prompts, scripts)
+dirctl context current --json   # persisted context details as JSON
+dirctl context set <name>     # switch persisted context
+dirctl context show [name]    # effective config, secrets redacted
+dirctl context validate       # catch config mistakes before use
 ```
+
+**There is no `context add` / `create` / `delete` subcommand** — the group is
+`list`, `current`, `set`, `show`, `validate` only. To add a context, edit
+`config.yaml` (create it if absent), then confirm with `context validate` and
+`context set <name>`. Never claim to have "created a context" via a command.
+
+**The parser rejects unknown keys.** A typo (`server-addr` for
+`server_address`, `authMode` for `auth_mode`) is a hard decode error, not a
+silently ignored field — so use exact names from this list:
+
+| Key                                | Purpose                                                  |
+| ---------------------------------- | -------------------------------------------------------- |
+| `server_address`                   | Directory endpoint `host:port` — required for every usable context |
+| `auth_mode`                        | `x509`, `jwt`, `jwt-tls`, `token`, `tls`, `oidc`, `insecure`, `none`; omit to auto-detect |
+| `oidc_issuer`, `oidc_client_id`    | Used by `auth login` for OIDC contexts                    |
+| `oidc_scopes`                      | List; changing it requires `auth login --force`           |
+| `auth_token`                       | Pre-issued bearer token — prefer the env var instead      |
+| `jwt_audience`                     | For `jwt` / `jwt-tls` modes                               |
+| `tls_skip_verify`, `tls_cert_file`, `tls_key_file`, `tls_ca_file` | Custom PKI / mTLS         |
+| `spiffe_socket_path`, `spiffe_token` | SPIFFE workload identity                                |
+| `doctor.bootstrap_peers`           | List of peer multiaddrs `doctor` checks for this context  |
+
+Pinning bootstrap peers to the context beats passing `--bootstrap-peer` every
+time:
+
+```yaml
+contexts:
+  prod:
+    server_address: gateway.example.com:443
+    auth_mode: oidc
+    oidc_issuer: https://idp.example.com
+    oidc_client_id: dirctl
+    doctor:
+      bootstrap_peers:
+        - /dns4/routing.example.com/tcp/5555/p2p/12D3KooWExample
+```
+
+The same file also holds a top-level `extractor:` block (`oasf_url`,
+`asset_dir`, `remote_addr`) written by `dirctl init` — that is what makes
+natural-language search and local enrichment work. Leave it alone unless the
+user wants to relocate or repoint the assets.
 
 Selection order per invocation: `--context` flag → `DIRECTORY_CLIENT_CONTEXT`
 → `current_context`. Root flags (`--server-addr`, `--auth-mode`,
 `--oidc-issuer`, `--auth-token`) override the selected context for that call.
+Prefer `--context <name>` for one-off commands against another node over
+switching the persisted context and forgetting to switch back.
 
 Do not store long-lived tokens in `config.yaml` — prefer
 `DIRECTORY_CLIENT_AUTH_TOKEN` or a secret manager.
@@ -149,19 +259,53 @@ Local daemon needs none (auto-detect falls back to insecure for local
 development).
 
 ```bash
-dirctl auth login --oidc-issuer "https://idp.example.com" --oidc-client-id "dirctl"
+dirctl auth login     # uses the selected context's oidc_issuer / oidc_client_id
 dirctl auth status
 dirctl auth logout
 ```
 
+Pass `--oidc-issuer` / `--oidc-client-id` only when the context does not
+already carry them — with a configured context, bare `auth login` is correct.
+
 - `auth login` uses OIDC PKCE (browser); `--no-browser` and `--device` exist
-  for headless environments.
+  for headless environments. `--callback-port` (default 8484) when that port is
+  taken; `--timeout` (default 5m) for slow flows.
+- **`auth login` is a no-op when a valid token is cached** — it prints
+  `✓ Already authenticated as: <user>` and exits without re-authenticating.
+  After changing `oidc_scopes` (or any context auth setting), you **must** use
+  `dirctl auth login --force`, otherwise the old token stays in use and the
+  change appears to have worked when it has not.
 - CI / automation: pre-issued token via `--auth-token` or
   `DIRECTORY_CLIENT_AUTH_TOKEN`.
 - Other modes need an explicit `--auth-mode`: `x509`, `jwt`, `token` (SPIFFE),
   `tls`, `oidc`, `insecure`, `none`.
 - On auth errors: show the raw error and ask the user which mechanism they
   use. Never guess flags.
+
+Reading `auth status` — report the token line, not the exit code of `login`:
+
+| Token line     | Meaning                                                    |
+| -------------- | ---------------------------------------------------------- |
+| `Valid ✓`      | Healthy.                                                    |
+| `Refreshed ✓`  | Healthy — cached token had expired and was refreshed.       |
+| `Expired ✗`    | No usable refresh token; run `auth login` again.            |
+
+### Authenticated ≠ allowed
+
+`auth status` proves who you are, never what you may do. Behind a gateway,
+methods are authorized per principal or group, so a token that reports
+`Valid ✓` can still be refused:
+
+```text
+rpc error: code = PermissionDenied
+```
+
+Reads (`pull`, `lookup`, `search`, `list`, `verify`) are commonly granted
+broadly while writes (`push`, `sign`, `routing publish`, `delete`, `sync`) are
+restricted to administrators. When a write is denied, say which method was
+denied and that it needs elevated rights on that deployment — do **not** retry,
+re-login, or suggest `--force`, none of which change entitlements. Only
+`Unauthenticated` and `Expired ✗` are login problems.
 
 ## 7. Verify the environment: `dirctl doctor`
 


### PR DESCRIPTION
## Summary

Fixes incorrect guidance in the `agntcy-dir` agent skill and fills gaps that
caused agents to fail or report success wrongly. All behaviour below was
verified against dirctl v1.6.3, not read off the structs.

**`authoring.md` — import enrichment was documented wrong.** The no-LLM path
told users to set `enricher.skip_enricher: true` with `skills`/`domains`
directly under `enricher:`. `skip_enricher` does not exist in the codebase, and
the real schema is `enricher.llm` / `enricher.static` / `enricher.extractor`.
Because the import config parser is not strict, the bogus keys were silently
discarded and import fell back to the LLM enricher — so following the
documentation verbatim fails with `AZURE_OPENAI_API_KEY is required`, the exact
opposite of the promised no-credentials path. Replaced with the three real
blocks, added the previously undocumented `extractor` (LLM-free, needs
`dirctl init`), and added a full `import.config.yaml` reference with the
flags-override-file precedence and the `dry_run: true` gotcha.

**`setup.md` — daemon configuration.** `dirctl daemon config init` was missing
entirely. Documented it, plus three silent failure modes: the config is not
auto-discovered (`daemon start` ignores `<data-dir>/daemon.config.yaml` unless
`--config` is passed), `--config` replaces the defaults rather than merging,
and `--data-dir`/`--config` are parent flags so `status`/`stop` need the same
`--data-dir` as `start`. Added a throwaway-test-setup workflow for agents
validating configs without touching the user's directory.

**`setup.md` — contexts and auth.** Documented all 15 context keys (only 4 were
listed) and that the parser rejects unknown keys, that there is no
`context add`/`create` subcommand, and `doctor.bootstrap_peers`. For auth:
bare `auth login` when a context supplies the issuer, the `--force` requirement
after changing `oidc_scopes` (login is a no-op with a cached token, so scope
changes silently do not apply), and how to read the `auth status` token line.

**`SKILL.md` — authentication is not authorization.** A valid token says
nothing about what the caller may do. Gateways enforce per-method access
control, so `PermissionDenied` on `push`/`sign`/`routing publish` is an
entitlement problem that re-logging-in cannot fix. Added as a CLI convention
plus a dispatch row for auth intents.