### PR TITLE
fix(dir/server): handle missing manifest gracefully to prevent orphaned search index rows

### DIFF
--- a/server/controller/store.go
+++ b/server/controller/store.go
@@ -201,7 +201,7 @@ func (s storeCtrl) Delete(stream storev1.StoreService_DeleteServer) error {
 
 		// Delete record from store
 		err = s.store.Delete(stream.Context(), recordRef)
-		if err != nil {
+		if err != nil && status.Code(err) != codes.NotFound {
 			st := status.Convert(err)
 
 			return status.Errorf(st.Code(), "failed to delete record: %s", st.Message())

--- a/server/controller/store_test.go
+++ b/server/controller/store_test.go
@@ -1,0 +1,81 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/server/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type mockStore struct {
+	types.StoreAPI
+	deleteErr error
+}
+
+func (m *mockStore) Delete(ctx context.Context, ref *corev1.RecordRef) error {
+	return m.deleteErr
+}
+
+type mockDB struct {
+	types.DatabaseAPI
+	removeRecordCalled bool
+}
+
+func (m *mockDB) RemoveRecord(cid string) error {
+	m.removeRecordCalled = true
+
+	return nil
+}
+
+type mockDeleteServer struct {
+	grpc.ServerStream
+	reqs []*corev1.RecordRef
+	idx  int
+}
+
+func (m *mockDeleteServer) Recv() (*corev1.RecordRef, error) {
+	if m.idx < len(m.reqs) {
+		req := m.reqs[m.idx]
+		m.idx++
+
+		return req, nil
+	}
+
+	return nil, io.EOF
+}
+
+func (m *mockDeleteServer) SendAndClose(*emptypb.Empty) error {
+	return nil
+}
+
+func (m *mockDeleteServer) Context() context.Context {
+	return context.Background()
+}
+
+func TestStoreDelete_NotFound(t *testing.T) {
+	storeMock := &mockStore{
+		deleteErr: status.Error(codes.NotFound, "record not found"),
+	}
+	dbMock := &mockDB{}
+
+	ctrl := NewStoreController(storeMock, dbMock, nil, nil, nil)
+
+	stream := &mockDeleteServer{
+		reqs: []*corev1.RecordRef{{Cid: "test-cid"}},
+	}
+
+	err := ctrl.Delete(stream)
+	require.NoError(t, err)
+	assert.True(t, dbMock.removeRecordCalled, "RemoveRecord should be called even if store returns codes.NotFound")
+}

--- a/server/store/oci/internal.go
+++ b/server/store/oci/internal.go
@@ -6,6 +6,7 @@ package oci
 import (
 	"context"
 	"encoding/json"
+	stdErrors "errors"
 	"fmt"
 	"io"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry/remote"
 )
 
@@ -111,6 +113,11 @@ func (s *store) deleteFromOCIStore(ctx context.Context, cid string) error {
 
 	manifestDesc, err := s.repo.Resolve(ctx, cid)
 	if err != nil {
+		if stdErrors.Is(err, errdef.ErrNotFound) {
+			internalLogger.Info("Manifest not found (never existed or deleted already)", "cid", cid)
+
+			return nil
+		}
 		// Manifest might already be gone - this is not necessarily an error
 		internalLogger.Debug("Failed to resolve manifest during delete (may already be deleted)", "cid", cid, "error", err)
 		errors = append(errors, fmt.Sprintf("manifest resolve: %v", err))
@@ -175,6 +182,13 @@ func (s *store) deleteFromRemoteRepository(ctx context.Context, cid string) erro
 
 	manifestDesc, err := s.repo.Resolve(ctx, cid)
 	if err != nil {
+		// If manifest is completely missing (errdef.ErrNotFound), treat as successful deletion
+		if stdErrors.Is(err, errdef.ErrNotFound) {
+			internalLogger.Info("Manifest not found (never existed or deleted already)", "cid", cid)
+
+			return nil
+		}
+
 		// If manifest doesn't exist, consider it already deleted
 		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "NOT_FOUND") {
 			internalLogger.Info("Manifest not found (never existed or deleted already)", "cid", cid)

--- a/server/store/oci/internal_test.go
+++ b/server/store/oci/internal_test.go
@@ -1,0 +1,28 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/oci"
+)
+
+func TestDeleteFromOCIStore_NotFound(t *testing.T) {
+	// Create an empty OCI store which will return errdef.ErrNotFound for any non-existent CID
+	tmpDir := t.TempDir()
+	ociStore, err := oci.New(tmpDir)
+	require.NoError(t, err)
+
+	s := &store{
+		repo: ociStore,
+	}
+
+	// Attempting to delete a non-existent CID should return nil (success)
+	err = s.deleteFromOCIStore(context.Background(), "bafybeib76j4m6pfr253a652y5z2ndifewfhztdv73cyb25yhtv4b3445nm")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
**Fixes #2066**

### Problem Statement
Previously, `StoreService.Delete` would fail and return an error if a record's manifest was already missing from the OCI store. Because the OCI deletion step failed, the subsequent database search-index cleanup step was never reached, leaving behind an orphaned, unrecoverable row in the search index.

### Proposed Changes
This PR implements the maintainer's proposed solution to make "record not found in OCI" a non-fatal outcome, allowing the deletion process to continue and clean up the database index:

1. **OCI Store (`server/store/oci/internal.go`):** 
   - Updated `deleteFromOCIStore` and `deleteFromRemoteRepository` to check for `errdef.ErrNotFound` using `errors.Is`.
   - If the manifest is missing, it logs an informational message and returns `nil` (success), treating the deletion as idempotent.
2. **Controller (`server/controller/store.go`):** 
   - Updated the error evaluation block immediately following `s.store.Delete`.
   - The deletion process now proceeds to `s.db.RemoveRecord` even if the store returns a `codes.NotFound` gRPC status.
3. **Unit Tests Added:**
   - `TestDeleteFromOCIStore_NotFound`: Verifies that attempting to delete a non-existent CID in the OCI store correctly returns `nil`.
   - `TestStoreDelete_NotFound`: Verifies that the controller's `Delete` method correctly invokes the database `RemoveRecord` mock even when the OCI store returns `codes.NotFound`.

### Checklist
- [x] I have read the contributing guidelines
- [x] I have signed off my commits (DCO)
- [x] I have added tests that prove my fix is effective
- [x] All local tests pass successfully (`go test`)