### PR TITLE
fix(store): stop tagging referrers with their CID

### DIFF
--- a/reconciler/tasks/indexer/manifest.go
+++ b/reconciler/tasks/indexer/manifest.go
@@ -29,10 +29,13 @@ type manifestReader interface {
 // isReferrerTag reports whether the manifest behind tag is a referrer artifact
 // (signature, public key, scan report, ...) instead of a record.
 //
-// Referrers are stored in the same repository as their subject record and are
-// tagged with their own CID, so a tag parsing as a CID does not make it a
-// record. Referrer manifests are identified by the OCI subject field that links
+// Referrers are stored in the same repository as their subject record. New ones are not tagged,
+// but those written earlier still carry a tag of their own CID, so a tag parsing as a CID does
+// not make it a record. Referrer manifests are identified by the OCI subject field that links
 // them to the record they describe, and by the Dir referrer type annotation.
+//
+// This check is therefore still needed, and stays needed until those legacy tags are stripped
+// from the registries.
 //
 // If the tag cannot be inspected, the error is returned and the caller decides
 // how to proceed; an unreadable manifest is not assumed to be a referrer.

--- a/reconciler/tasks/scan/referrer_test.go
+++ b/reconciler/tasks/scan/referrer_test.go
@@ -21,11 +21,13 @@ type fakeReferrerStore struct {
 	pushedCID string
 	pushErr   error
 
-	existing []*corev1.RecordReferrer
-	walkErr  error
+	existing  []*corev1.RecordReferrer
+	walkErr   error
+	walkCalls int
 
-	deleteErr error
-	deleted   []string
+	deleteErr   error
+	deleted     []string
+	deleteCalls int
 }
 
 func (f *fakeReferrerStore) PushReferrer(_ context.Context, _ string, _ *corev1.RecordReferrer) (*corev1.ReferrerRef, error) {
@@ -37,12 +39,14 @@ func (f *fakeReferrerStore) PushReferrer(_ context.Context, _ string, _ *corev1.
 }
 
 func (f *fakeReferrerStore) WalkReferrers(_ context.Context, _ string, referrerType string, walkFn func(*corev1.RecordReferrer) error) error {
+	f.walkCalls++
+
 	if f.walkErr != nil {
 		return f.walkErr
 	}
 
 	for _, ref := range f.existing {
-		if referrerType != "" && ref.GetType() != referrerType {
+		if !sharesArtifactType(referrerType, ref.GetType()) {
 			continue
 		}
 
@@ -54,14 +58,42 @@ func (f *fakeReferrerStore) WalkReferrers(_ context.Context, _ string, referrerT
 	return nil
 }
 
+// sharesArtifactType reproduces the OCI store's type filter, which is coarser than it looks:
+// apiToOCIType maps every referrer type except signatures and public keys onto one shared media
+// type, so a walk filtered on scan reports also yields every other custom referrer. The fake
+// matches that, otherwise it would hide the task's need to check the type itself.
+func sharesArtifactType(want, got string) bool {
+	if want == "" || want == got {
+		return true
+	}
+
+	distinct := func(t string) bool {
+		return t == corev1.SignatureReferrerType || t == corev1.PublicKeyReferrerType
+	}
+
+	return !distinct(want) && !distinct(got)
+}
+
 func (f *fakeReferrerStore) DeleteReferrer(_ context.Context, _ string, referrerCID string, _ string) ([]string, error) {
 	if f.deleteErr != nil {
 		return nil, f.deleteErr
 	}
 
+	f.deleteCalls++
 	f.deleted = append(f.deleted, referrerCID)
 
 	return []string{referrerCID}, nil
+}
+
+func (f *fakeReferrerStore) DeleteReferrers(_ context.Context, _ string, referrerCIDs []string, _ string) ([]string, error) {
+	if f.deleteErr != nil {
+		return nil, f.deleteErr
+	}
+
+	f.deleteCalls++
+	f.deleted = append(f.deleted, referrerCIDs...)
+
+	return referrerCIDs, nil
 }
 
 // scanReferrer builds a stored scan report referrer as WalkReferrers would
@@ -122,6 +154,88 @@ func TestPushReferrer_PrunesOnlySameScannerReports(t *testing.T) {
 
 	if !slices.Equal(store.deleted, want) {
 		t.Errorf("deleted = %v, want %v", store.deleted, want)
+	}
+}
+
+// Pruning a backlog must cost one delete call, not one per report. A delete needs the referrer's
+// manifest descriptor, which only a walk supplies, so a loop of single deletes repeats the walk
+// once per report and the cost grows with the square of the backlog.
+func TestPushReferrer_PrunesInOneCall(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeReferrerStore{pushedCID: "new-mcp"}
+
+	for _, cid := range []string{"old-1", "old-2", "old-3", "old-4", "old-5", "old-6", "old-7", "old-8"} {
+		store.existing = append(store.existing, scanReferrer(t, cid, scanv1.ScannerType_SCANNER_TYPE_MCP))
+	}
+
+	task := &Task{refStore: store}
+
+	if err := task.pushReferrer(t.Context(), testRecordCID, mcpReport()); err != nil {
+		t.Fatalf("pushReferrer: %v", err)
+	}
+
+	if len(store.deleted) != len(store.existing) {
+		t.Errorf("deleted %d referrers, want %d", len(store.deleted), len(store.existing))
+	}
+
+	if store.walkCalls != 1 {
+		t.Errorf("walkCalls = %d, want 1", store.walkCalls)
+	}
+
+	if store.deleteCalls != 1 {
+		t.Errorf("deleteCalls = %d, want 1", store.deleteCalls)
+	}
+}
+
+// The store's type filter passes every custom referrer type, so a walk for scan reports also
+// yields unrelated artifacts. Here one carries a payload that does parse as an MCP report, which
+// leaves the task's own type check as the only thing keeping it.
+func TestPushReferrer_LeavesOtherReferrerTypesAlone(t *testing.T) {
+	t.Parallel()
+
+	foreign := scanReferrer(t, "not-a-scan-report", scanv1.ScannerType_SCANNER_TYPE_MCP)
+	foreign.Type = "agntcy.dir.other.v1.Artifact"
+
+	store := &fakeReferrerStore{
+		pushedCID: "new-mcp",
+		existing: []*corev1.RecordReferrer{
+			foreign,
+			scanReferrer(t, "old-mcp", scanv1.ScannerType_SCANNER_TYPE_MCP),
+		},
+	}
+
+	task := &Task{refStore: store}
+
+	if err := task.pushReferrer(t.Context(), testRecordCID, mcpReport()); err != nil {
+		t.Fatalf("pushReferrer: %v", err)
+	}
+
+	if !slices.Equal(store.deleted, []string{"old-mcp"}) {
+		t.Errorf("deleted = %v, want [old-mcp]", store.deleted)
+	}
+}
+
+// Nothing superseded means no delete call at all. Reaching the store with an empty set would
+// depend on it reading that as "delete none" rather than "delete all of this type".
+func TestPushReferrer_NothingSupersededIssuesNoDelete(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeReferrerStore{
+		pushedCID: "new-mcp",
+		existing: []*corev1.RecordReferrer{
+			scanReferrer(t, "old-a2a", scanv1.ScannerType_SCANNER_TYPE_A2A),
+		},
+	}
+
+	task := &Task{refStore: store}
+
+	if err := task.pushReferrer(t.Context(), testRecordCID, mcpReport()); err != nil {
+		t.Fatalf("pushReferrer: %v", err)
+	}
+
+	if store.deleteCalls != 0 {
+		t.Errorf("deleteCalls = %d, want 0", store.deleteCalls)
 	}
 }
 

--- a/reconciler/tasks/scan/task.go
+++ b/reconciler/tasks/scan/task.go
@@ -268,6 +268,13 @@ func (t *Task) pruneScanReferrers(ctx context.Context, recordCID string, scanner
 	var superseded []string
 
 	err := t.refStore.WalkReferrers(ctx, recordCID, corev1.ScanReportReferrerType, func(ref *corev1.RecordReferrer) error {
+		// The store's type filter maps every referrer type except signatures and public keys
+		// onto one shared media type, so the walk also yields other custom referrers. Check the
+		// type here instead of trusting the filter.
+		if ref.GetType() != corev1.ScanReportReferrerType {
+			return nil
+		}
+
 		cid := ref.GetReferrerRef().GetCid()
 		if cid == "" || cid == keepCID {
 			return nil
@@ -294,17 +301,22 @@ func (t *Task) pruneScanReferrers(ctx context.Context, recordCID string, scanner
 		return
 	}
 
-	for _, cid := range superseded {
-		if _, err := t.refStore.DeleteReferrer(ctx, recordCID, cid, corev1.ScanReportReferrerType); err != nil {
-			logger.Warn("Failed to delete superseded scan report referrer",
-				"cid", recordCID, "referrer", cid, "error", err)
-
-			continue
-		}
-
-		logger.Debug("Deleted superseded scan report referrer",
-			"cid", recordCID, "referrer", cid, "scanner", scannerType.String())
+	if len(superseded) == 0 {
+		return
 	}
+
+	// One call rather than one per report: a delete needs the referrer's manifest descriptor,
+	// which only a walk supplies, so DeleteReferrer repeats the whole walk every time.
+	deleted, err := t.refStore.DeleteReferrers(ctx, recordCID, superseded, corev1.ScanReportReferrerType)
+	if err != nil {
+		logger.Warn("Failed to delete superseded scan report referrers", "cid", recordCID,
+			"deleted", len(deleted), "superseded", len(superseded), "error", err)
+
+		return
+	}
+
+	logger.Debug("Deleted superseded scan report referrers",
+		"cid", recordCID, "count", len(deleted), "scanner", scannerType.String())
 }
 
 // buildScanReport converts a runner name + ScanResult into a scanv1.ScanReport proto.

--- a/server/ingest/ingest_test.go
+++ b/server/ingest/ingest_test.go
@@ -116,6 +116,10 @@ func (m *mockStore) DeleteReferrer(context.Context, string, string, string) ([]s
 	return nil, nil
 }
 
+func (m *mockStore) DeleteReferrers(context.Context, string, []string, string) ([]string, error) {
+	return nil, nil
+}
+
 // recordOnlyStore implements only types.StoreAPI (no referrer support).
 type recordOnlyStore struct {
 	types.StoreAPI

--- a/server/store/eventswrap/eventswrap.go
+++ b/server/store/eventswrap/eventswrap.go
@@ -22,6 +22,11 @@ type eventsStore struct {
 	eventBus *events.SafeEventBus
 }
 
+// Wrap returns a StoreAPI, but callers reach referrer operations by asserting this type to
+// ReferrerStoreAPI at runtime. Without this check, adding a method to that interface would turn
+// every referrer call into an Unimplemented error instead of a build failure.
+var _ types.ReferrerStoreAPI = (*eventsStore)(nil)
+
 // Wrap creates an event-emitting wrapper around a StoreAPI.
 // All successful operations will emit corresponding events.
 func Wrap(source types.StoreAPI, eventBus *events.SafeEventBus) types.StoreAPI {
@@ -147,4 +152,16 @@ func (s *eventsStore) DeleteReferrer(ctx context.Context, recordCID string, refe
 	// Delegate to source (no event emitted for referrer operations)
 	//nolint:wrapcheck
 	return referrerStore.DeleteReferrer(ctx, recordCID, referrerCID, referrerType)
+}
+
+func (s *eventsStore) DeleteReferrers(ctx context.Context, recordCID string, referrerCIDs []string, referrerType string) ([]string, error) {
+	// Check if source supports referrer operations
+	referrerStore, ok := s.source.(types.ReferrerStoreAPI)
+	if !ok {
+		return nil, status.Errorf(codes.Unimplemented, "source store does not support referrer operations")
+	}
+
+	// Delegate to source (no event emitted for referrer operations)
+	//nolint:wrapcheck
+	return referrerStore.DeleteReferrers(ctx, recordCID, referrerCIDs, referrerType)
 }

--- a/server/store/oci/internal.go
+++ b/server/store/oci/internal.go
@@ -219,3 +219,59 @@ func (s *store) deleteFromRemoteRepository(ctx context.Context, cid string) erro
 
 	return nil
 }
+
+// deleteReferrerManifest deletes a referrer's manifest by descriptor, and its blob on local stores.
+//
+// It deliberately does not go through the record delete helpers above. Those resolve a CID as a
+// reference, which for a referrer only works while referrers carry a CID tag, and they report
+// success when resolution fails - so reusing them would make referrer deletion a silent no-op the
+// moment tagging stops.
+func (s *store) deleteReferrerManifest(ctx context.Context, referrerCID string, manifestDesc ocispec.Descriptor) error {
+	switch repo := s.repo.(type) {
+	case *oci.Store:
+		if err := repo.Delete(ctx, manifestDesc); err != nil && !stdErrors.Is(err, errdef.ErrNotFound) {
+			return status.Errorf(codes.Internal, "failed to delete referrer manifest %s: %v",
+				manifestDesc.Digest.String(), err)
+		}
+
+		// The blob is addressed by the referrer CID, so it needs no descriptor. A failure here
+		// leaves an unreferenced blob for GC rather than a visible referrer, so it only warns.
+		if err := s.deleteBlobForLocalStore(ctx, referrerCID, repo); err != nil {
+			internalLogger.Warn("Failed to delete referrer blob", "cid", referrerCID, "error", err)
+		}
+
+		internalLogger.Debug("Referrer deleted", "cid", referrerCID, "digest", manifestDesc.Digest.String())
+
+		return nil
+
+	case *remote.Repository:
+		if err := repo.Manifests().Delete(ctx, manifestDesc); err != nil {
+			errStr := err.Error()
+
+			if strings.Contains(errStr, "405") || strings.Contains(errStr, "unsupported") {
+				internalLogger.Warn("Registry does not support manifest deletion via OCI API",
+					"cid", referrerCID, "error", err)
+
+				return status.Errorf(codes.Unimplemented,
+					"registry does not support OCI delete API; use the registry's web UI or native API to delete packages")
+			}
+
+			if stdErrors.Is(err, errdef.ErrNotFound) ||
+				strings.Contains(errStr, "404") || strings.Contains(errStr, "NOT_FOUND") {
+				internalLogger.Info("Referrer manifest already deleted",
+					"cid", referrerCID, "digest", manifestDesc.Digest.String())
+
+				return nil
+			}
+
+			return status.Errorf(codes.Internal, "failed to delete referrer manifest: %v", err)
+		}
+
+		internalLogger.Debug("Referrer deleted", "cid", referrerCID, "digest", manifestDesc.Digest.String())
+
+		return nil
+
+	default:
+		return status.Errorf(codes.FailedPrecondition, "unsupported repo type: %T", s.repo)
+	}
+}

--- a/server/store/oci/referrers.go
+++ b/server/store/oci/referrers.go
@@ -15,8 +15,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content/oci"
-	"oras.land/oras-go/v2/registry/remote"
 )
 
 var referrersLogger = logging.Logger("store/oci/referrers")
@@ -144,6 +142,23 @@ func (s *store) pushReferrer(ctx context.Context, recordCID string, referrer *co
 // WalkReferrers walks through referrers for a given record CID, calling walkFn for each referrer.
 // If referrerType is empty, all referrers are walked, otherwise only referrers of the specified type.
 func (s *store) WalkReferrers(ctx context.Context, recordCID string, referrerType string, walkFn func(*corev1.RecordReferrer) error) error {
+	if walkFn == nil {
+		return status.Error(codes.InvalidArgument, "walkFn is required") //nolint:wrapcheck
+	}
+
+	return s.walkReferrers(ctx, recordCID, referrerType,
+		func(referrer *corev1.RecordReferrer, _ ocispec.Descriptor) error {
+			return walkFn(referrer)
+		},
+	)
+}
+
+// walkReferrers is WalkReferrers, additionally handing walkFn the referrer's manifest descriptor.
+//
+// Deletion needs that descriptor: a referrer CID addresses the referrer's blob, not its manifest,
+// so the manifest is reachable only by its own digest or by a tag - and the tag is what we are
+// removing.
+func (s *store) walkReferrers(ctx context.Context, recordCID string, referrerType string, walkFn func(*corev1.RecordReferrer, ocispec.Descriptor) error) error {
 	referrersLogger.Debug("Walking referrers from OCI store", "recordCID", recordCID, "type", referrerType)
 
 	if recordCID == "" {
@@ -195,7 +210,7 @@ func (s *store) WalkReferrers(ctx context.Context, recordCID string, referrerTyp
 			}
 
 			// Call the walk function
-			if err := walkFn(referrer); err != nil {
+			if err := walkFn(referrer, referrerDesc); err != nil {
 				walkErr = err
 
 				return err // Stop walking on error
@@ -221,7 +236,7 @@ func (s *store) WalkReferrers(ctx context.Context, recordCID string, referrerTyp
 }
 
 // walkReferrersViaPredecessors walks referrers using the graph Predecessors API.
-func (s *store) walkReferrersViaPredecessors(ctx context.Context, subjectDesc ocispec.Descriptor, recordCID string, matcher ReferrerMatcher, walkFn func(*corev1.RecordReferrer) error) error {
+func (s *store) walkReferrersViaPredecessors(ctx context.Context, subjectDesc ocispec.Descriptor, recordCID string, matcher ReferrerMatcher, walkFn func(*corev1.RecordReferrer, ocispec.Descriptor) error) error {
 	predecessors, err := s.repo.Predecessors(ctx, subjectDesc)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to get predecessors for manifest %s: %v", subjectDesc.Digest.String(), err)
@@ -243,7 +258,7 @@ func (s *store) walkReferrersViaPredecessors(ctx context.Context, subjectDesc oc
 			continue
 		}
 
-		if err := walkFn(referrer); err != nil {
+		if err := walkFn(referrer, predDesc); err != nil {
 			return err
 		}
 
@@ -291,10 +306,18 @@ func (s *store) extractReferrerFromManifest(ctx context.Context, manifestDesc oc
 		referrer.Type = ociToAPIType(referrer.GetType())
 	}
 
+	// The CID addresses the referrer blob, so it can be recomputed when the annotation is
+	// absent. Referrers pushed before the annotation existed would otherwise carry no
+	// ReferrerRef, and an empty CID makes deletion and pull-by-CID skip them in silence.
 	referrerCID, ok := manifest.Annotations[ManifestKeyCid]
-	if ok {
-		referrer.ReferrerRef = &corev1.ReferrerRef{Cid: referrerCID}
+	if !ok {
+		referrerCID, err = corev1.ConvertDigestToCID(blobDesc.Digest)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to derive referrer CID for record %s: %v", recordCID, err)
+		}
 	}
+
+	referrer.ReferrerRef = &corev1.ReferrerRef{Cid: referrerCID}
 
 	return referrer, nil
 }
@@ -314,27 +337,76 @@ func (s *store) MediaTypeReferrerMatcher(expectedMediaType string) ReferrerMatch
 	}
 }
 
+// DeleteReferrer deletes the referrer identified by referrerCID, or every referrer of
+// referrerType when referrerCID is empty.
 func (s *store) DeleteReferrer(
 	ctx context.Context,
 	recordCID string,
 	referrerCID string,
 	referrerType string,
 ) ([]string, error) {
-	var err error
+	if referrerCID == "" {
+		return s.deleteReferrers(ctx, recordCID, referrerType, func(string) bool { return true })
+	}
 
-	cids := []string{}
+	return s.deleteReferrers(ctx, recordCID, referrerType, func(cid string) bool { return cid == referrerCID })
+}
 
-	err = s.WalkReferrers(
-		ctx,
-		recordCID,
-		referrerType,
-		func(referrer *corev1.RecordReferrer) error {
+// DeleteReferrers deletes the named referrers in a single pass over the record's referrers.
+//
+// Callers that already know which referrers to remove should prefer this to a loop of
+// DeleteReferrer. Every delete needs the referrer's manifest descriptor, which only a walk can
+// supply, so a loop re-walks the entire referrer set once per deletion.
+//
+// An empty referrerCIDs deletes nothing. Deleting every referrer of a type stays an explicit
+// request through DeleteReferrer with an empty CID, so a caller that computed an empty set cannot
+// clear the record by accident.
+func (s *store) DeleteReferrers(
+	ctx context.Context,
+	recordCID string,
+	referrerCIDs []string,
+	referrerType string,
+) ([]string, error) {
+	if len(referrerCIDs) == 0 {
+		return []string{}, nil
+	}
+
+	targets := make(map[string]struct{}, len(referrerCIDs))
+	for _, cid := range referrerCIDs {
+		targets[cid] = struct{}{}
+	}
+
+	return s.deleteReferrers(ctx, recordCID, referrerType, func(cid string) bool {
+		_, ok := targets[cid]
+
+		return ok
+	})
+}
+
+// deleteReferrers walks the record's referrers once and deletes the ones match selects.
+func (s *store) deleteReferrers(
+	ctx context.Context,
+	recordCID string,
+	referrerType string,
+	match func(referrerCID string) bool,
+) ([]string, error) {
+	type target struct {
+		cid  string
+		desc ocispec.Descriptor
+	}
+
+	// Collected during the walk and deleted after it, so deletion does not mutate the referrer
+	// set being iterated.
+	var targets []target
+
+	err := s.walkReferrers(ctx, recordCID, referrerType,
+		func(referrer *corev1.RecordReferrer, desc ocispec.Descriptor) error {
 			cid := referrer.GetReferrerRef().GetCid()
-			if referrerCID != "" && referrerCID != cid {
+			if cid == "" || !match(cid) {
 				return nil
 			}
 
-			cids = append(cids, cid)
+			targets = append(targets, target{cid: cid, desc: desc})
 
 			return nil
 		},
@@ -343,24 +415,15 @@ func (s *store) DeleteReferrer(
 		return nil, err //nolint:wrapcheck
 	}
 
-	result := []string{}
+	deleted := []string{}
 
-	for _, cid := range cids {
-		switch s.repo.(type) {
-		case *oci.Store:
-			err = s.deleteFromOCIStore(ctx, cid)
-		case *remote.Repository:
-			err = s.deleteFromRemoteRepository(ctx, cid)
-		default:
-			err = status.Errorf(codes.FailedPrecondition, "unsupported repo type: %T", s.repo)
+	for _, t := range targets {
+		if err := s.deleteReferrerManifest(ctx, t.cid, t.desc); err != nil {
+			return deleted, err
 		}
 
-		if err != nil {
-			return result, err //nolint:wrapcheck
-		}
-
-		result = append(result, cid)
+		deleted = append(deleted, t.cid)
 	}
 
-	return result, nil
+	return deleted, nil
 }

--- a/server/store/oci/referrers.go
+++ b/server/store/oci/referrers.go
@@ -128,12 +128,10 @@ func (s *store) pushReferrer(ctx context.Context, recordCID string, referrer *co
 		return nil, fmt.Errorf("failed to pack referrer manifest: %w", err)
 	}
 
-	// Create CID tag for content-addressable storage
-	err = s.tagWithRetry(ctx, manifestDesc.Digest.String(), referrerCID)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create CID tag: %v", err)
-	}
-
+	// Deliberately not tagged. A referrer is reached through its subject's Referrers API, so a
+	// tag adds nothing to discovery while making every referrer a top-level entry in the
+	// registry's tag list and index - which is what made that index outgrow the records it
+	// describes. The CID stays available as a manifest annotation.
 	referrersLogger.Debug("Referrer pushed successfully", "digest", manifestDesc.Digest.String(), "type", referrer.GetType())
 
 	return &corev1.ReferrerRef{Cid: referrerCID}, nil

--- a/server/store/oci/referrers_test.go
+++ b/server/store/oci/referrers_test.go
@@ -77,6 +77,29 @@ func sorted(cids ...string) []string {
 	return cids
 }
 
+// A referrer is reached through its subject's Referrers API, so it carries no tag of its own. A
+// tag would add nothing to discovery while listing every referrer alongside the records in the
+// registry's tag list and index.
+func TestPushReferrer_DoesNotTagTheReferrer(t *testing.T) {
+	s, recordCID := referrerStoreFixture(t)
+
+	cid := attachReferrer(t, s, recordCID, "untagged")
+
+	_, err := s.repo.Resolve(testCtx, cid)
+	require.Error(t, err, "referrer CID should not resolve as a tag")
+
+	_, err = s.repo.Resolve(testCtx, recordCID)
+	require.NoError(t, err, "the record itself stays tagged")
+
+	// Discovery and deletion go through the subject, so both still work untagged.
+	assert.Equal(t, []string{cid}, walkCIDs(t, s, recordCID))
+
+	deleted, err := s.DeleteReferrer(testCtx, recordCID, cid, corev1.ScanReportReferrerType)
+	require.NoError(t, err, "delete referrer")
+	assert.Equal(t, []string{cid}, deleted)
+	assert.Empty(t, walkCIDs(t, s, recordCID), "referrer should be gone")
+}
+
 func TestDeleteReferrer_RemovesTheReferrer(t *testing.T) {
 	s, recordCID := referrerStoreFixture(t)
 

--- a/server/store/oci/referrers_test.go
+++ b/server/store/oci/referrers_test.go
@@ -1,0 +1,191 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package oci
+
+import (
+	"slices"
+	"testing"
+
+	typesv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1alpha1"
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2"
+)
+
+// Deletion is the one referrer operation that cannot work from the CID alone: a referrer CID
+// addresses its blob, not its manifest. These tests assert the referrer is actually gone rather
+// than that the call returned no error, because every failure mode in this path reports success.
+
+// referrerStoreFixture returns a local store holding one record to attach referrers to.
+func referrerStoreFixture(t *testing.T) (*store, string) {
+	t.Helper()
+
+	s, ok := loadLocalStore(t).(*store)
+	require.True(t, ok, "local store should be *store")
+
+	ref, err := s.Push(testCtx, corev1.New(&typesv1alpha1.Record{
+		Name:          "referrer-test-agent",
+		SchemaVersion: "0.7.0",
+	}))
+	require.NoError(t, err, "push record")
+
+	return s, ref.GetCid()
+}
+
+// attachReferrer pushes a scan-report referrer whose payload is unique to payload, so that each
+// referrer gets a distinct CID.
+func attachReferrer(t *testing.T, s *store, recordCID, payload string) string {
+	t.Helper()
+
+	ref, err := s.PushReferrer(testCtx, recordCID, &corev1.RecordReferrer{
+		Type:        corev1.ScanReportReferrerType,
+		RecordRef:   &corev1.RecordRef{Cid: recordCID},
+		Annotations: map[string]string{"payload": payload},
+	})
+	require.NoError(t, err, "push referrer")
+	require.NotEmpty(t, ref.GetCid(), "pushed referrer should have a CID")
+
+	return ref.GetCid()
+}
+
+// walkCIDs returns the sorted CIDs of the record's scan-report referrers.
+func walkCIDs(t *testing.T, s *store, recordCID string) []string {
+	t.Helper()
+
+	cids := []string{}
+
+	err := s.WalkReferrers(testCtx, recordCID, corev1.ScanReportReferrerType,
+		func(ref *corev1.RecordReferrer) error {
+			cids = append(cids, ref.GetReferrerRef().GetCid())
+
+			return nil
+		},
+	)
+	require.NoError(t, err, "walk referrers")
+
+	slices.Sort(cids)
+
+	return cids
+}
+
+func sorted(cids ...string) []string {
+	slices.Sort(cids)
+
+	return cids
+}
+
+func TestDeleteReferrer_RemovesTheReferrer(t *testing.T) {
+	s, recordCID := referrerStoreFixture(t)
+
+	cid := attachReferrer(t, s, recordCID, "only")
+	require.Equal(t, []string{cid}, walkCIDs(t, s, recordCID), "referrer should be attached")
+
+	deleted, err := s.DeleteReferrer(testCtx, recordCID, cid, corev1.ScanReportReferrerType)
+	require.NoError(t, err, "delete referrer")
+	assert.Equal(t, []string{cid}, deleted)
+
+	assert.Empty(t, walkCIDs(t, s, recordCID), "referrer should be gone")
+}
+
+func TestDeleteReferrer_LeavesTheOthers(t *testing.T) {
+	s, recordCID := referrerStoreFixture(t)
+
+	first := attachReferrer(t, s, recordCID, "first")
+	second := attachReferrer(t, s, recordCID, "second")
+	third := attachReferrer(t, s, recordCID, "third")
+
+	deleted, err := s.DeleteReferrer(testCtx, recordCID, second, corev1.ScanReportReferrerType)
+	require.NoError(t, err, "delete referrer")
+	assert.Equal(t, []string{second}, deleted)
+
+	assert.Equal(t, sorted(first, third), walkCIDs(t, s, recordCID))
+}
+
+func TestDeleteReferrers_DeletesOnlyTheNamedOnes(t *testing.T) {
+	s, recordCID := referrerStoreFixture(t)
+
+	first := attachReferrer(t, s, recordCID, "first")
+	second := attachReferrer(t, s, recordCID, "second")
+	third := attachReferrer(t, s, recordCID, "third")
+
+	deleted, err := s.DeleteReferrers(testCtx, recordCID,
+		[]string{first, third}, corev1.ScanReportReferrerType)
+	require.NoError(t, err, "delete referrers")
+	assert.Equal(t, sorted(first, third), sorted(deleted...))
+
+	assert.Equal(t, []string{second}, walkCIDs(t, s, recordCID))
+}
+
+// An empty set must mean "delete nothing". Reading it as "delete everything of this type" would
+// let a caller that computed no candidates clear the record's referrers.
+func TestDeleteReferrers_EmptyDeletesNothing(t *testing.T) {
+	s, recordCID := referrerStoreFixture(t)
+
+	first := attachReferrer(t, s, recordCID, "first")
+	second := attachReferrer(t, s, recordCID, "second")
+
+	deleted, err := s.DeleteReferrers(testCtx, recordCID, nil, corev1.ScanReportReferrerType)
+	require.NoError(t, err, "delete referrers")
+	assert.Empty(t, deleted)
+
+	assert.Equal(t, sorted(first, second), walkCIDs(t, s, recordCID))
+}
+
+// Deleting with an empty CID stays the explicit way to clear a type.
+func TestDeleteReferrer_EmptyCIDDeletesEveryReferrerOfType(t *testing.T) {
+	s, recordCID := referrerStoreFixture(t)
+
+	attachReferrer(t, s, recordCID, "first")
+	attachReferrer(t, s, recordCID, "second")
+
+	deleted, err := s.DeleteReferrer(testCtx, recordCID, "", corev1.ScanReportReferrerType)
+	require.NoError(t, err, "delete referrers")
+	assert.Len(t, deleted, 2)
+
+	assert.Empty(t, walkCIDs(t, s, recordCID))
+}
+
+// Referrers pushed before the CID annotation existed carry no CID of their own. The CID addresses
+// the referrer blob, so it can be recomputed - without that, such a referrer has no identity and
+// deletion and pull-by-CID skip it in silence.
+func TestWalkReferrers_DerivesCIDWhenAnnotationIsMissing(t *testing.T) {
+	s, recordCID := referrerStoreFixture(t)
+
+	recordDesc, err := s.repo.Resolve(testCtx, recordCID)
+	require.NoError(t, err, "resolve record")
+
+	payload, err := (&corev1.RecordReferrer{
+		Type:      corev1.ScanReportReferrerType,
+		RecordRef: &corev1.RecordRef{Cid: recordCID},
+	}).Marshal()
+	require.NoError(t, err, "marshal referrer")
+
+	blobDesc, err := oras.PushBytes(testCtx, s.repo, DefaultReferrerArtifactMediaType, payload)
+	require.NoError(t, err, "push referrer blob")
+
+	// No CID annotation, reproducing a referrer written before that annotation was introduced.
+	_, err = oras.PackManifest(testCtx, s.repo, oras.PackManifestVersion1_1,
+		ocispec.MediaTypeImageManifest, oras.PackManifestOptions{
+			Subject: &recordDesc,
+			ManifestAnnotations: map[string]string{
+				corev1.ReferrerTypeAnnotationKey: corev1.ScanReportReferrerType,
+			},
+			Layers: []ocispec.Descriptor{blobDesc},
+		})
+	require.NoError(t, err, "pack referrer manifest")
+
+	wantCID, err := corev1.ConvertDigestToCID(blobDesc.Digest)
+	require.NoError(t, err, "derive CID")
+
+	assert.Equal(t, []string{wantCID}, walkCIDs(t, s, recordCID),
+		"walk should report the CID derived from the blob digest")
+
+	deleted, err := s.DeleteReferrer(testCtx, recordCID, wantCID, corev1.ScanReportReferrerType)
+	require.NoError(t, err, "delete referrer")
+	assert.Equal(t, []string{wantCID}, deleted, "an untagged, unannotated referrer must be deletable")
+
+	assert.Empty(t, walkCIDs(t, s, recordCID))
+}

--- a/server/types/store.go
+++ b/server/types/store.go
@@ -44,6 +44,11 @@ type ReferrerStoreAPI interface {
 	WalkReferrers(ctx context.Context, recordCID string, referrerType string, walkFn func(*corev1.RecordReferrer) error) error
 
 	DeleteReferrer(ctx context.Context, recordCID string, referrerCID string, referrerType string) ([]string, error)
+
+	// DeleteReferrers deletes the named referrers in a single pass over the record's referrers.
+	// Prefer it to a loop of DeleteReferrer, which repeats that pass once per deletion.
+	// An empty referrerCIDs deletes nothing.
+	DeleteReferrers(ctx context.Context, recordCID string, referrerCIDs []string, referrerType string) ([]string, error)
 }
 
 // FullStore is the complete store interface with all optional capabilities.


### PR DESCRIPTION
Closes #2102

Referrers are no longer tagged with their CID. Deletion now works from the manifest descriptor, which is the only thing those tags were needed for.

Also fixes two findings from the #2095 review: superseded scan reports are removed in one batched call instead of one full referrer walk per report, and the prune checks the referrer type itself, since the store's type filter passes every custom type.

Verified against a local Zot with `deleteUntagged` and `deleteReferrers` on: signing adds 0 tags and 2 untagged referrers, `pull --signature/--public-key/--scan-report` and `verify` all work, and an untagged referrer whose subject is alive survives a GC pass.

Made with [Cursor](https://cursor.com)