### PR TITLE
feat(ci): raise import matrix max-parallel to 3 (fixes #2047)

### DIFF
--- a/.github/workflows/import-records.yaml
+++ b/.github/workflows/import-records.yaml
@@ -160,7 +160,7 @@ jobs:
       id-token: write # Required for OIDC signing with Sigstore
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 3
       matrix:
         entry: ${{ fromJson(needs.setup-matrix.outputs.mcp_matrix) }}
     env:
@@ -355,7 +355,7 @@ jobs:
       id-token: write # Required for OIDC signing with Sigstore
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 3
       matrix:
         entry: ${{ fromJson(needs.setup-matrix.outputs.agent_skills_matrix) }}
     env:


### PR DESCRIPTION
**Fixes #2047**

### Problem Statement
The importer pipelines were historically bottlenecked at `max-parallel: 1` to protect production from compounding load during eager dedup cache building. Since the importer now uses lazy per-item lookups, this serialization is no longer necessary.

### Proposed Changes
This PR increases `max-parallel` from `1` to `3` for both the `import-mcp` and `import-agent-skills` matrix jobs.

### ⚠️ Verification Required
As noted in the original issue, **I am unable to run the Verification step locally** since this workflow requires access to repository secrets and Sigstore authentication. 

Could a maintainer please trigger this workflow manually via `workflow_dispatch` with `sign: false` and `dry_run: false` to verify no cross-job interference before merging?

### Checklist
- [x] I have read the contributing guidelines
- [x] I have signed off my commits (DCO)