### PR TITLE
fix(reconciler): skip referrer tags in the indexer

### DIFF
--- a/api/core/v1/referrer_types.go
+++ b/api/core/v1/referrer_types.go
@@ -14,3 +14,18 @@ const (
 	// ScanReportReferrerType is the type for ScanReport referrers.
 	ScanReportReferrerType = "agntcy.dir.security.v1.ScanReport"
 )
+
+// Annotation keys written on referrer manifests by the storage layer.
+// Referrers live in the same repository as the records they describe, so these
+// keys are also how consumers tell a referrer manifest apart from a record one.
+const (
+	// ReferrerTypeAnnotationKey holds the referrer type. Its presence marks a
+	// manifest as a referrer rather than a record.
+	ReferrerTypeAnnotationKey = "agntcy.dir.referrer.type"
+
+	// ReferrerCreatedAtAnnotationKey holds the referrer creation timestamp.
+	ReferrerCreatedAtAnnotationKey = "agntcy.dir.referrer.created_at"
+
+	// ReferrerAnnotationPrefix namespaces custom annotations copied from the referrer.
+	ReferrerAnnotationPrefix = "agntcy.dir.referrer.annotation."
+)

--- a/reconciler/go.mod
+++ b/reconciler/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/agntcy/dir/utils v1.7.0
 	github.com/agntcy/oasf-sdk/pkg v1.1.0
 	github.com/csirmazbendeguz/regclient v0.0.0-20260429082137-82ab6d426079
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/sigstore/sigstore v1.10.9
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.12.0
@@ -152,8 +154,6 @@ require (
 	github.com/nlpodyssey/spago v1.1.0 // indirect
 	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/reconciler/tasks/indexer/manifest.go
+++ b/reconciler/tasks/indexer/manifest.go
@@ -1,0 +1,80 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package indexer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+)
+
+// maxManifestSize bounds how much data is read while inspecting a manifest.
+// Manifests are a few kilobytes at most, so anything larger is rejected rather
+// than buffered.
+const maxManifestSize = 1 << 20 // 1 MiB
+
+// manifestReader is the subset of the OCI target API needed to read the
+// manifest behind a tag. Both the local *oci.Store and the remote
+// *remote.Repository that back the task's tag lister implement it.
+type manifestReader interface {
+	content.Resolver
+	content.Fetcher
+}
+
+// isReferrerTag reports whether the manifest behind tag is a referrer artifact
+// (signature, public key, scan report, ...) instead of a record.
+//
+// Referrers are stored in the same repository as their subject record and are
+// tagged with their own CID, so a tag parsing as a CID does not make it a
+// record. Referrer manifests are identified by the OCI subject field that links
+// them to the record they describe, and by the Dir referrer type annotation.
+//
+// If the tag cannot be inspected, the error is returned and the caller decides
+// how to proceed; an unreadable manifest is not assumed to be a referrer.
+func (t *Task) isReferrerTag(ctx context.Context, tag string) (bool, error) {
+	if t.manifests == nil {
+		return false, nil
+	}
+
+	desc, err := t.manifests.Resolve(ctx, tag)
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve tag: %w", err)
+	}
+
+	if desc.MediaType != ocispec.MediaTypeImageManifest {
+		return false, nil
+	}
+
+	if desc.Size > maxManifestSize {
+		return false, fmt.Errorf("manifest is too large: %d bytes", desc.Size)
+	}
+
+	// FetchAll verifies the content against the descriptor size and digest.
+	manifestData, err := content.FetchAll(ctx, t.manifests, desc)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch manifest: %w", err)
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		return false, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+
+	return isReferrerManifest(&manifest), nil
+}
+
+// isReferrerManifest reports whether a manifest describes a referrer artifact.
+func isReferrerManifest(manifest *ocispec.Manifest) bool {
+	if manifest.Subject != nil {
+		return true
+	}
+
+	_, hasReferrerType := manifest.Annotations[corev1.ReferrerTypeAnnotationKey]
+
+	return hasReferrerType
+}

--- a/reconciler/tasks/indexer/manifest_test.go
+++ b/reconciler/tasks/indexer/manifest_test.go
@@ -1,0 +1,187 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package indexer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	ocidigest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeManifestReader serves a single manifest for any tag, mimicking the
+// Resolve/Fetch pair implemented by local and remote OCI targets.
+type fakeManifestReader struct {
+	manifest   ocispec.Manifest
+	mediaType  string
+	resolveErr error
+	fetchErr   error
+}
+
+func (f *fakeManifestReader) descriptor() (ocispec.Descriptor, []byte) {
+	data, err := json.Marshal(f.manifest)
+	if err != nil {
+		panic(err)
+	}
+
+	mediaType := f.mediaType
+	if mediaType == "" {
+		mediaType = ocispec.MediaTypeImageManifest
+	}
+
+	return ocispec.Descriptor{
+		MediaType: mediaType,
+		Digest:    ocidigest.FromBytes(data),
+		Size:      int64(len(data)),
+	}, data
+}
+
+func (f *fakeManifestReader) Resolve(_ context.Context, _ string) (ocispec.Descriptor, error) {
+	if f.resolveErr != nil {
+		return ocispec.Descriptor{}, f.resolveErr
+	}
+
+	desc, _ := f.descriptor()
+
+	return desc, nil
+}
+
+func (f *fakeManifestReader) Fetch(_ context.Context, _ ocispec.Descriptor) (io.ReadCloser, error) {
+	if f.fetchErr != nil {
+		return nil, f.fetchErr
+	}
+
+	_, data := f.descriptor()
+
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func TestIsReferrerManifest(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest ocispec.Manifest
+		want     bool
+	}{
+		{
+			name:     "record manifest",
+			manifest: ocispec.Manifest{Annotations: map[string]string{"org.agntcy.dir/type": "record"}},
+			want:     false,
+		},
+		{
+			name:     "referrer with subject",
+			manifest: ocispec.Manifest{Subject: &ocispec.Descriptor{Digest: "sha256:abc"}},
+			want:     true,
+		},
+		{
+			name: "referrer with type annotation only",
+			manifest: ocispec.Manifest{
+				Annotations: map[string]string{corev1.ReferrerTypeAnnotationKey: corev1.ScanReportReferrerType},
+			},
+			want: true,
+		},
+		{
+			name:     "manifest without annotations",
+			manifest: ocispec.Manifest{},
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isReferrerManifest(&tt.manifest))
+		})
+	}
+}
+
+func TestIsReferrerTag(t *testing.T) {
+	recordManifest := ocispec.Manifest{Annotations: map[string]string{"org.agntcy.dir/type": "record"}}
+	referrerManifest := ocispec.Manifest{
+		Subject:     &ocispec.Descriptor{Digest: "sha256:abc"},
+		Annotations: map[string]string{corev1.ReferrerTypeAnnotationKey: corev1.SignatureReferrerType},
+	}
+
+	tests := []struct {
+		name    string
+		reader  manifestReader
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "no manifest reader available",
+			reader: nil,
+			want:   false,
+		},
+		{
+			name:   "record",
+			reader: &fakeManifestReader{manifest: recordManifest},
+			want:   false,
+		},
+		{
+			name:   "referrer",
+			reader: &fakeManifestReader{manifest: referrerManifest},
+			want:   true,
+		},
+		{
+			name:   "non manifest media type",
+			reader: &fakeManifestReader{manifest: referrerManifest, mediaType: ocispec.MediaTypeImageIndex},
+			want:   false,
+		},
+		{
+			name:    "resolve fails",
+			reader:  &fakeManifestReader{manifest: recordManifest, resolveErr: errors.New("not found")},
+			wantErr: true,
+		},
+		{
+			name:    "fetch fails",
+			reader:  &fakeManifestReader{manifest: recordManifest, fetchErr: errors.New("connection reset")},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task := &Task{manifests: tt.reader}
+
+			got, err := task.isReferrerTag(t.Context(), "baeareihwzcbx3ymdhvbgpzialtketsctkkikubksllegiqyhrouwlrdnz4")
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsReferrerTag_RejectsOversizedManifest(t *testing.T) {
+	reader := &fakeManifestReader{manifest: ocispec.Manifest{}}
+	desc, _ := reader.descriptor()
+	desc.Size = maxManifestSize + 1
+
+	task := &Task{manifests: &oversizedManifestReader{desc: desc}}
+
+	_, err := task.isReferrerTag(t.Context(), "tag")
+	require.ErrorContains(t, err, "too large")
+}
+
+// oversizedManifestReader reports a manifest larger than the read limit.
+type oversizedManifestReader struct {
+	desc ocispec.Descriptor
+}
+
+func (o *oversizedManifestReader) Resolve(_ context.Context, _ string) (ocispec.Descriptor, error) {
+	return o.desc, nil
+}
+
+func (o *oversizedManifestReader) Fetch(_ context.Context, _ ocispec.Descriptor) (io.ReadCloser, error) {
+	return nil, errors.New("should not be fetched")
+}

--- a/reconciler/tasks/indexer/task.go
+++ b/reconciler/tasks/indexer/task.go
@@ -34,6 +34,10 @@ type Task struct {
 	repo      registry.TagLister
 	validator corev1.Validator
 
+	// manifests reads manifests behind tags to separate records from referrers.
+	// It is nil when repo does not support manifest reads.
+	manifests manifestReader
+
 	mu           sync.Mutex
 	lastSnapshot *registrySnapshot
 }
@@ -53,6 +57,11 @@ var emptySnapshot = &registrySnapshot{
 
 // NewTask creates a new indexer reconciliation task.
 func NewTask(config Config, localRegistry ociconfig.Config, store types.StoreAPI, repo registry.TagLister, db types.SearchDatabaseAPI, validator corev1.Validator) (*Task, error) {
+	manifests, ok := repo.(manifestReader)
+	if !ok && repo != nil {
+		logger.Warn("Registry cannot read manifests, referrer tags will be indexed as records", "type", fmt.Sprintf("%T", repo))
+	}
+
 	return &Task{
 		config:       config,
 		db:           db,
@@ -60,6 +69,7 @@ func NewTask(config Config, localRegistry ociconfig.Config, store types.StoreAPI
 		ociConfig:    localRegistry,
 		repo:         repo,
 		validator:    validator,
+		manifests:    manifests,
 		lastSnapshot: emptySnapshot,
 	}, nil
 }
@@ -102,12 +112,27 @@ func (t *Task) Run(ctx context.Context) error {
 		return nil
 	}
 
-	logger.Info("Found new records to index", "count", len(newTags))
+	logger.Info("Found new tags to process", "count", len(newTags))
 
 	// Process each new tag
-	var indexedCount, failedCount int
+	var indexedCount, skippedCount, failedCount int
 
 	for _, tag := range newTags {
+		// Referrers share the repository with records and are tagged with their
+		// own CID, so they must be filtered out before attempting to index them.
+		isReferrer, err := t.isReferrerTag(ctx, tag)
+		if err != nil {
+			logger.Warn("Failed to inspect manifest, handling tag as a record", "tag", tag, "error", err)
+		}
+
+		if isReferrer {
+			logger.Debug("Skipping referrer tag", "tag", tag)
+
+			skippedCount++
+
+			continue
+		}
+
 		if err := t.indexRecord(ctx, tag); err != nil {
 			logger.Error("Failed to index record", "tag", tag, "error", err)
 
@@ -119,7 +144,7 @@ func (t *Task) Run(ctx context.Context) error {
 		indexedCount++
 	}
 
-	logger.Info("Indexing complete", "indexed", indexedCount, "failed", failedCount)
+	logger.Info("Indexing complete", "indexed", indexedCount, "skipped", skippedCount, "failed", failedCount)
 
 	// Update last snapshot
 	t.lastSnapshot = snapshot

--- a/server/store/oci/referrers.go
+++ b/server/store/oci/referrers.go
@@ -105,15 +105,15 @@ func (s *store) pushReferrer(ctx context.Context, recordCID string, referrer *co
 
 	// Create annotations for the referrer manifest
 	annotations := make(map[string]string)
-	annotations["agntcy.dir.referrer.type"] = referrer.GetType()
+	annotations[corev1.ReferrerTypeAnnotationKey] = referrer.GetType()
 	annotations[ManifestKeyCid] = referrerCID
 
 	if referrer.GetCreatedAt() != "" {
-		annotations["agntcy.dir.referrer.created_at"] = referrer.GetCreatedAt()
+		annotations[corev1.ReferrerCreatedAtAnnotationKey] = referrer.GetCreatedAt()
 	}
 	// Add custom annotations from the referrer
 	for key, value := range referrer.GetAnnotations() {
-		annotations["agntcy.dir.referrer.annotation."+key] = value
+		annotations[corev1.ReferrerAnnotationPrefix+key] = value
 	}
 
 	// Create the referrer manifest with proper OCI subject field


### PR DESCRIPTION
Referrers live in the same repository as their subject record and are tagged with their own CID, so the indexer treated every CID tag as a record and failed to decode them. This produced ERROR log noise and inflated failure counts, re-emitted in full on every restart because the tag snapshot is in-memory.
Inspect the manifest behind each new tag and skip the ones carrying an OCI subject field or the Dir referrer type annotation. Tags that cannot be inspected are still indexed, so a transient registry error does not drop a record.

Fixes #2043