### PR TITLE
test(e2e): cover the remote extractor in Kind

### DIFF
--- a/.github/workflows/reusable-test-e2e.yaml
+++ b/.github/workflows/reusable-test-e2e.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Verify Kind has no host extractor assets
         if: matrix.task == 'e2e:test:local:kind'
-        run: test ! -e "$HOME/.agntcy/oasf-sdk/extractor/manifest.json"
+        run: test ! -e "$HOME/.agntcy/oasf-sdk"
 
       - name: Run end-to-end tests
         env:

--- a/.github/workflows/reusable-test-e2e.yaml
+++ b/.github/workflows/reusable-test-e2e.yaml
@@ -29,6 +29,8 @@ jobs:
             label: "Client"
           - task: e2e:test:local:local
             label: "Local"
+          - task: e2e:test:local:kind
+            label: "Local Kind"
           - task: e2e:test:network:local
             label: "Network"
           - task: e2e:test:daemon:external
@@ -61,6 +63,10 @@ jobs:
           cache-dependency-path: "**/*.sum"
           cache: true
 
+      - name: Install Kind test dependencies
+        if: matrix.task == 'e2e:test:local:kind'
+        run: task e2e:deps:kind
+
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -81,10 +87,15 @@ jobs:
           chmod +x ./.bin/dirctl
 
       - name: Cache OASF extractor model
+        if: matrix.task != 'e2e:test:local:kind'
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.agntcy/oasf-sdk
           key: oasf-extractor-${{ runner.os }}-v1
+
+      - name: Verify Kind has no host extractor assets
+        if: matrix.task == 'e2e:test:local:kind'
+        run: test ! -e "$HOME/.agntcy/oasf-sdk/extractor/manifest.json"
 
       - name: Run end-to-end tests
         env:

--- a/tests/Taskfile.yml
+++ b/tests/Taskfile.yml
@@ -98,6 +98,14 @@ vars:
   GOCOVERDIR: "{{.COVERAGE_DIR}}/e2e/.gocover"
 
 tasks:
+  e2e:deps:kind:
+    desc: Install Kind test tools and build locked Helm dependencies
+    deps:
+      - deps:kind
+      - deps:kubectl
+    cmds:
+      - task: helm:dep:build
+
   e2e:testenv:*:*:up:
     desc: Create testenv for a test case
     silent: true

--- a/tests/e2e/local/19_remote_extractor_test.go
+++ b/tests/e2e/local/19_remote_extractor_test.go
@@ -1,0 +1,123 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	catalogv1 "github.com/agntcy/dir/api/catalog/v1"
+	"github.com/agntcy/dir/tests/e2e/shared/testdata"
+	"github.com/agntcy/dir/tests/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ = ginkgo.Describe("Remote extractor HTTP API", ginkgo.Ordered, ginkgo.Label("remote-extractor"), func() {
+	const (
+		query      = "I need a MCP server to connect to an AGNTCY directory and integrate APIs."
+		recordName = "remote_extractor_e2e_directory"
+	)
+
+	var recordCID string
+
+	ginkgo.BeforeAll(func() {
+		if !testEnv.Config.RemoteExtractorEnabled {
+			ginkgo.Skip("remote extractor not enabled for this environment")
+		}
+
+		gomega.Expect(testEnv.Config.GatewayAddress).NotTo(gomega.BeEmpty(),
+			"remote_extractor_enabled requires gateway_address")
+		utils.ResetCLIState()
+
+		tempDir, err := os.MkdirTemp("", "remote-extractor-e2e-*")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+		// Publish a local fixture, without importing from a source registry or
+		// provisioning extractor assets on the test runner.
+		var record map[string]any
+		gomega.Expect(json.Unmarshal(testdata.DirectoryRecordJSON, &record)).To(gomega.Succeed())
+		record["name"] = recordName
+		data, err := json.Marshal(record)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		recordPath := filepath.Join(tempDir, "record.json")
+		gomega.Expect(os.WriteFile(recordPath, data, 0o600)).To(gomega.Succeed())
+		recordCID = strings.TrimSpace(testEnv.CLI.Push(recordPath).WithArgs("--output", "raw").ShouldSucceed())
+		gomega.Expect(recordCID).NotTo(gomega.BeEmpty())
+		ginkgo.DeferCleanup(func() {
+			testEnv.CLI.Delete(recordCID).ShouldSucceed()
+		})
+	})
+
+	ginkgo.It("extracts relevant taxonomy through the deployed gateway", func(ctx ginkgo.SpecContext) {
+		var response catalogv1.ExtractTaxonomyResponse
+		postRemoteExtractor(ctx, "/v1/extract", &catalogv1.ExtractTaxonomyRequest{Text: query}, &response)
+
+		// Match a relevant taxonomy family rather than model-specific scores or
+		// ordering, which can change between extractor model versions.
+		domainNames := make([]string, 0, len(response.GetDomains()))
+		for _, domain := range response.GetDomains() {
+			gomega.Expect(domain.GetId()).NotTo(gomega.BeZero())
+			gomega.Expect(domain.GetScore()).To(gomega.BeNumerically(">", 0))
+			domainNames = append(domainNames, domain.GetName())
+		}
+
+		gomega.Expect(domainNames).To(gomega.ContainElement(gomega.HavePrefix("technology/software_engineering")))
+	}, ginkgo.SpecTimeout(2*time.Minute))
+
+	ginkgo.It("finds the published directory record by natural language", func(ctx ginkgo.SpecContext) {
+		gomega.Eventually(func() []string {
+			var response catalogv1.SearchAgentsResponse
+			postRemoteExtractor(ctx, "/v1/search", &catalogv1.SearchAgentsRequest{Query: query, PageSize: 100}, &response)
+
+			var matches []string
+
+			for _, entry := range response.GetResults() {
+				if entry.GetDisplayName() == recordName {
+					_, cid, found := strings.Cut(entry.GetIdentifier(), ":cid:")
+					gomega.Expect(found).To(gomega.BeTrue())
+
+					matches = append(matches, cid)
+				}
+			}
+
+			return matches
+		}).WithContext(ctx).WithTimeout(time.Minute).WithPolling(time.Second).Should(gomega.ContainElement(recordCID))
+	}, ginkgo.SpecTimeout(2*time.Minute))
+})
+
+// Requests have a deadline even if the gateway or its remote extractor hangs.
+// An enabled but broken deployment fails rather than skipping these specs.
+func postRemoteExtractor(ctx context.Context, path string, request, response proto.Message) {
+	ginkgo.GinkgoHelper()
+
+	data, err := protojson.Marshal(request)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		strings.TrimRight(testEnv.Config.GatewayAddress, "/")+path, bytes.NewReader(data))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "%s: %s", path, body)
+	gomega.Expect(protojson.Unmarshal(body, response)).To(gomega.Succeed())
+}

--- a/tests/e2e/local/19_remote_extractor_test.go
+++ b/tests/e2e/local/19_remote_extractor_test.go
@@ -63,7 +63,12 @@ var _ = ginkgo.Describe("Remote extractor HTTP API", ginkgo.Ordered, ginkgo.Labe
 
 	ginkgo.It("extracts relevant taxonomy through the deployed gateway", func(ctx ginkgo.SpecContext) {
 		var response catalogv1.ExtractTaxonomyResponse
-		postRemoteExtractor(ctx, "/v1/extract", &catalogv1.ExtractTaxonomyRequest{Text: query}, &response)
+
+		// Pod readiness can precede the gateway reconnecting to the extractor.
+		// Keep retries bounded so an enabled but broken deployment still fails.
+		gomega.Eventually(func(g gomega.Gomega) {
+			postRemoteExtractor(ctx, g, "/v1/extract", &catalogv1.ExtractTaxonomyRequest{Text: query}, &response)
+		}).WithContext(ctx).WithTimeout(90 * time.Second).WithPolling(2 * time.Second).Should(gomega.Succeed())
 
 		// Match a relevant taxonomy family rather than model-specific scores or
 		// ordering, which can change between extractor model versions.
@@ -78,46 +83,46 @@ var _ = ginkgo.Describe("Remote extractor HTTP API", ginkgo.Ordered, ginkgo.Labe
 	}, ginkgo.SpecTimeout(2*time.Minute))
 
 	ginkgo.It("finds the published directory record by natural language", func(ctx ginkgo.SpecContext) {
-		gomega.Eventually(func() []string {
+		gomega.Eventually(func(g gomega.Gomega) {
 			var response catalogv1.SearchAgentsResponse
-			postRemoteExtractor(ctx, "/v1/search", &catalogv1.SearchAgentsRequest{Query: query, PageSize: 100}, &response)
+			postRemoteExtractor(ctx, g, "/v1/search", &catalogv1.SearchAgentsRequest{Query: query, PageSize: 100}, &response)
 
 			var matches []string
 
 			for _, entry := range response.GetResults() {
 				if entry.GetDisplayName() == recordName {
 					_, cid, found := strings.Cut(entry.GetIdentifier(), ":cid:")
-					gomega.Expect(found).To(gomega.BeTrue())
+					g.Expect(found).To(gomega.BeTrue())
 
 					matches = append(matches, cid)
 				}
 			}
 
-			return matches
-		}).WithContext(ctx).WithTimeout(time.Minute).WithPolling(time.Second).Should(gomega.ContainElement(recordCID))
+			g.Expect(matches).To(gomega.ContainElement(recordCID))
+		}).WithContext(ctx).WithTimeout(time.Minute).WithPolling(time.Second).Should(gomega.Succeed())
 	}, ginkgo.SpecTimeout(2*time.Minute))
 })
 
 // Requests have a deadline even if the gateway or its remote extractor hangs.
 // An enabled but broken deployment fails rather than skipping these specs.
-func postRemoteExtractor(ctx context.Context, path string, request, response proto.Message) {
+func postRemoteExtractor(ctx context.Context, g gomega.Gomega, path string, request, response proto.Message) {
 	ginkgo.GinkgoHelper()
 
 	data, err := protojson.Marshal(request)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		strings.TrimRight(testEnv.Config.GatewayAddress, "/")+path, bytes.NewReader(data))
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "%s: %s", path, body)
-	gomega.Expect(protojson.Unmarshal(body, response)).To(gomega.Succeed())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK), "%s: %s", path, body)
+	g.Expect(protojson.Unmarshal(body, response)).To(gomega.Succeed())
 }

--- a/tests/e2e/local/config/config.go
+++ b/tests/e2e/local/config/config.go
@@ -15,6 +15,10 @@ type Config struct {
 	// this environment, in which case AI Finder HTTP tests are skipped.
 	GatewayAddress string `json:"gateway_address,omitempty" mapstructure:"gateway_address"`
 
+	// RemoteExtractorEnabled requires the gateway to use a deployed OASF extractor.
+	// Disabled environments skip the remote extractor HTTP tests.
+	RemoteExtractorEnabled bool `json:"remote_extractor_enabled,omitempty" mapstructure:"remote_extractor_enabled"`
+
 	// CliPath is the path to the CLI binary.
 	CliPath string `json:"cli_path,omitempty" mapstructure:"cli_path"`
 

--- a/tests/e2e/local/testenv/kind/test-config.yaml
+++ b/tests/e2e/local/testenv/kind/test-config.yaml
@@ -1,6 +1,8 @@
 local:
   server_address: "localhost:18888"
   metrics_address: "http://localhost:18889/metrics"
+  gateway_address: "http://localhost:18892"
+  remote_extractor_enabled: true
   # cli_path: "/path/to/cli"
   cli_extra_args:
   - "--server-addr=localhost:18888"

--- a/tests/e2e/local/testenv/kind/test-config.yaml
+++ b/tests/e2e/local/testenv/kind/test-config.yaml
@@ -7,4 +7,4 @@ local:
   cli_extra_args:
   - "--server-addr=localhost:18888"
   - "--auth-mode=insecure"
-  name_verification_host: "dns-validation-http"
+  name_verification_host: "dns-validation-http.dir.svc.cluster.local"


### PR DESCRIPTION
Adds a Kind job to the e2e matrix and exercises the deployed HTTP gateway's `/v1/extract` and `/v1/search` endpoints without restoring or provisioning extractor assets on the runner. The tests publish a local fixture, check relevant extracted taxonomy, and require natural-language search to return that fixture's exact CID.

The job installs the pinned Kind/Kubectl tools and locked Helm dependencies. Extraction has a bounded startup wait; a persistently wrong remote address or unregistered extractor service fails the test. The Kind naming fixture uses its fully qualified Service hostname so the existing naming tests can run in the newly enabled job.

Closes #2091.

Validation:

- Full local suite against Kind, with a fresh non-root runner and no host SDK assets: 220 passed, 0 failed, 4 existing skips.
- Wrong remote address: extraction test fails with HTTP 503 after its bounded retry window.
- Empty `OASF_SDK_EXTRACTOR_OASF_URL`: pod passes readiness, but the test fails; apiserver logs confirm `unknown service agntcy.oasfsdk.extractor.v1.ExtractorService`. Restoring configuration returns both new tests to green.
- Go test compilation, pinned golangci-lint 2.13.2, and `git diff --check` pass.

Local deployment validation reused server images from #2117's successful CI build (its changes are UI-only). This PR's CI builds its own revision.

Implemented with Codex assistance and independent model review.
