### PR TITLE
fix(github): renew Directory token while signing records

### DIFF
--- a/.github/actions/sign-record/README.md
+++ b/.github/actions/sign-record/README.md
@@ -10,7 +10,7 @@ Sign record CIDs using GitHub OIDC (keyless). Use after **push-record** or **dir
   with:
     cids: ${{ steps.push.outputs.cids }}
     server_addr: ${{ vars.DIRECTORY_ADDRESS }}
-    auth_token: ${{ steps.oidc-dir.outputs.token }}
+    auth_audience: dir
     oidc_client_id: https://github.com/${{ github.repository }}/.github/workflows/my-workflow.yaml@${{ github.ref }}
     max_retries: 3
     cleanup_on_failure: true
@@ -22,7 +22,8 @@ Sign record CIDs using GitHub OIDC (keyless). Use after **push-record** or **dir
 |-------|-------------|----------|---------|
 | `cids` | JSON object (file→CID) from push-record, or newline-separated CIDs | Yes | - |
 | `server_addr` | Directory server address (host:port). Omit to use dirctl default. | No | `""` |
-| `auth_token` | Optional OIDC bearer token for Directory authentication | No | `""` |
+| `auth_audience` | Audience for Directory tokens minted per `dirctl` invocation. Preferred: each CID gets a fresh token, so a long batch cannot outlive it. | No | `""` |
+| `auth_token` | Pre-issued OIDC bearer token for Directory authentication. Ignored when `auth_audience` is set, and cannot be renewed. | No | `""` |
 | `oidc_client_id` | Workflow URL for keyless signing. Job must have `id-token: write`. | Yes | - |
 | `dirctl_path` | Optional absolute path to the dirctl binary | No | PATH lookup |
 | `max_retries` | Sign attempts per CID (fresh Sigstore OIDC token each attempt) | No | `3` |

--- a/.github/actions/sign-record/action.yaml
+++ b/.github/actions/sign-record/action.yaml
@@ -19,8 +19,18 @@ inputs:
     description: Optional Directory server address (host:port). Uses dirctl default if omitted.
     required: false
     default: ""
+  auth_audience:
+    description: |
+      Audience for Directory tokens minted per dirctl invocation. Preferred over
+      auth_token: signing a batch with retries can outlive a single GitHub ID
+      token, and each CID is signed by its own dirctl process, so each one can
+      mint a fresh token. Requires a dirctl that supports --oidc-audience.
+    required: false
+    default: ""
   auth_token:
-    description: Optional OIDC bearer token for Directory authentication
+    description: |
+      Pre-issued OIDC bearer token for Directory authentication. Ignored when
+      auth_audience is set. It cannot be renewed, so a long batch may outlive it.
     required: false
     default: ""
   oidc_client_id:
@@ -72,6 +82,7 @@ runs:
       env:
         CIDS: ${{ inputs.cids }}
         SERVER_ADDR: ${{ inputs.server_addr }}
+        AUTH_AUDIENCE: ${{ inputs.auth_audience }}
         AUTH_TOKEN: ${{ inputs.auth_token }}
         OIDC_CLIENT_ID: ${{ inputs.oidc_client_id }}
         DIRCTL_PATH: ${{ inputs.dirctl_path }}

--- a/.github/actions/sign-record/sign.sh
+++ b/.github/actions/sign-record/sign.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 : "${CIDS:?CIDS is required}"
 : "${OIDC_CLIENT_ID:?OIDC_CLIENT_ID is required}"
 SERVER_ADDR="${SERVER_ADDR:-}"
+AUTH_AUDIENCE="${AUTH_AUDIENCE:-}"
 AUTH_TOKEN="${AUTH_TOKEN:-}"
 MAX_RETRIES="${MAX_RETRIES:-3}"
 CLEANUP_ON_FAILURE="${CLEANUP_ON_FAILURE:-false}"
@@ -42,6 +43,7 @@ trap 'rm -f "$FAILED_CIDS_FILE" "$CLEANED_CIDS_FILE"' EXIT
 echo "=== Sign Records (OIDC) ==="
 echo "dirctl: ${DIRCTL_BIN}"
 echo "Server address: ${SERVER_ADDR:-"(dirctl default)"}"
+echo "Directory audience: ${AUTH_AUDIENCE:-"(dirctl config)"}"
 echo "Max retries per CID: ${MAX_RETRIES}"
 echo "Cleanup on failure: ${CLEANUP_ON_FAILURE}"
 echo ""
@@ -81,10 +83,19 @@ fetch_sigstore_oidc_token() {
   printf '%s' "$token"
 }
 
+# Each CID is signed by its own dirctl process, so an audience lets every
+# invocation mint a fresh token, while a token fetched once for the whole batch
+# expires partway through a long or retrying run and takes the cleanup deletes
+# down with it. The token remains for callers on a dirctl without the flag.
 append_dirctl_auth_args() {
   local -n cmd_ref=$1
   [ -n "$SERVER_ADDR" ] && cmd_ref+=(--server-addr "$SERVER_ADDR")
-  [ -n "$AUTH_TOKEN" ] && cmd_ref+=(--auth-mode=oidc "--auth-token=$AUTH_TOKEN")
+
+  if [ -n "$AUTH_AUDIENCE" ]; then
+    cmd_ref+=(--auth-mode=oidc "--oidc-audience=$AUTH_AUDIENCE")
+  elif [ -n "$AUTH_TOKEN" ]; then
+    cmd_ref+=(--auth-mode=oidc "--auth-token=$AUTH_TOKEN")
+  fi
 }
 
 sign_cid_once() {

--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -317,13 +317,9 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Fetch Directory OIDC token for signing
-        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
-        id: oidc-dir-sign
-        uses: ./.github/actions/fetch-oidc-token
-        with:
-          audience: dir
-
+      # No token is fetched here either: signing a batch with retries can outlive
+      # a GitHub ID token, and each CID is signed by its own dirctl process, so
+      # dirctl mints one per invocation from the audience.
       - name: Sign imported records
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
         id: sign-records
@@ -332,7 +328,7 @@ jobs:
           cids: ${{ steps.sign-cids.outputs.cids }}
           oidc_client_id: https://github.com/${{ github.repository }}/.github/workflows/import-records.yaml@${{ github.ref }}
           server_addr: ${{ env.SERVER_ADDRESS }}
-          auth_token: ${{ steps.oidc-dir-sign.outputs.token }}
+          auth_audience: dir
           dirctl_path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
           max_retries: ${{ env.SIGN_MAX_RETRIES }}
           cleanup_on_failure: ${{ env.SIGN_CLEANUP_ON_FAILURE }}
@@ -539,13 +535,9 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Fetch Directory OIDC token for signing
-        if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
-        id: oidc-dir-sign
-        uses: ./.github/actions/fetch-oidc-token
-        with:
-          audience: dir
-
+      # No token is fetched here either: signing a batch with retries can outlive
+      # a GitHub ID token, and each CID is signed by its own dirctl process, so
+      # dirctl mints one per invocation from the audience.
       - name: Sign imported records
         if: ${{ env.SIGN == 'true' && env.DRY_RUN == 'false' && steps.sign-cids.outputs.skip != 'true' }}
         id: sign-records
@@ -554,7 +546,7 @@ jobs:
           cids: ${{ steps.sign-cids.outputs.cids }}
           oidc_client_id: https://github.com/${{ github.repository }}/.github/workflows/import-records.yaml@${{ github.ref }}
           server_addr: ${{ env.SERVER_ADDRESS }}
-          auth_token: ${{ steps.oidc-dir-sign.outputs.token }}
+          auth_audience: dir
           dirctl_path: ${{ steps.setup-dirctl.outputs.dirctl_path }}
           max_retries: ${{ env.SIGN_MAX_RETRIES }}
           cleanup_on_failure: ${{ env.SIGN_CLEANUP_ON_FAILURE }}


### PR DESCRIPTION
The sign-record action received a GitHub ID token fetched once before the loop, so a batch that signs slower than the token's ~5 minute lifetime failed partway through, and took the cleanup deletes with it. Each CID is signed by its own `dirctl` process, so pass the audience and let each one mint a fresh token. `auth_token` stays for callers on a `dirctl` without `--oidc-audience`.