### PR TITLE
chore(deps): clear fixable CVEs from published container images

### DIFF
--- a/.github/actions/build-dirctl/action.yaml
+++ b/.github/actions/build-dirctl/action.yaml
@@ -13,7 +13,7 @@ inputs:
   go_version:
     description: Go version to use for building dirctl
     required: false
-    default: "1.26.5"
+    default: "1.26.7"
 
 outputs:
   dirctl_path:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache-dependency-path: "**/*.sum"
 
       - name: Install Task

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -78,7 +78,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache: true
 
       - name: Install Task

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache: true
           cache-dependency-path: "**/*.sum"
 

--- a/.github/workflows/oidc-test.yml
+++ b/.github/workflows/oidc-test.yml
@@ -42,7 +42,7 @@ jobs:
         id: build-dirctl
         uses: ./.github/actions/build-dirctl
         with:
-          go_version: "1.26.5"
+          go_version: "1.26.7"
 
       - name: Fetch GitHub OIDC token
         id: oidc

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache-dependency-path: "**/*.sum"
           cache: true # NOTE: Default value, just to be explicit
 

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache-dependency-path: "**/*.sum"
           cache: true # NOTE: Default value, just to be explicit
 

--- a/.github/workflows/reusable-test-e2e-cross-platform.yaml
+++ b/.github/workflows/reusable-test-e2e-cross-platform.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache-dependency-path: "**/*.sum"
           cache: true
 

--- a/.github/workflows/reusable-test-e2e.yaml
+++ b/.github/workflows/reusable-test-e2e.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache-dependency-path: "**/*.sum"
           cache: true
 

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache-dependency-path: "**/*.sum"
           cache: true # NOTE: Default value, just to be explicit
 

--- a/Taskfile.vars.yml
+++ b/Taskfile.vars.yml
@@ -64,7 +64,7 @@ vars:
   PROTOC_BIN: "{{ .BIN_DIR }}/protoc-{{.PROTOC_VERSION}}"
   BUFBUILD_VERSION: "1.66.1"
   BUFBUILD_BIN: "{{ .BIN_DIR }}/bufbuild-{{.BUFBUILD_VERSION}}"
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.7"
   MULTIMOD_VERSION: "0.29.0"
   MULTIMOD_BIN: "{{ .BIN_DIR }}/multimod-{{.MULTIMOD_VERSION}}"
   # renovate: datasource=go depName=github.com/mikefarah/yq/v4 versioning=semver

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/agntcy/dir/api
 
-go 1.26.5
+go 1.26.7
 
 require (
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.12-20260811133823-5281d0c487b5.1

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -3,7 +3,7 @@
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-bookworm@sha256:e60d708a92ad26a6d61901334510d3debd23ddcba125663ecd6008d42e8ec669 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm@sha256:6ef6e30f0ea5c384f6d111cf856e024e3086bbdcb1779da3f3b3fbba0aea53d2 AS builder
 
 COPY --link --from=xx / /
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/agntcy/dir/cli
 
-go 1.26.5
+go 1.26.7
 
 // Replace local modules
 replace (

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/agntcy/dir/client
 
-go 1.26.5
+go 1.26.7
 
 // Replace local modules
 replace (

--- a/reconciler/Dockerfile
+++ b/reconciler/Dockerfile
@@ -3,7 +3,7 @@
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-bookworm@sha256:e60d708a92ad26a6d61901334510d3debd23ddcba125663ecd6008d42e8ec669 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm@sha256:6ef6e30f0ea5c384f6d111cf856e024e3086bbdcb1779da3f3b3fbba0aea53d2 AS builder
 
 COPY --link --from=xx / /
 

--- a/reconciler/Dockerfile
+++ b/reconciler/Dockerfile
@@ -88,7 +88,7 @@ USER 55532:55532
 
 ENTRYPOINT ["./reconciler"]
 
-FROM python:3.13-slim AS scanner
+FROM python:3.13-slim@sha256:ffb752e139c0a19692a43af8d8523b274222dd68eebad5d583b45c2201c6e30a AS scanner
 
 RUN groupadd -g 55532 -r nonroot && useradd -u 55532 -r -g nonroot nonroot \
     && mkdir -p /home/nonroot && chown 55532:55532 /home/nonroot
@@ -99,17 +99,23 @@ COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 COPY --from=builder /bin/reconciler ./reconciler
 
+# The base image lags behind Debian security updates.
 RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
     && apt-get install -y --no-install-recommends git \
     && rm -rf /var/lib/apt/lists/*
 
 ARG MCP_SCANNER_VERSION
 ARG SKILL_SCANNER_VERSION
 ARG A2A_SCANNER_VERSION
+# pip vendors CVE-carrying msgpack and setuptools copies and nothing needs it
+# at runtime, so drop it and its ensurepip wheel in the install layer.
 RUN pip install --no-cache-dir \
     cisco-ai-mcp-scanner==${MCP_SCANNER_VERSION} \
     cisco-ai-skill-scanner==${SKILL_SCANNER_VERSION} \
-    cisco-ai-a2a-scanner==${A2A_SCANNER_VERSION}
+    cisco-ai-a2a-scanner==${A2A_SCANNER_VERSION} \
+    && python -m pip uninstall -y pip \
+    && rm -rf /usr/local/lib/python3.*/ensurepip/_bundled
 
 USER 55532:55532
 

--- a/reconciler/go.mod
+++ b/reconciler/go.mod
@@ -1,6 +1,6 @@
 module github.com/agntcy/dir/reconciler
 
-go 1.26.5
+go 1.26.7
 
 // Replace local modules
 replace (

--- a/renovate.json
+++ b/renovate.json
@@ -53,7 +53,6 @@
     "before 8am on Wednesday",
     "before 8am on Friday"
   ],
-  "prCreation": "not-pending",
   "enabledManagers": [
     "custom.regex",
     "docker-compose",

--- a/renovate.json
+++ b/renovate.json
@@ -49,9 +49,7 @@
   "enabled": true,
   "minimumReleaseAge": "7 days",
   "schedule": [
-    "before 8am on Monday",
-    "before 8am on Wednesday",
-    "before 8am on Friday"
+    "before 8am on Monday"
   ],
   "enabledManagers": [
     "custom.regex",

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -45,7 +45,7 @@ FROM builder AS debug
 WORKDIR /
 
 COPY --from=builder /bin/apiserver ./apiserver
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.53 /ko-app/grpc-health-probe /bin/grpc-health-probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.55@sha256:d261bc6df0fdd676c2f77230e1107636f43ef843cecd9ac05b89e4aabd017679 /ko-app/grpc-health-probe /bin/grpc-health-probe
 
 RUN xx-go install github.com/go-delve/delve/cmd/dlv@v1.26.2
 
@@ -57,7 +57,7 @@ FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb0147
 WORKDIR /
 
 COPY --from=builder /bin/apiserver ./apiserver
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.53 /ko-app/grpc-health-probe /bin/grpc-health-probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.55@sha256:d261bc6df0fdd676c2f77230e1107636f43ef843cecd9ac05b89e4aabd017679 /ko-app/grpc-health-probe /bin/grpc-health-probe
 
 USER 65532:65532
 
@@ -72,7 +72,7 @@ COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder /usr/share/ca-certificates /usr/share/ca-certificates
 
 COPY --from=builder /bin/apiserver ./apiserver
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.53 /ko-app/grpc-health-probe /bin/grpc-health-probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.55@sha256:d261bc6df0fdd676c2f77230e1107636f43ef843cecd9ac05b89e4aabd017679 /ko-app/grpc-health-probe /bin/grpc-health-probe
 
 # Create a non-root user for coverage
 RUN addgroup -g 55532 -S nonroot && adduser -u 55532 -S nonroot -G nonroot

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.9.0@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-bookworm@sha256:e60d708a92ad26a6d61901334510d3debd23ddcba125663ecd6008d42e8ec669 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.7-bookworm@sha256:6ef6e30f0ea5c384f6d111cf856e024e3086bbdcb1779da3f3b3fbba0aea53d2 AS builder
 
 COPY --link --from=xx / /
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/agntcy/dir/server
 
-go 1.26.5
+go 1.26.7
 
 // Replace local modules
 replace (

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/agntcy/dir/tests
 
-go 1.26.5
+go 1.26.7
 
 // Replace local modules (paths relative to tests/; repo root is ..)
 replace (

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/agntcy/dir/utils
 
-go 1.26.5
+go 1.26.7
 
 require (
 	buf.build/gen/go/agntcy/oasf-sdk/grpc/go v1.6.2-20260811133823-5281d0c487b5.1


### PR DESCRIPTION
`task deps:vuln:images` reported 92 fixable HIGH/MEDIUM findings across the three images we publish. Bumping Go to 1.26.7, updating the gRPC health probe, and patching the reconciler's scanner image clears all of them. The only findings left are five in upstream zot, which has fixed them on main but not released, so its pin is unchanged.

- pip is uninstalled after the scanners install, since it vendors CVE-carrying msgpack and setuptools copies with no upstream fix. This disables mcp-scanner's `vulnerable_package` analyzer, which the reconciler never requests.
- The reconciler runs `apt-get upgrade` rather than waiting on a base image refresh, because Debian had already published the util-linux fix behind 54 of the findings.
- The Python base is now digest-pinned, the last floating `FROM` in the repo.
- Unrelated: the Renovate `prCreation: not-pending` setting is dropped.