### PR TITLE
docs(cli): document directory input and the oasf type in import help

### DIFF
--- a/cli/cmd/import/import.go
+++ b/cli/cmd/import/import.go
@@ -20,15 +20,20 @@ import (
 
 var Command = &cobra.Command{
 	Use:   "import",
-	Short: "Import MCP, A2A, or Agent Skill records into DIR from a registry, JSON file, or skill directory",
-	Long: `Import MCP server, A2A AgentCard, or Agent Skill records into DIR. Records are transformed, enriched, optionally
+	Short: "Import MCP, A2A, Agent Skill, or OASF records into DIR from a registry, file, or directory",
+	Long: `Import MCP server, A2A AgentCard, Agent Skill, or OASF records into DIR. Records are transformed, enriched, optionally
 scanned, then pushed. The same pipeline runs for every source.
 
 Import kinds (--type):
-  mcp            Local JSON: one MCP server object or a JSON array (--file-path)
+  mcp            Local JSON: one MCP server object or a JSON array, or a directory of such files (--file-path)
   mcp-registry   HTTP MCP registry, e.g. v0.1 list API (--url)
-  a2a            Local JSON: one A2A AgentCard or an array of cards (--file-path)
+  a2a            Local JSON: one A2A AgentCard or an array of cards, or a directory of such files (--file-path)
   agent-skill    Local directory: one Agent Skills folder containing SKILL.md (--file-path); see https://agentskills.io/specification
+  oasf           Local JSON: records already in OASF format, or a directory of such files (--file-path); re-imports --dry-run output
+
+For mcp, a2a and oasf, --file-path may be a directory, in which case every *.json
+file directly inside it is imported. The search is not recursive, and a file that
+fails to parse is reported without stopping the rest of the run.
 
 Examples:
   dirctl import --config import.config.yaml
@@ -37,6 +42,7 @@ Examples:
   dirctl import --type=mcp-registry --url=https://registry.modelcontextprotocol.io/v0.1
   dirctl import --type=mcp --file-path=./servers.json
   dirctl import --type=a2a --file-path=./agent.json
+  dirctl import --type=a2a --file-path=./agent-cards/
   dirctl import --type=agent-skill --file-path=./my-skill
 
   dirctl import --type=mcp-registry --url=https://registry.modelcontextprotocol.io/v0.1 --sign --key=./cosign.key

--- a/cli/cmd/import/options.go
+++ b/cli/cmd/import/options.go
@@ -32,10 +32,10 @@ func init() {
 	flags.StringVar(&opts.ConfigFile, "config", "", "Path to a YAML import config file. Values are overridden by command-line flags")
 
 	// File flags
-	flags.StringVar(&opts.FilePath, "file-path", "", "Path to source: JSON file for mcp/a2a, or skill directory for agent-skill")
+	flags.StringVar(&opts.FilePath, "file-path", "", "Path to source: JSON file, or directory of *.json files, for mcp/a2a/oasf; skill directory for agent-skill")
 
 	// Import source
-	flags.StringVar(&opts.TypeFlag, "type", "", "Import kind: mcp, mcp-registry, a2a, or agent-skill (local Agent Skills directory with SKILL.md)")
+	flags.StringVar(&opts.TypeFlag, "type", "", "Import kind: mcp, mcp-registry, a2a, agent-skill (local Agent Skills directory with SKILL.md), or oasf")
 	flags.StringVar(&opts.RegistryURL, "url", "", "Registry base URL (required when --type=mcp-registry)")
 	flags.StringToStringVar(&opts.Filters, "filter", nil, "Filters (key=value)")
 	flags.IntVar(&opts.Limit, "limit", 0, "Maximum number of records to import (0 = no limit)")


### PR DESCRIPTION
## Summary

Two gaps in `dirctl import --help`, both about things the CLI can do but does not tell you about.

**Directory input.** agntcy/dir-importer#87 added directory support for the `mcp`, `a2a` and `oasf` import types, so `--file-path` can now point at a folder of `*.json` files instead of a single file. The help still describes it as a JSON file only.

**The `oasf` type.** This one predates that work. `--type` binds to a plain string which is handed straight to `config.ImportType` with no allowlist in the CLI:

```go
// cli/cmd/import/config.go:162
if o.TypeFlag != "" {
    o.Type = config.ImportType(o.TypeFlag)
}
```

and `dir-importer`'s `config.Validate()` accepts `oasf`. So `--type=oasf` has been working, but it appeared in neither the kinds list, the `--type` flag description, nor the command summary. There was no way to find it from the CLI.

## Please do not merge yet

This documents behaviour that only ships with a `dir-importer` release containing agntcy/dir-importer#87. That change merged a few hours after `v1.5.3` was cut, and `cli/go.mod` currently pins `v1.5.2`:

```
github.com/agntcy/dir-importer v1.5.2
```

So the directory wording is accurate against `dir-importer` `main`, but not against the version this module builds with today. Opening as a draft so it is ready to go, but it should land only after a release containing #87 and a bump here. Happy to add the `go.mod` bump to this PR once such a release exists, or to split the `oasf` half out if you would rather have that part now, since it is correct against `v1.5.2` already.

## Rendered output

```
Import kinds (--type):
  mcp            Local JSON: one MCP server object or a JSON array, or a directory of such files (--file-path)
  mcp-registry   HTTP MCP registry, e.g. v0.1 list API (--url)
  a2a            Local JSON: one A2A AgentCard or an array of cards, or a directory of such files (--file-path)
  agent-skill    Local directory: one Agent Skills folder containing SKILL.md (--file-path); see https://agentskills.io/specification
  oasf           Local JSON: records already in OASF format, or a directory of such files (--file-path); re-imports --dry-run output

For mcp, a2a and oasf, --file-path may be a directory, in which case every *.json
file directly inside it is imported. The search is not recursive, and a file that
fails to parse is reported without stopping the rest of the run.
```

Also adds `dirctl import --type=a2a --file-path=./agent-cards/` to the examples, and updates the `--file-path` and `--type` flag descriptions to match.

Docs only, no behaviour change. Verified by building the CLI and reading back `dirctl import --help`.
