### PR TITLE
fix(tests): point nl-search e2e guard at the extractor manifest path

### DIFF
--- a/tests/e2e/local/15_nl_search_test.go
+++ b/tests/e2e/local/15_nl_search_test.go
@@ -25,12 +25,12 @@ var _ = ginkgo.Describe("Natural-language search", func() {
 
 	ginkgo.Context("free-text query with OASF extractor", ginkgo.Ordered, func() {
 		ginkgo.BeforeAll(func() {
-			// Check for the oasf-sdk manifest written by `dirctl init`. This mirrors
-			// what extractor.IsProvisioned does without importing the internal package.
+			// Check for the oasf-sdk extractor manifest written by `dirctl init`.
+			// This mirrors extractor.IsProvisioned without importing the internal package.
 			home, homeErr := os.UserHomeDir()
 			gomega.Expect(homeErr).NotTo(gomega.HaveOccurred())
 
-			manifest := filepath.Join(home, ".agntcy", "oasf-sdk", "manifest.json")
+			manifest := filepath.Join(home, ".agntcy", "oasf-sdk", "extractor", "manifest.json")
 			if _, err := os.Stat(manifest); err != nil {
 				ginkgo.Skip("OASF extractor not provisioned — run `dirctl init` to enable natural-language search tests")
 			}

--- a/tests/e2e/local/15_nl_search_test.go
+++ b/tests/e2e/local/15_nl_search_test.go
@@ -49,6 +49,14 @@ var _ = ginkgo.Describe("Natural-language search", func() {
 		})
 
 		ginkgo.AfterAll(func() {
+			// Delete the pushed record so it does not leak into the shared daemon.
+			// The fixture is named "org.agntcy/directory", the same name the daemon
+			// self-publishes its skill record under, so a leaked copy would shadow
+			// it in name searches run by other suites (e.g. 14_skill_record_test).
+			// Mirrors the cleanup in 16_extractor_enricher_test.go.
+			if recordCID != "" {
+				_ = testEnv.CLI.Delete(recordCID).ShouldSucceed()
+			}
 			if tempDir != "" {
 				_ = os.RemoveAll(tempDir)
 			}


### PR DESCRIPTION
## Problem

`tests/e2e/local/15_nl_search_test.go` never runs. Its `BeforeAll` guard checks for the OASF extractor manifest at the wrong path, so the "Natural-language search" suite skips in every environment — including the `e2e:test:local:local` CI job — and has silently reported green while executing nothing since it was added in #1770.

## Root cause

The guard looked for the manifest directly under `.agntcy/oasf-sdk`:

```go
manifest := filepath.Join(home, ".agntcy", "oasf-sdk", "manifest.json")
```

but `dirctl init` provisions it under `.agntcy/oasf-sdk/extractor/`, per `extractor.DefaultAssetDir` (`utils/extractor/config.go`). `tests/e2e/local/16_extractor_enricher_test.go` already checks the correct path.

## Fix

Point the guard at the same `extractor/manifest.json` path that `dirctl init` provisions and `16_extractor_enricher_test.go` checks (and align the comment wording). The `os.Stat`-then-`Skip` structure is unchanged, so an unprovisioned machine still skips cleanly.

## Verification

- `go vet ./e2e/local/` passes; `gofmt` clean.
- Unprovisioned machine: manifest absent, guard still skips cleanly via `ginkgo.Skip`.
- Provisioned machine (`dirctl init`): the manifest now resolves, so the suite executes instead of skipping — CI's `e2e:test:local:local` job will exercise it.

## Acceptance criteria

- [x] The guard checks the same manifest path `dirctl init` provisions and `16_extractor_enricher_test.go` checks
- [x] The suite now executes rather than skipping on a provisioned machine (enabled here; exercised for the first time since #1770 by the provisioned CI job)
- [x] A skip still happens cleanly when the extractor genuinely is not provisioned

Note: because this re-enables a suite dormant since #1770, any assertions that have drifted will surface on the first provisioned CI run — flagging for reviewer visibility, as the issue anticipated.

Closes #2090
