### PR TITLE
ci(release): sign release artifacts and backfill published releases

### DIFF
--- a/.github/workflows/backfill-release-signatures.yaml
+++ b/.github/workflows/backfill-release-signatures.yaml
@@ -1,0 +1,41 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+# Maintenance workflow for releases published before the release pipeline
+# started attaching provenance. New releases are covered by
+# reusable-release.yaml.
+name: Backfill Release Signatures
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        required: false
+        type: string
+        default: ""
+        description: "Comma-separated release tags to sign. Defaults to the five newest published releases."
+
+permissions:
+  contents: read
+
+jobs:
+  sign:
+    name: Sign published assets
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign and attach bundles
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAGS: ${{ inputs.tags }}
+        run: |
+          chmod +x .github/workflows/scripts/backfill-release-signatures.sh
+          .github/workflows/scripts/backfill-release-signatures.sh

--- a/.github/workflows/reusable-release.yaml
+++ b/.github/workflows/reusable-release.yaml
@@ -137,3 +137,43 @@ jobs:
           files: .bin/dirctl-${{ matrix.os }}-${{ matrix.arch }}
           append_body: true
           draft: true
+
+  provenance:
+    name: Provenance
+    needs:
+      - upload
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download CLI artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cli-artifacts
+          path: .bin
+
+      - name: Attest build provenance
+        id: attest
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: .bin/dirctl-*
+
+      # The attestation is queryable through GitHub's attestations API, but
+      # consumers and OpenSSF Scorecard look for a .intoto.jsonl release asset.
+      - name: Name the bundle for release
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: cp "$BUNDLE_PATH" "dirctl-${RELEASE_TAG}.intoto.jsonl"
+
+      - name: Upload provenance Release Asset
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          files: dirctl-${{ inputs.release_tag }}.intoto.jsonl
+          append_body: true
+          draft: true

--- a/.github/workflows/scripts/backfill-release-signatures.sh
+++ b/.github/workflows/scripts/backfill-release-signatures.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+# Signing is keyless, so the certificate is bound to whoever runs this. Run it
+# from CI to get the repository's identity rather than a maintainer's.
+if [ -n "${TAGS:-}" ]; then
+  IFS=',' read -ra tags <<<"$TAGS"
+else
+  # Scorecard's Signed-Releases check only inspects the five newest releases.
+  mapfile -t tags < <(gh release list --repo "$GITHUB_REPOSITORY" --limit 5 \
+    --exclude-drafts --json tagName --jq '.[].tagName')
+fi
+
+for tag in "${tags[@]}"; do
+  tag="${tag//[[:space:]]/}"
+  [ -n "$tag" ] || continue
+
+  echo "::group::$tag"
+  workdir="$(mktemp -d)"
+
+  if ! gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+    --dir "$workdir" --pattern 'dirctl-*'; then
+    echo "no dirctl assets on $tag, skipping"
+    rm -rf "$workdir"
+    echo "::endgroup::"
+    continue
+  fi
+
+  for asset in "$workdir"/dirctl-*; do
+    # A re-run downloads the bundles the previous run attached.
+    case "$asset" in
+    *.sigstore.json) continue ;;
+    esac
+
+    cosign sign-blob --yes --bundle "${asset}.sigstore.json" "$asset"
+  done
+
+  gh release upload "$tag" --repo "$GITHUB_REPOSITORY" --clobber \
+    "$workdir"/*.sigstore.json
+
+  rm -rf "$workdir"
+  echo "::endgroup::"
+done


### PR DESCRIPTION
The OpenSSF Scorecard Signed-Releases check scores 0 because we publish bare `dirctl` binaries with nothing attesting to their origin. This adds a provenance step so every future release ships a Sigstore-signed build attestation, plus a one-off workflow to retrofit signatures onto the releases the check currently inspects.

- The backfill workflow is temporary — it only fixes already-published releases and should be deleted once run.
- Backfilled releases get `cosign sign-blob` signatures rather than provenance, since a build attestation can't be produced retroactively.
- Backfilling is dispatch-triggered rather than run locally because keyless signing binds the certificate to whoever signs, so CI attributes the signatures to the repository instead of a maintainer.
- No detached signatures on new releases: provenance outranks a plain signature in the check's scoring.