### PR TITLE
chore(github): add additional vendor prefixes to import records

### DIFF
--- a/.github/workflows/scripts/import-records.json
+++ b/.github/workflows/scripts/import-records.json
@@ -38,6 +38,42 @@
     },
     {
       "search": "com.atlassian/"
+    },
+    {
+      "search": "com.gitlab/"
+    },
+    {
+      "search": "com.circleci/"
+    },
+    {
+      "search": "io.github.buildkite/"
+    },
+    {
+      "search": "io.github.SonarSource/"
+    },
+    {
+      "search": "io.snyk/"
+    },
+    {
+      "search": "io.github.snyk/"
+    },
+    {
+      "search": "io.github.jfrog/"
+    },
+    {
+      "search": "io.github.hashicorp/"
+    },
+    {
+      "search": "io.github.grafana/"
+    },
+    {
+      "search": "io.github.getsentry/"
+    },
+    {
+      "search": "com.newrelic/"
+    },
+    {
+      "search": "io.github.sourcegraph/"
     }
   ],
   "agent-skill": [


### PR DESCRIPTION
Prod currently has no CI/CD or static analysis coverage — nothing matches `gitlab`, `sonar`, or `ci-cd` by name. This adds twelve first-party MCP registry namespaces to close that gap: GitLab, SonarQube, CircleCI, and Buildkite directly, plus Terraform, Snyk, JFrog, Grafana, Sentry, New Relic, and Sourcegraph from the same search.