### PR TITLE
fix(scanner): make MCP source and endpoint scans produce results

### DIFF
--- a/utils/scanner/mcp.go
+++ b/utils/scanner/mcp.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -238,13 +239,25 @@ func gitClone(ctx context.Context, repoURL, dest string) error {
 }
 
 func runMCPScanner(ctx context.Context, cliPath, scanDir string) ([]byte, error) {
-	var stdout, stderr bytes.Buffer
+	// Results go to a file because stdout carries the scanner's own logs and
+	// LiteLLM's banners. --output is redeclared by the behavioral subparser,
+	// whose default clobbers a global one, so it must follow the subcommand.
+	outDir, err := os.MkdirTemp("", "mcp-scan-out-*")
+	if err != nil {
+		return nil, fmt.Errorf("create mcp-scanner output dir: %w", err)
+	}
 
-	// The behavioral subparser declares its own --raw, whose default
-	// overwrites a global one, so --raw must follow the subcommand to get
-	// JSON rather than a human-readable summary.
-	cmd := exec.CommandContext(ctx, cliPath, "--analyzers", "yara,readiness", "behavioral", scanDir, "--raw")
-	cmd.Stdout = &stdout
+	defer os.RemoveAll(outDir)
+
+	outPath := filepath.Join(outDir, "scan-result.json")
+
+	var stderr bytes.Buffer
+
+	cmd := exec.CommandContext(ctx, cliPath,
+		"--analyzers", "yara,readiness",
+		"behavioral", scanDir,
+		"--output", outPath,
+	)
 	cmd.Stderr = &stderr
 	cmd.Env = buildMCPScannerEnv()
 
@@ -254,7 +267,12 @@ func runMCPScanner(ctx context.Context, cliPath, scanDir string) ([]byte, error)
 		return nil, fmt.Errorf("mcp-scanner exited with error: %w", err)
 	}
 
-	return stdout.Bytes(), nil
+	out, err := os.ReadFile(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("read mcp-scanner output: %w", err)
+	}
+
+	return out, nil
 }
 
 // buildMCPScannerEnv returns the parent env with MCP_SCANNER_LLM_* vars derived from
@@ -363,10 +381,8 @@ func (r mcpScannerResult) subject() string {
 }
 
 func parseMCPOutput(raw []byte) (*ScanResult, error) {
-	raw = trimToJSON(raw)
-
-	var results []mcpScannerResult
-	if err := json.Unmarshal(raw, &results); err != nil {
+	results, err := decodeMCPResults(raw)
+	if err != nil {
 		return nil, fmt.Errorf("parse mcp-scanner output: %w", err)
 	}
 
@@ -400,12 +416,45 @@ func parseMCPOutput(raw []byte) (*ScanResult, error) {
 	return &ScanResult{Safe: len(findings) == 0, Findings: findings}, nil
 }
 
-// trimToJSON strips any leading non-JSON content by finding the first '['.
-func trimToJSON(raw []byte) []byte {
-	idx := bytes.IndexByte(raw, '[')
-	if idx > 0 {
-		return raw[idx:]
+// decodeMCPResults extracts the results array from output that may carry log
+// lines either side of it: the live-server subcommands ignore --output, and an
+// ANSI colour escape (\x1b[1;31m) contains a '[' of its own. A non-empty array
+// wins outright so a bracket in a log line cannot pass an empty result off as
+// a clean scan.
+func decodeMCPResults(raw []byte) ([]mcpScannerResult, error) {
+	var (
+		empty      []mcpScannerResult
+		foundEmpty bool
+	)
+
+	for off := 0; off < len(raw); {
+		idx := bytes.IndexByte(raw[off:], '[')
+		if idx < 0 {
+			break
+		}
+
+		start := off + idx
+		off = start + 1
+
+		var results []mcpScannerResult
+
+		// Decoder, not Unmarshal: log lines may trail the array too.
+		if err := json.NewDecoder(bytes.NewReader(raw[start:])).Decode(&results); err != nil {
+			continue
+		}
+
+		if len(results) > 0 {
+			return results, nil
+		}
+
+		if !foundEmpty {
+			empty, foundEmpty = results, true
+		}
 	}
 
-	return raw
+	if foundEmpty {
+		return empty, nil
+	}
+
+	return nil, errors.New("no JSON results array found in output")
 }

--- a/utils/scanner/mcp.go
+++ b/utils/scanner/mcp.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	typesv1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1"
@@ -143,7 +144,9 @@ func (r *MCPRunner) runSourceScan(ctx context.Context, record *corev1.Record) (*
 
 	scanDir := tmpDir
 	if subfolder != "" {
-		scanDir = filepath.Join(tmpDir, subfolder)
+		// The subfolder is publisher-controlled record data. Rooting the inner
+		// join at "/" collapses any leading .. so it cannot walk out of the clone.
+		scanDir = filepath.Join(tmpDir, filepath.Join("/", subfolder))
 	}
 
 	absDir, err := filepath.Abs(scanDir)
@@ -249,10 +252,20 @@ func gitClone(ctx context.Context, repoURL, dest string) error {
 	return nil
 }
 
+// mcpSourceArgs builds the argv for the source-code scan.
+//
+// --output has to follow the subcommand. The behavioral subparser redeclares
+// it, and the subparser's default overwrites whatever a leading one set, so a
+// conventionally-placed flag leaves the results on stdout - where the
+// scanner's own logs and LiteLLM's banners already are.
+func mcpSourceArgs(scanDir, outputPath string) []string {
+	return []string{
+		"behavioral", scanDir,
+		"--output", outputPath,
+	}
+}
+
 func runMCPScanner(ctx context.Context, cliPath, scanDir string) ([]byte, error) {
-	// Results go to a file because stdout carries the scanner's own logs and
-	// LiteLLM's banners. --output is redeclared by the behavioral subparser,
-	// whose default clobbers a global one, so it must follow the subcommand.
 	outDir, err := os.MkdirTemp("", "mcp-scan-out-*")
 	if err != nil {
 		return nil, fmt.Errorf("create mcp-scanner output dir: %w", err)
@@ -264,10 +277,8 @@ func runMCPScanner(ctx context.Context, cliPath, scanDir string) ([]byte, error)
 
 	var stderr bytes.Buffer
 
-	cmd := exec.CommandContext(ctx, cliPath,
-		"behavioral", scanDir,
-		"--output", outPath,
-	)
+	//nolint:gosec // G204: cliPath is operator config, and the argv is fixed - both paths are ours, under temp dirs.
+	cmd := exec.CommandContext(ctx, cliPath, mcpSourceArgs(scanDir, outPath)...)
 	cmd.Stderr = &stderr
 	cmd.Env = buildMCPScannerEnv()
 
@@ -291,10 +302,22 @@ func buildMCPScannerEnv() []string {
 	env := os.Environ()
 	env = appendEnvIfMissing(env, "MCP_SCANNER_LLM_API_KEY", os.Getenv("AZURE_OPENAI_API_KEY"))
 	env = appendEnvIfMissing(env, "MCP_SCANNER_LLM_BASE_URL", os.Getenv("AZURE_OPENAI_BASE_URL"))
-	env = appendEnvIfMissing(env, "MCP_SCANNER_LLM_MODEL", "azure/"+os.Getenv("AZURE_OPENAI_DEPLOYMENT"))
+	env = appendEnvIfMissing(env, "MCP_SCANNER_LLM_MODEL", azureLLMModel())
 	env = appendEnvIfMissing(env, "MCP_SCANNER_LLM_API_VERSION", os.Getenv("AZURE_OPENAI_API_VERSION"))
 
 	return env
+}
+
+// azureLLMModel names the configured Azure deployment in the azure/<deployment>
+// form the scanner resolves, or "" when there is no deployment to name. A bare
+// "azure/" is not a model the scanner can resolve.
+func azureLLMModel() string {
+	deployment := os.Getenv("AZURE_OPENAI_DEPLOYMENT")
+	if deployment == "" {
+		return ""
+	}
+
+	return "azure/" + deployment
 }
 
 // llmConfigured reports whether an LLM is configured for the scanner, either
@@ -372,6 +395,12 @@ func (r mcpScannerResult) analyzerFindings() ([]mcpFinding, error) {
 				names:    a.ThreatNames,
 			})
 		}
+
+		// Map iteration is randomized, so without this two scans of identical
+		// output produce reports that differ only in finding order.
+		slices.SortFunc(findings, func(a, b mcpFinding) int {
+			return strings.Compare(a.analyzer, b.analyzer)
+		})
 
 		return findings, nil
 	}

--- a/utils/scanner/mcp.go
+++ b/utils/scanner/mcp.go
@@ -240,9 +240,10 @@ func gitClone(ctx context.Context, repoURL, dest string) error {
 func runMCPScanner(ctx context.Context, cliPath, scanDir string) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
 
-	// mcp-scanner requires global flags (--analyzers, --raw) to precede the
-	// subcommand; placing them after `behavioral` is rejected by the CLI.
-	cmd := exec.CommandContext(ctx, cliPath, "--analyzers", "yara,readiness", "--raw", "behavioral", scanDir)
+	// The behavioral subparser declares its own --raw, whose default
+	// overwrites a global one, so --raw must follow the subcommand to get
+	// JSON rather than a human-readable summary.
+	cmd := exec.CommandContext(ctx, cliPath, "--analyzers", "yara,readiness", "behavioral", scanDir, "--raw")
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	cmd.Env = buildMCPScannerEnv()

--- a/utils/scanner/mcp.go
+++ b/utils/scanner/mcp.go
@@ -61,8 +61,9 @@ type MCPConfig struct {
 // and scans the source repository, then scans any live endpoints the record
 // declares, and merges the findings.
 //
-// The two phases fail differently on purpose. The source scan fails hard,
-// because a scanner that cannot run at all is a scan we cannot vouch for. The
+// The two phases fail differently on purpose. The source scan fails hard when
+// the scanner cannot run, because that is a scan we cannot vouch for, though
+// an LLM that is simply not configured is a skip rather than a fault. The
 // endpoint phase is skip-with-warning, because endpoints are third-party
 // servers that may be down, moved, or behind auth, and one unreachable
 // endpoint must not fail an otherwise-clean source scan.
@@ -111,6 +112,17 @@ func (r *MCPRunner) runSourceScan(ctx context.Context, record *corev1.Record) (*
 	repoURL, subfolder := extractSourceInfo(record)
 	if repoURL == "" {
 		return &ScanResult{Skipped: true, SkippedReason: "no source-code locator found"}, nil
+	}
+
+	// behavioral runs an LLM alignment pass and exits non-zero without
+	// credentials for it, whatever --analyzers asks for, and it is the only
+	// subcommand that takes a source tree. Skipping keeps a deployment with no
+	// LLM configured from failing every record that declares source code.
+	if !llmConfigured() {
+		return &ScanResult{
+			Skipped:       true,
+			SkippedReason: "no LLM configured for the behavioral analyzer",
+		}, nil
 	}
 
 	tmpDir, err := os.MkdirTemp("", "mcp-scan-*")
@@ -285,6 +297,19 @@ func buildMCPScannerEnv() []string {
 	env = appendEnvIfMissing(env, "MCP_SCANNER_LLM_API_VERSION", os.Getenv("AZURE_OPENAI_API_VERSION"))
 
 	return env
+}
+
+// llmConfigured reports whether an LLM is configured for the scanner, either
+// directly or through the AZURE_OPENAI_* vars buildMCPScannerEnv maps from.
+func llmConfigured() bool {
+	direct := os.Getenv("MCP_SCANNER_LLM_API_KEY") != "" &&
+		os.Getenv("MCP_SCANNER_LLM_MODEL") != ""
+
+	azure := os.Getenv("AZURE_OPENAI_API_KEY") != "" &&
+		os.Getenv("AZURE_OPENAI_BASE_URL") != "" &&
+		os.Getenv("AZURE_OPENAI_DEPLOYMENT") != ""
+
+	return direct || azure
 }
 
 func appendEnvIfMissing(env []string, key, fallback string) []string {

--- a/utils/scanner/mcp.go
+++ b/utils/scanner/mcp.go
@@ -279,12 +279,14 @@ func appendEnvIfMissing(env []string, key, fallback string) []string {
 
 // --- output parsing ---
 
-// mcpScannerResult represents a single tool result from `mcp-scanner behavioral --raw`.
+// mcpScannerResult represents a single result from `mcp-scanner --raw`.
+// Findings stays raw because its shape varies; see analyzerFindings.
 type mcpScannerResult struct {
-	ToolName string                       `json:"tool_name"`
-	Status   string                       `json:"status"`
-	IsSafe   bool                         `json:"is_safe"`
-	Findings map[string]mcpAnalyzerResult `json:"findings"`
+	ToolName   string          `json:"tool_name"`
+	ServerName string          `json:"server_name"`
+	Status     string          `json:"status"`
+	IsSafe     bool            `json:"is_safe"`
+	Findings   json.RawMessage `json:"findings"`
 }
 
 // mcpAnalyzerResult represents the output of a single analyzer within mcp-scanner.
@@ -293,6 +295,71 @@ type mcpAnalyzerResult struct {
 	ThreatSummary string   `json:"threat_summary"`
 	ThreatNames   []string `json:"threat_names"`
 	TotalFindings int      `json:"total_findings"`
+}
+
+// mcpListedFinding is one entry of the array form of findings.
+type mcpListedFinding struct {
+	Severity string `json:"severity"`
+	Summary  string `json:"summary"`
+	Analyzer string `json:"analyzer"`
+}
+
+// mcpFinding is the shape-independent view of one analyzer's verdict.
+type mcpFinding struct {
+	analyzer string
+	severity string
+	summary  string
+	names    []string
+}
+
+// analyzerFindings normalizes the two shapes mcp-scanner uses for findings:
+// most subcommands return an object keyed by analyzer name, while
+// `instructions` returns an array of entries that name their own analyzer.
+func (r mcpScannerResult) analyzerFindings() ([]mcpFinding, error) {
+	if len(r.Findings) == 0 {
+		return nil, nil
+	}
+
+	var byAnalyzer map[string]mcpAnalyzerResult
+	if err := json.Unmarshal(r.Findings, &byAnalyzer); err == nil {
+		findings := make([]mcpFinding, 0, len(byAnalyzer))
+		for name, a := range byAnalyzer {
+			findings = append(findings, mcpFinding{
+				analyzer: name,
+				severity: a.Severity,
+				summary:  a.ThreatSummary,
+				names:    a.ThreatNames,
+			})
+		}
+
+		return findings, nil
+	}
+
+	var listed []mcpListedFinding
+	if err := json.Unmarshal(r.Findings, &listed); err != nil {
+		return nil, fmt.Errorf("parse mcp-scanner findings: %w", err)
+	}
+
+	findings := make([]mcpFinding, 0, len(listed))
+	for _, f := range listed {
+		findings = append(findings, mcpFinding{
+			analyzer: f.Analyzer,
+			severity: f.Severity,
+			summary:  f.Summary,
+		})
+	}
+
+	return findings, nil
+}
+
+// subject names what a result is about. `instructions` results describe a
+// server rather than a tool and so carry no tool_name.
+func (r mcpScannerResult) subject() string {
+	if r.ToolName != "" {
+		return r.ToolName
+	}
+
+	return r.ServerName
 }
 
 func parseMCPOutput(raw []byte) (*ScanResult, error) {
@@ -314,15 +381,19 @@ func parseMCPOutput(raw []byte) (*ScanResult, error) {
 			continue
 		}
 
-		for analyzerName, ar := range r.Findings {
-			severity := mapScannerSeverity(ar.Severity)
-			msg := fmt.Sprintf("[%s] %s: %s", analyzerName, r.ToolName, ar.ThreatSummary)
+		analyzerFindings, err := r.analyzerFindings()
+		if err != nil {
+			return nil, err
+		}
 
-			if len(ar.ThreatNames) > 0 {
-				msg += " (" + strings.Join(ar.ThreatNames, ", ") + ")"
+		for _, af := range analyzerFindings {
+			msg := fmt.Sprintf("[%s] %s: %s", af.analyzer, r.subject(), af.summary)
+
+			if len(af.names) > 0 {
+				msg += " (" + strings.Join(af.names, ", ") + ")"
 			}
 
-			findings = append(findings, Finding{Severity: severity, Message: msg})
+			findings = append(findings, Finding{Severity: mapScannerSeverity(af.severity), Message: msg})
 		}
 	}
 

--- a/utils/scanner/mcp.go
+++ b/utils/scanner/mcp.go
@@ -161,10 +161,9 @@ func (r *MCPRunner) runSourceScan(ctx context.Context, record *corev1.Record) (*
 		return nil, err
 	}
 
-	// yara and readiness are zero-dependency analyzers (no third-party credentials
-	// required) so they are always run. llm and api analyzers require third-party
-	// credentials and are opt-in only; wiring them up is left as follow-up work.
-	result.Analyzers = []string{"yara", "readiness"}
+	// The subcommand selects its own analyzer, so behavioral is the only one
+	// this phase runs.
+	result.Analyzers = []string{"behavioral"}
 
 	return result, nil
 }
@@ -266,7 +265,6 @@ func runMCPScanner(ctx context.Context, cliPath, scanDir string) ([]byte, error)
 	var stderr bytes.Buffer
 
 	cmd := exec.CommandContext(ctx, cliPath,
-		"--analyzers", "yara,readiness",
 		"behavioral", scanDir,
 		"--output", outPath,
 	)

--- a/utils/scanner/mcp_endpoint.go
+++ b/utils/scanner/mcp_endpoint.go
@@ -154,8 +154,7 @@ func tagFindings(subcommand, endpoint string, findings []Finding) []Finding {
 func endpointAnalyzers() []string {
 	analyzers := []string{"yara", "readiness"}
 
-	// buildMCPScannerEnv derives the llm key from the Azure one.
-	if os.Getenv("MCP_SCANNER_LLM_API_KEY") != "" || os.Getenv("AZURE_OPENAI_API_KEY") != "" {
+	if llmConfigured() {
 		analyzers = append(analyzers, "llm")
 	}
 

--- a/utils/scanner/mcp_endpoint.go
+++ b/utils/scanner/mcp_endpoint.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/netip"
 	"net/url"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -145,12 +146,36 @@ func tagFindings(subcommand, endpoint string, findings []Finding) []Finding {
 	return tagged
 }
 
+// endpointAnalyzers returns the analyzer set for the live-endpoint phase.
+// mcp-scanner aborts this path when a requested analyzer's credentials are
+// missing, so its "api,yara,llm" default fails every scan on a deployment
+// without a Cisco AI Defense key. yara and readiness need no credentials and
+// always run; llm and api stay opt-in until their key is configured.
+func endpointAnalyzers() []string {
+	analyzers := []string{"yara", "readiness"}
+
+	// buildMCPScannerEnv derives the llm key from the Azure one.
+	if os.Getenv("MCP_SCANNER_LLM_API_KEY") != "" || os.Getenv("AZURE_OPENAI_API_KEY") != "" {
+		analyzers = append(analyzers, "llm")
+	}
+
+	if os.Getenv("MCP_SCANNER_API_KEY") != "" {
+		analyzers = append(analyzers, "api")
+	}
+
+	return analyzers
+}
+
 func runMCPScannerEndpoint(ctx context.Context, cliPath, subcommand, serverURL string) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
 
-	// mcp-scanner requires the global --raw flag to precede the subcommand;
-	// only subcommand-specific flags (--server-url) follow it.
-	cmd := exec.CommandContext(ctx, cliPath, "--raw", subcommand, "--server-url", serverURL) //nolint:gosec
+	// mcp-scanner requires global flags (--analyzers, --raw) to precede the
+	// subcommand; only subcommand-specific flags (--server-url) follow it.
+	cmd := exec.CommandContext(ctx, cliPath, //nolint:gosec
+		"--analyzers", strings.Join(endpointAnalyzers(), ","),
+		"--raw", subcommand,
+		"--server-url", serverURL,
+	)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	// Maps AZURE_OPENAI_* onto the MCP_SCANNER_LLM_* names the scanner reads.

--- a/utils/scanner/mcp_endpoint.go
+++ b/utils/scanner/mcp_endpoint.go
@@ -153,6 +153,8 @@ func runMCPScannerEndpoint(ctx context.Context, cliPath, subcommand, serverURL s
 	cmd := exec.CommandContext(ctx, cliPath, "--raw", subcommand, "--server-url", serverURL) //nolint:gosec
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	// Maps AZURE_OPENAI_* onto the MCP_SCANNER_LLM_* names the scanner reads.
+	cmd.Env = buildMCPScannerEnv()
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("mcp-scanner %s exited with error: %s: %w", subcommand, strings.TrimSpace(stderr.String()), err)

--- a/utils/scanner/mcp_endpoint.go
+++ b/utils/scanner/mcp_endpoint.go
@@ -122,7 +122,9 @@ func (r *MCPRunner) runEndpointSubcommand(ctx context.Context, subcommand, endpo
 	}
 
 	result.Findings = tagFindings(subcommand, endpoint, result.Findings)
-	result.Analyzers = []string{subcommand}
+	// The analyzers that ran, not the subcommand that ran them; the subcommand
+	// stays traceable through the finding tags.
+	result.Analyzers = endpointAnalyzers()
 
 	return result
 }

--- a/utils/scanner/mcp_endpoint.go
+++ b/utils/scanner/mcp_endpoint.go
@@ -167,15 +167,25 @@ func endpointAnalyzers() []string {
 	return analyzers
 }
 
+// mcpEndpointArgs builds the argv for one live-endpoint scan.
+//
+// --analyzers and --raw have to precede the subcommand. The live-server
+// subparsers do not redeclare either flag, so one placed after the subcommand
+// is not recognized at all. Only --server-url belongs to the subcommand. This
+// is the opposite of mcpSourceArgs, and deliberately so.
+func mcpEndpointArgs(subcommand, serverURL string, analyzers []string) []string {
+	return []string{
+		"--analyzers", strings.Join(analyzers, ","),
+		"--raw", subcommand,
+		"--server-url", serverURL,
+	}
+}
+
 func runMCPScannerEndpoint(ctx context.Context, cliPath, subcommand, serverURL string) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
 
-	// mcp-scanner requires global flags (--analyzers, --raw) to precede the
-	// subcommand; only subcommand-specific flags (--server-url) follow it.
 	cmd := exec.CommandContext(ctx, cliPath, //nolint:gosec
-		"--analyzers", strings.Join(endpointAnalyzers(), ","),
-		"--raw", subcommand,
-		"--server-url", serverURL,
+		mcpEndpointArgs(subcommand, serverURL, endpointAnalyzers())...,
 	)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/utils/scanner/mcp_endpoint_test.go
+++ b/utils/scanner/mcp_endpoint_test.go
@@ -520,6 +520,27 @@ func TestEndpointAnalyzers_AllCredentials_RequestsEverything(t *testing.T) {
 	}
 }
 
+// --- mcpEndpointArgs ---
+
+// The live-server subparsers do not redeclare --analyzers or --raw, so either
+// one placed after the subcommand is rejected as unrecognized. That is the
+// reverse of mcpSourceArgs, where --output has to trail the subcommand, and the
+// two orderings cannot be made to match.
+func TestMCPEndpointArgs_GlobalFlagsPrecedeSubcommand(t *testing.T) {
+	t.Parallel()
+
+	got := mcpEndpointArgs("prompts", "https://mcp.example.com/mcp", []string{"yara", "readiness"})
+	want := []string{
+		"--analyzers", "yara,readiness",
+		"--raw", "prompts",
+		"--server-url", "https://mcp.example.com/mcp",
+	}
+
+	if !slices.Equal(got, want) {
+		t.Errorf("mcpEndpointArgs() = %q, want %q", got, want)
+	}
+}
+
 // --- MCPRunner endpoint subcommand ---
 
 func TestMCPRunner_EndpointSubcommand_Success_TagsAndSetsAnalyzer(t *testing.T) {

--- a/utils/scanner/mcp_endpoint_test.go
+++ b/utils/scanner/mcp_endpoint_test.go
@@ -425,9 +425,26 @@ func TestRunMCPScannerEndpoint_ExecFailure_WrapsStderr(t *testing.T) {
 func clearAnalyzerCredentials(t *testing.T) {
 	t.Helper()
 
-	t.Setenv("MCP_SCANNER_LLM_API_KEY", "")
-	t.Setenv("AZURE_OPENAI_API_KEY", "")
-	t.Setenv("MCP_SCANNER_API_KEY", "")
+	for _, k := range []string{
+		"MCP_SCANNER_LLM_API_KEY",
+		"MCP_SCANNER_LLM_MODEL",
+		"AZURE_OPENAI_API_KEY",
+		"AZURE_OPENAI_BASE_URL",
+		"AZURE_OPENAI_DEPLOYMENT",
+		"MCP_SCANNER_API_KEY",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// setAzureCredentials configures a complete LLM setup the way the chart and
+// the docker env file do, which is the only form any shipped deployment uses.
+func setAzureCredentials(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("AZURE_OPENAI_API_KEY", "test-key")
+	t.Setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
+	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "gpt-4o")
 }
 
 func TestEndpointAnalyzers_NoCredentials_CredentialFreeOnly(t *testing.T) {
@@ -440,25 +457,41 @@ func TestEndpointAnalyzers_NoCredentials_CredentialFreeOnly(t *testing.T) {
 	}
 }
 
-func TestEndpointAnalyzers_AzureKey_AddsLLM(t *testing.T) {
+func TestEndpointAnalyzers_AzureConfig_AddsLLM(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	setAzureCredentials(t)
+
+	want := []string{"yara", "readiness", "llm"}
+	if got := endpointAnalyzers(); !slices.Equal(got, want) {
+		t.Errorf("want %v when Azure is fully configured, got %v", want, got)
+	}
+}
+
+// buildMCPScannerEnv lets a pre-set MCP_SCANNER_LLM_* value win over the
+// Azure-derived one, so the analyzer set has to recognise that form too.
+func TestEndpointAnalyzers_DirectConfig_AddsLLM(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	t.Setenv("MCP_SCANNER_LLM_API_KEY", "test-key")
+	t.Setenv("MCP_SCANNER_LLM_MODEL", "openai/test-model")
+
+	want := []string{"yara", "readiness", "llm"}
+	if got := endpointAnalyzers(); !slices.Equal(got, want) {
+		t.Errorf("want %v when the scanner LLM vars are set directly, got %v", want, got)
+	}
+}
+
+// A key with no model passes the scanner's own validation and then fails at
+// request time, so it must not count as a configured LLM.
+func TestEndpointAnalyzers_KeyWithoutModel_OmitsLLM(t *testing.T) {
 	// Cannot run in parallel: uses t.Setenv.
 	clearAnalyzerCredentials(t)
 	t.Setenv("AZURE_OPENAI_API_KEY", "test-key")
 
-	want := []string{"yara", "readiness", "llm"}
+	want := []string{"yara", "readiness"}
 	if got := endpointAnalyzers(); !slices.Equal(got, want) {
-		t.Errorf("want %v when an Azure key is configured, got %v", want, got)
-	}
-}
-
-func TestEndpointAnalyzers_ScannerKey_AddsLLM(t *testing.T) {
-	// Cannot run in parallel: uses t.Setenv.
-	clearAnalyzerCredentials(t)
-	t.Setenv("MCP_SCANNER_LLM_API_KEY", "test-key")
-
-	want := []string{"yara", "readiness", "llm"}
-	if got := endpointAnalyzers(); !slices.Equal(got, want) {
-		t.Errorf("want %v when a scanner key is configured, got %v", want, got)
+		t.Errorf("want %v when only a key is configured, got %v", want, got)
 	}
 }
 
@@ -478,7 +511,7 @@ func TestEndpointAnalyzers_APIKey_AddsAPI(t *testing.T) {
 func TestEndpointAnalyzers_AllCredentials_RequestsEverything(t *testing.T) {
 	// Cannot run in parallel: uses t.Setenv.
 	clearAnalyzerCredentials(t)
-	t.Setenv("MCP_SCANNER_LLM_API_KEY", "test-key")
+	setAzureCredentials(t)
 	t.Setenv("MCP_SCANNER_API_KEY", "test-key")
 
 	want := []string{"yara", "readiness", "llm", "api"}

--- a/utils/scanner/mcp_endpoint_test.go
+++ b/utils/scanner/mcp_endpoint_test.go
@@ -418,6 +418,75 @@ func TestRunMCPScannerEndpoint_ExecFailure_WrapsStderr(t *testing.T) {
 	}
 }
 
+// --- endpoint analyzer selection ---
+
+// clearAnalyzerCredentials makes the analyzer set independent of whichever
+// credentials the machine running the test happens to export.
+func clearAnalyzerCredentials(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("MCP_SCANNER_LLM_API_KEY", "")
+	t.Setenv("AZURE_OPENAI_API_KEY", "")
+	t.Setenv("MCP_SCANNER_API_KEY", "")
+}
+
+func TestEndpointAnalyzers_NoCredentials_CredentialFreeOnly(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+
+	want := []string{"yara", "readiness"}
+	if got := endpointAnalyzers(); !slices.Equal(got, want) {
+		t.Errorf("want %v with no credentials, got %v", want, got)
+	}
+}
+
+func TestEndpointAnalyzers_AzureKey_AddsLLM(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	t.Setenv("AZURE_OPENAI_API_KEY", "test-key")
+
+	want := []string{"yara", "readiness", "llm"}
+	if got := endpointAnalyzers(); !slices.Equal(got, want) {
+		t.Errorf("want %v when an Azure key is configured, got %v", want, got)
+	}
+}
+
+func TestEndpointAnalyzers_ScannerKey_AddsLLM(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	t.Setenv("MCP_SCANNER_LLM_API_KEY", "test-key")
+
+	want := []string{"yara", "readiness", "llm"}
+	if got := endpointAnalyzers(); !slices.Equal(got, want) {
+		t.Errorf("want %v when a scanner key is configured, got %v", want, got)
+	}
+}
+
+// The api analyzer is opt-in rather than excluded: an operator who configures
+// a Cisco AI Defense key gets it, which is what #1775 intended by "opt-in".
+func TestEndpointAnalyzers_APIKey_AddsAPI(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	t.Setenv("MCP_SCANNER_API_KEY", "test-key")
+
+	want := []string{"yara", "readiness", "api"}
+	if got := endpointAnalyzers(); !slices.Equal(got, want) {
+		t.Errorf("want %v when an api key is configured, got %v", want, got)
+	}
+}
+
+func TestEndpointAnalyzers_AllCredentials_RequestsEverything(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	t.Setenv("MCP_SCANNER_LLM_API_KEY", "test-key")
+	t.Setenv("MCP_SCANNER_API_KEY", "test-key")
+
+	want := []string{"yara", "readiness", "llm", "api"}
+	if got := endpointAnalyzers(); !slices.Equal(got, want) {
+		t.Errorf("want %v when every key is configured, got %v", want, got)
+	}
+}
+
 // --- MCPRunner endpoint subcommand ---
 
 func TestMCPRunner_EndpointSubcommand_Success_TagsAndSetsAnalyzer(t *testing.T) {

--- a/utils/scanner/mcp_endpoint_test.go
+++ b/utils/scanner/mcp_endpoint_test.go
@@ -523,7 +523,8 @@ func TestEndpointAnalyzers_AllCredentials_RequestsEverything(t *testing.T) {
 // --- MCPRunner endpoint subcommand ---
 
 func TestMCPRunner_EndpointSubcommand_Success_TagsAndSetsAnalyzer(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
 
 	r := NewMCPRunner(MCPConfig{CLIPath: fakeCLIPath(t)})
 
@@ -542,8 +543,11 @@ func TestMCPRunner_EndpointSubcommand_Success_TagsAndSetsAnalyzer(t *testing.T) 
 		t.Errorf("finding message should be tagged with subcommand+url, want prefix %q, got %q", wantPrefix, got.Findings[0].Message)
 	}
 
-	if len(got.Analyzers) != 1 || got.Analyzers[0] != "prompts" {
-		t.Errorf("want Analyzers=[prompts], got %v", got.Analyzers)
+	// The analyzers that ran, not the subcommand: "prompts" is already carried
+	// by the finding tag asserted above.
+	wantAnalyzers := []string{"yara", "readiness"}
+	if !slices.Equal(got.Analyzers, wantAnalyzers) {
+		t.Errorf("want Analyzers=%v, got %v", wantAnalyzers, got.Analyzers)
 	}
 }
 
@@ -582,7 +586,8 @@ func TestMCPRunner_EndpointSubcommand_UnparsableOutput_SkippedNotError(t *testin
 }
 
 func TestMCPRunner_EndpointSubcommand_EmptySafeOutput_NoFindings(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
 
 	r := NewMCPRunner(MCPConfig{CLIPath: fakeCLIPath(t)})
 
@@ -596,8 +601,9 @@ func TestMCPRunner_EndpointSubcommand_EmptySafeOutput_NoFindings(t *testing.T) {
 		t.Errorf("empty mcp-scanner output should produce Safe=true with no findings: %+v", got)
 	}
 
-	if len(got.Analyzers) != 1 || got.Analyzers[0] != "instructions" {
-		t.Errorf("want Analyzers=[instructions], got %v", got.Analyzers)
+	wantAnalyzers := []string{"yara", "readiness"}
+	if !slices.Equal(got.Analyzers, wantAnalyzers) {
+		t.Errorf("want Analyzers=%v, got %v", wantAnalyzers, got.Analyzers)
 	}
 }
 
@@ -630,9 +636,11 @@ func recordWithEndpoints(t *testing.T, urls ...string) *corev1.Record {
 }
 
 func TestMCPRunner_EndpointScan_MergesFindingsAcrossEndpointsAndSubcommands(t *testing.T) {
-	t.Parallel()
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
 
 	r := NewMCPRunner(MCPConfig{CLIPath: fakeCLIPath(t)})
+
 	rec := recordWithEndpoints(t, "https://a.example.com/mcp", "https://b.example.com/mcp")
 
 	got, err := r.Run(context.Background(), rec)
@@ -656,11 +664,12 @@ func TestMCPRunner_EndpointScan_MergesFindingsAcrossEndpointsAndSubcommands(t *t
 		t.Error("merged result should be Safe=false: every sub-scan reported an unsafe finding")
 	}
 
-	wantAnalyzers := []string{"remote", "prompts", "resources", "instructions"}
-	for _, a := range wantAnalyzers {
-		if !slices.Contains(got.Analyzers, a) {
-			t.Errorf("merged Analyzers missing %q, got %v", a, got.Analyzers)
-		}
+	// Every sub-scan runs the same analyzers, so the union is deduplicated and
+	// sorted rather than one entry per sub-scan. That all four subcommands ran
+	// is what the finding count above establishes.
+	wantAnalyzers := []string{"readiness", "yara"}
+	if !slices.Equal(got.Analyzers, wantAnalyzers) {
+		t.Errorf("want merged Analyzers=%v, got %v", wantAnalyzers, got.Analyzers)
 	}
 }
 

--- a/utils/scanner/mcp_test.go
+++ b/utils/scanner/mcp_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	typesv1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1"
@@ -464,24 +465,51 @@ func localGitRepo(t *testing.T) string {
 	return dir
 }
 
-func TestMCPRunner_Run_Success(t *testing.T) {
-	t.Parallel()
+// sourceRecord builds a record whose source-code locator points at repoDir. A
+// subfolder becomes part of the scan path, which is how a test steers the fake
+// CLI, since the fake matches on argv.
+func sourceRecord(t *testing.T, repoDir, subfolder string, endpoints ...string) *corev1.Record {
+	t.Helper()
 
-	repoDir := localGitRepo(t)
+	moduleData := map[string]any{}
+
+	if subfolder != "" {
+		moduleData["repository"] = map[string]any{"subfolder": subfolder}
+	}
+
+	if len(endpoints) > 0 {
+		conns := make([]any, 0, len(endpoints))
+		for _, u := range endpoints {
+			conns = append(conns, map[string]any{"type": "streamable-http", "url": u})
+		}
+
+		moduleData["connections"] = conns
+	}
 
 	data, err := structpb.NewStruct(map[string]any{
 		"schema_version": "1.0.0",
 		"locators": []any{
 			map[string]any{"type": "source_code", "urls": []any{repoDir}},
 		},
+		"modules": []any{
+			map[string]any{"name": "core/mcp", "data": moduleData},
+		},
 	})
 	if err != nil {
 		t.Fatalf("structpb.NewStruct: %v", err)
 	}
 
+	return &corev1.Record{Data: data}
+}
+
+func TestMCPRunner_Run_Success(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	setAzureCredentials(t)
+
 	r := NewMCPRunner(MCPConfig{CLIPath: fakeCLIPath(t)})
 
-	got, err := r.Run(context.Background(), &corev1.Record{Data: data})
+	got, err := r.Run(context.Background(), sourceRecord(t, localGitRepo(t), ""))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -502,6 +530,74 @@ func TestMCPRunner_Run_Success(t *testing.T) {
 	wantAnalyzers := []string{"readiness", "yara"}
 	if !slices.Equal(got.Analyzers, wantAnalyzers) {
 		t.Errorf("want Analyzers=%v, got %v", wantAnalyzers, got.Analyzers)
+	}
+}
+
+// behavioral is the only subcommand that takes a source tree and it exits
+// non-zero without LLM credentials, so an unconfigured deployment must skip
+// the phase rather than fail every record that declares source code.
+func TestMCPRunner_Run_NoLLMConfigured_SourceSkippedNotError(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+
+	r := NewMCPRunner(MCPConfig{CLIPath: fakeCLIPath(t), DisableEndpointScan: true})
+
+	got, err := r.Run(context.Background(), sourceRecord(t, localGitRepo(t), ""))
+	if err != nil {
+		t.Fatalf("a missing LLM configuration must not fail the scan: %v", err)
+	}
+
+	if !got.Skipped {
+		t.Fatal("want the source phase skipped when no LLM is configured")
+	}
+
+	if !strings.Contains(got.SkippedReason, "LLM") {
+		t.Errorf("want a reason naming the missing LLM configuration, got %q", got.SkippedReason)
+	}
+}
+
+// A skipped source phase must not take the endpoint findings with it.
+func TestMCPRunner_Run_NoLLMConfigured_KeepsEndpointFindings(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+
+	r := NewMCPRunner(MCPConfig{CLIPath: fakeCLIPath(t)})
+
+	got, err := r.Run(context.Background(), sourceRecord(t, localGitRepo(t), "", "https://ok.example.com/mcp"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(got.Findings) == 0 {
+		t.Fatal("want the endpoint findings to survive a skipped source phase")
+	}
+
+	// Every finding must carry an endpoint tag: one from the source phase
+	// would mean behavioral ran without an LLM configured for it.
+	for _, f := range got.Findings {
+		if !strings.Contains(f.Message, "ok.example.com") {
+			t.Errorf("want only endpoint findings, got %q", f.Message)
+		}
+	}
+}
+
+// A scanner that cannot run at all is still a hard failure: unlike a missing
+// credential, it leaves no basis for reporting on the record.
+func TestMCPRunner_Run_SourceExecFailure_IsError(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	clearAnalyzerCredentials(t)
+	setAzureCredentials(t)
+
+	r := NewMCPRunner(MCPConfig{CLIPath: fakeCLIPath(t), DisableEndpointScan: true})
+
+	// The subfolder lands in the scan path, which is what the fake CLI matches.
+	_, err := r.Run(context.Background(), sourceRecord(t, localGitRepo(t), "fail-exec"))
+	if err == nil {
+		t.Fatal("want an error when mcp-scanner cannot run")
+	}
+
+	if !strings.Contains(err.Error(), "exited with error") {
+		t.Errorf("want the scanner's exec failure, got %q", err)
 	}
 }
 

--- a/utils/scanner/mcp_test.go
+++ b/utils/scanner/mcp_test.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-// --- parseMCPOutput / trimToJSON / mapMCPSeverity ---
+// --- parseMCPOutput / decodeMCPResults ---
 
 func TestParseMCPOutput_EmptyArray(t *testing.T) {
 	t.Parallel()
@@ -188,7 +188,7 @@ func TestParseMCPOutput_LeadingTextStripped(t *testing.T) {
 
 	got, err := parseMCPOutput([]byte(raw))
 	if err != nil {
-		t.Fatalf("trimToJSON should strip leading text: %v", err)
+		t.Fatalf("leading text should be stripped: %v", err)
 	}
 
 	if !got.Safe {
@@ -205,34 +205,49 @@ func TestParseMCPOutput_InvalidJSON(t *testing.T) {
 	}
 }
 
-// --- trimToJSON ---
+// --- decodeMCPResults ---
 
-func TestTrimToJSON_AlreadyJSON(t *testing.T) {
+// An ANSI colour escape puts a '[' ahead of the results.
+func TestDecodeMCPResults_ANSIBannerBeforeResults(t *testing.T) {
 	t.Parallel()
 
-	in := []byte(`[{"a":1}]`)
-	if got := string(trimToJSON(in)); got != string(in) {
-		t.Errorf("clean JSON should be returned unchanged, got %q", got)
+	raw := []byte("\x1b[1;31mGive Feedback / Get Help\x1b[0m\n" +
+		`[{"tool_name":"exec","is_safe":false,"findings":{"yara":{"severity":"HIGH","threat_summary":"s"}}}]`)
+
+	got, err := parseMCPOutput(raw)
+	if err != nil {
+		t.Fatalf("results preceded by an ANSI banner must still parse: %v", err)
+	}
+
+	if len(got.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got.Findings), got.Findings)
 	}
 }
 
-func TestTrimToJSON_WithPreamble(t *testing.T) {
+func TestDecodeMCPResults_TrailingLogLines(t *testing.T) {
 	t.Parallel()
 
-	in := []byte("warning: something\n[1,2,3]")
-	want := "[1,2,3]"
+	raw := []byte(`[{"tool_name":"exec","is_safe":true,"findings":{}}]` + "\nINFO scan complete\n")
 
-	if got := string(trimToJSON(in)); got != want {
-		t.Errorf("got %q, want %q", got, want)
+	if _, err := parseMCPOutput(raw); err != nil {
+		t.Fatalf("log lines after the results must not break parsing: %v", err)
 	}
 }
 
-func TestTrimToJSON_NoArray(t *testing.T) {
+// An empty array in a log line must not stand in for the real results.
+func TestDecodeMCPResults_EmptyArrayInLogPrefersRealResults(t *testing.T) {
 	t.Parallel()
 
-	in := []byte("no array here")
-	if got := string(trimToJSON(in)); got != string(in) {
-		t.Errorf("no '[' → should return input unchanged, got %q", got)
+	raw := []byte("INFO analyzers=[] starting\n" +
+		`[{"tool_name":"exec","is_safe":false,"findings":{"yara":{"severity":"HIGH","threat_summary":"s"}}}]`)
+
+	got, err := parseMCPOutput(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Safe {
+		t.Error("want Safe=false: the real results carry a finding")
 	}
 }
 
@@ -479,13 +494,11 @@ func TestMCPRunner_Run_Success(t *testing.T) {
 		t.Fatalf("want 1 finding, got %d: %+v", len(got.Findings), got.Findings)
 	}
 
-	// yara and readiness are the zero-dependency analyzers that always run;
-	// this is the line the PR changed from the old hardcoded ["behavioral"].
+	// yara and readiness are the zero-dependency analyzers that always run.
 	//
-	// Sorted order, not source order: Run now merges the source and endpoint
-	// phases, and merge() sorts the analyzer union so the field is stable
-	// across runs (it is persisted to the DB and the OCI referrer). Asserting
-	// the sorted form is what pins that guarantee.
+	// Sorted, not source order: merge() sorts the analyzer union so the field
+	// is stable across runs, since it is persisted to the DB and the OCI
+	// referrer. Asserting the sorted form is what pins that guarantee.
 	wantAnalyzers := []string{"readiness", "yara"}
 	if !slices.Equal(got.Analyzers, wantAnalyzers) {
 		t.Errorf("want Analyzers=%v, got %v", wantAnalyzers, got.Analyzers)

--- a/utils/scanner/mcp_test.go
+++ b/utils/scanner/mcp_test.go
@@ -87,6 +87,48 @@ func TestParseMCPOutput_UnsafeWithFindings(t *testing.T) {
 	}
 }
 
+// Object-shaped findings arrive in a map, whose iteration order Go randomizes.
+// Two scans of identical output have to produce identical reports, or every
+// scan rewrites its stored result with the same findings in a new order.
+func TestParseMCPOutput_FindingOrderIsStable(t *testing.T) {
+	t.Parallel()
+
+	raw := `[{
+		"tool_name": "exec",
+		"status": "done",
+		"is_safe": false,
+		"findings": {
+			"gamma_analyzer": {"severity": "HIGH", "threat_summary": "g"},
+			"alpha_analyzer": {"severity": "HIGH", "threat_summary": "a"},
+			"beta_analyzer":  {"severity": "HIGH", "threat_summary": "b"}
+		}
+	}]`
+
+	want := []string{
+		"[alpha_analyzer] exec: a",
+		"[beta_analyzer] exec: b",
+		"[gamma_analyzer] exec: g",
+	}
+
+	// Repeated because an unsorted map would still land on the wanted order
+	// some of the time.
+	for range 10 {
+		got, err := parseMCPOutput([]byte(raw))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		msgs := make([]string, 0, len(got.Findings))
+		for _, f := range got.Findings {
+			msgs = append(msgs, f.Message)
+		}
+
+		if !slices.Equal(msgs, want) {
+			t.Fatalf("finding order = %q, want %q", msgs, want)
+		}
+	}
+}
+
 // Shape emitted by the `instructions` subcommand: findings is an array whose
 // entries name their own analyzer, and the subject is a server, not a tool.
 func TestParseMCPOutput_ArrayFindings(t *testing.T) {
@@ -598,6 +640,23 @@ func TestMCPRunner_Run_SourceExecFailure_IsError(t *testing.T) {
 	}
 }
 
+// --- mcpSourceArgs ---
+
+// The behavioral subparser redeclares --output, so a leading one is overwritten
+// by the subparser's default and the results never reach the file. Tidying
+// these into the conventional flags-first shape fails silently: the scan still
+// exits zero, having written nothing.
+func TestMCPSourceArgs_OutputFollowsSubcommand(t *testing.T) {
+	t.Parallel()
+
+	got := mcpSourceArgs("/src/server", "/out/scan-result.json")
+	want := []string{"behavioral", "/src/server", "--output", "/out/scan-result.json"}
+
+	if !slices.Equal(got, want) {
+		t.Errorf("mcpSourceArgs() = %q, want %q", got, want)
+	}
+}
+
 // --- buildMCPScannerEnv ---
 
 func TestBuildMCPScannerEnv_ContainsParentEnv(t *testing.T) {
@@ -646,6 +705,23 @@ func TestBuildMCPScannerEnv_MapsAzureVars(t *testing.T) {
 	for k, want := range cases {
 		if got := envMap[k]; got != want {
 			t.Errorf("env[%s] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// A deployment is the only part of the model name that varies, so without one
+// there is no model to name. Exporting the "azure/" prefix on its own hands the
+// scanner a model it cannot resolve.
+func TestBuildMCPScannerEnv_NoDeployment_OmitsModel(t *testing.T) {
+	// Cannot run in parallel: uses t.Setenv.
+	t.Setenv("AZURE_OPENAI_API_KEY", "test-key")
+	t.Setenv("AZURE_OPENAI_BASE_URL", "https://openai.example.com")
+	t.Setenv("AZURE_OPENAI_DEPLOYMENT", "")
+	t.Setenv("MCP_SCANNER_LLM_MODEL", "")
+
+	for _, e := range buildMCPScannerEnv() {
+		if k, v, ok := splitEnvEntry(e); ok && k == "MCP_SCANNER_LLM_MODEL" && v != "" {
+			t.Errorf("MCP_SCANNER_LLM_MODEL = %q, want it unset without a deployment", v)
 		}
 	}
 }

--- a/utils/scanner/mcp_test.go
+++ b/utils/scanner/mcp_test.go
@@ -86,6 +86,49 @@ func TestParseMCPOutput_UnsafeWithFindings(t *testing.T) {
 	}
 }
 
+// Shape emitted by the `instructions` subcommand: findings is an array whose
+// entries name their own analyzer, and the subject is a server, not a tool.
+func TestParseMCPOutput_ArrayFindings(t *testing.T) {
+	t.Parallel()
+
+	raw := `[{
+		"server_name": "DeepWiki",
+		"status": "completed",
+		"is_safe": false,
+		"findings": [
+			{"severity":"HIGH","summary":"Detected 1 threat: data exfiltration","analyzer":"YARA"}
+		]
+	}]`
+
+	got, err := parseMCPOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("array-shaped findings must parse, got error: %v", err)
+	}
+
+	if got.Safe {
+		t.Error("a result carrying findings must not be reported safe")
+	}
+
+	if len(got.Findings) != 1 {
+		t.Fatalf("want 1 finding, got %d: %+v", len(got.Findings), got.Findings)
+	}
+
+	want := "[YARA] DeepWiki: Detected 1 threat: data exfiltration"
+	if got.Findings[0].Message != want {
+		t.Errorf("want message %q, got %q", want, got.Findings[0].Message)
+	}
+}
+
+func TestParseMCPOutput_UnknownFindingsShape_Errors(t *testing.T) {
+	t.Parallel()
+
+	raw := `[{"tool_name":"exec","is_safe":false,"findings":"not-a-shape-we-know"}]`
+
+	if _, err := parseMCPOutput([]byte(raw)); err == nil {
+		t.Error("an unrecognized findings shape must error, not be silently dropped")
+	}
+}
+
 func TestParseMCPOutput_ThreatNamesAppended(t *testing.T) {
 	t.Parallel()
 

--- a/utils/scanner/mcp_test.go
+++ b/utils/scanner/mcp_test.go
@@ -522,12 +522,9 @@ func TestMCPRunner_Run_Success(t *testing.T) {
 		t.Fatalf("want 1 finding, got %d: %+v", len(got.Findings), got.Findings)
 	}
 
-	// yara and readiness are the zero-dependency analyzers that always run.
-	//
-	// Sorted, not source order: merge() sorts the analyzer union so the field
-	// is stable across runs, since it is persisted to the DB and the OCI
-	// referrer. Asserting the sorted form is what pins that guarantee.
-	wantAnalyzers := []string{"readiness", "yara"}
+	// behavioral is what the source subcommand runs, and the record declares
+	// no endpoints, so nothing else joins the union.
+	wantAnalyzers := []string{"behavioral"}
 	if !slices.Equal(got.Analyzers, wantAnalyzers) {
 		t.Errorf("want Analyzers=%v, got %v", wantAnalyzers, got.Analyzers)
 	}

--- a/utils/scanner/testdata/fakecli/main.go
+++ b/utils/scanner/testdata/fakecli/main.go
@@ -14,12 +14,15 @@
 //
 //	fail-exec  -> exits non-zero with a stderr message (simulates an
 //	              unreachable server / mcp-scanner invocation failure)
-//	bad-json   -> exits 0 but writes non-JSON stdout (simulates a corrupt
-//	              or unparsable mcp-scanner response)
-//	empty-safe -> exits 0 and writes "[]" (simulates a scan that found
+//	bad-json   -> exits 0 but emits non-JSON (simulates a corrupt or
+//	              unparsable mcp-scanner response)
+//	empty-safe -> exits 0 and emits "[]" (simulates a scan that found
 //	              nothing to report)
-//	(default)  -> exits 0 and writes a single well-formed, unsafe finding
+//	(default)  -> exits 0 and emits a single well-formed, unsafe finding
 //	              so callers can assert on parsed output.
+//
+// As in the real CLI, results go to the --output file when one is given and to
+// stdout otherwise.
 package main
 
 import (
@@ -36,9 +39,9 @@ func main() {
 		fmt.Fprintln(os.Stderr, "simulated exec failure: connection refused")
 		os.Exit(1)
 	case strings.Contains(args, "bad-json"):
-		fmt.Fprintln(os.Stdout, "not valid json output {{{")
+		emit("not valid json output {{{")
 	case strings.Contains(args, "empty-safe"):
-		fmt.Fprintln(os.Stdout, "[]")
+		emit("[]")
 	default:
 		tool := "default"
 
@@ -49,6 +52,30 @@ func main() {
 			}
 		}
 
-		fmt.Fprintf(os.Stdout, `[{"tool_name":%q,"status":"done","is_safe":false,"findings":{"test_analyzer":{"severity":"HIGH","threat_summary":"synthetic finding","threat_names":["synthetic"],"total_findings":1}}}]`, tool)
+		emit(fmt.Sprintf(`[{"tool_name":%q,"status":"done","is_safe":false,"findings":{"test_analyzer":{"severity":"HIGH","threat_summary":"synthetic finding","threat_names":["synthetic"],"total_findings":1}}}]`, tool))
 	}
+}
+
+func emit(payload string) {
+	path := outputPath()
+	if path == "" {
+		fmt.Fprintln(os.Stdout, payload)
+
+		return
+	}
+
+	if err := os.WriteFile(path, []byte(payload), 0o600); err != nil {
+		fmt.Fprintln(os.Stderr, "fakecli: write output file:", err)
+		os.Exit(1)
+	}
+}
+
+func outputPath() string {
+	for i, a := range os.Args[1:] {
+		if a == "--output" && i+2 < len(os.Args) {
+			return os.Args[i+2]
+		}
+	}
+
+	return ""
 }


### PR DESCRIPTION
MCP scanning returned almost nothing: endpoint scans aborted before dialing, source scans emitted output the parser could not read, and the instructions sub-scan was discarded every run. A local daemon run showed all three (`missing required configuration`, `invalid character '='`, `produced unparsable output`). A final local run reported none of them — only genuine environmental failures: unreachable published endpoints, one with an unexpanded `{tenant_id}` placeholder, and repositories that do not resolve.

- Endpoint scans now request analyzers explicitly. A requested analyzer with missing credentials raises rather than warns on that path, so the `api,yara,llm` default aborted every scan without a Cisco AI Defense key. yara and readiness always run; llm and api are added once their key is configured, keeping them opt-in rather than excluded.
- The endpoint subprocess now gets the mapped environment: credentials arrive as `AZURE_OPENAI_*` but the scanner reads `MCP_SCANNER_LLM_*`. The source path already did this.
- `--raw` moved after the subcommand for source scans only. The behavioral subparser's own `--raw` default overwrote the global one, so the CLI printed a human-readable summary. The live-server subparsers reject a trailing `--raw`, so the paths deliberately differ; both were verified against the real binary.
- Findings decode from either shape the scanner emits — an object keyed by analyzer, or the array instructions returns. An unrecognized shape now errors instead of being silently dropped.

Not addressed: GitHub `/tree/<ref>/<path>` locators still fail to clone, which is how monorepo-hosted MCP servers are usually published. Separate change, and it would give a live path to exercise the source fix.