### PR TITLE
docs(proposal): record quality gate — policy engine for record admission and retention

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,27 @@
+# Proposals
+
+Design documents for changes too large to explain in a pull request
+description. A proposal captures the problem, the constraints discovered while
+investigating the code, the options considered, and the open decisions — so that
+the reasoning survives past the discussion that produced it.
+
+These are **not** user documentation. Published docs live in `docs/content` and
+are built with mkdocs; nothing here is part of the docs site.
+
+A proposal is a folder, `proposals/<topic>/`, containing at least a `README.md`
+that states its status in the first lines. Status is one of:
+
+- **draft** — under discussion, nothing implemented, subject to change
+- **accepted** — agreed direction; implementation may be in progress or partial
+- **implemented** — shipped; kept for the reasoning, may drift from the code
+- **rejected** / **superseded** — kept deliberately, with a note explaining why
+  and a pointer to what replaced it
+
+Proposals are merged rather than left on a branch: the decisions and the
+discarded alternatives are the valuable part, and they need somewhere durable to
+live. A proposal being merged means "this is a real record of a discussion", not
+"this is approved" — that is what the status line is for.
+
+| Proposal | Status |
+|---|---|
+| [`quality-gate`](quality-gate/) — policy engine for admission and retention of records | draft |

--- a/proposals/quality-gate/README.md
+++ b/proposals/quality-gate/README.md
@@ -1,0 +1,281 @@
+# Record quality gate
+
+Status: **draft** — under discussion, nothing implemented, subject to change.
+
+Recommendations below are starting positions for the discussion, not decisions.
+The twelve numbered questions in `open-questions.md` are the parts that most
+need other people's judgement.
+
+A configurable policy engine that decides which records a Directory node is
+willing to keep, and which ones it should get rid of. Applies to records
+arriving by push, import, sync and autosync.
+
+Contents:
+
+- `README.md` — this file: placement in the process, phase model, engine choice
+- `policy-model.md` — the policy schema, predicate vocabulary, actions, worked examples
+- `tombstones.md` — the CID denylist that makes destructive actions safe
+- `open-questions.md` — decisions we need to make before writing code
+
+---
+
+## 1. The two motivating examples, and why they don't belong in the same place
+
+The two examples we started from look similar but have opposite requirements.
+
+**"Only keep records whose scan says they're trusted."** Trust is not a property
+of the record bytes. It is a *derived fact* that a reconciler task computes later
+by fetching keys, checking signatures and running scanners. At the instant a
+record is pushed, the node knows nothing about its trust. So this rule cannot be
+a synchronous admission check unless we are willing to do live signature
+verification and a full security scan inline on the push path — which would turn
+a sub-second push into a multi-second-to-multi-minute operation and make push
+availability depend on external scanners.
+
+**"Keep only 2 versions of the same record."** This is not a property of a single
+record at all. It is a property of a *set* of records grouped by name. You cannot
+evaluate it by looking at the record being admitted; you evaluate it by sweeping
+the store.
+
+Both therefore land after the fact. But we still want a synchronous gate, because
+some rules genuinely are decidable at push time (naming conventions, required
+annotations, allowed skills/domains, size, schema version, source peer) and for
+those, rejecting the push with a clear error is far better UX than silently
+deleting the record 6 hours later.
+
+**Conclusion: the quality gate is two gates, not one.**
+
+---
+
+## 2. What already exists (and why none of it is this)
+
+| Thing | Where | What it does | Why it isn't a quality gate |
+|---|---|---|---|
+| OASF validation | `api/core/v1/record.go:179` (`ValidateWith`) | Schema validity + 4 MB size cap | Well-formedness only, not policy; not configurable |
+| Autosync peer allow-list | `server/routing/autosync/autosync.go:171` (`MaybeEnqueue`) | Ignores announcements from untrusted peers | Source-based only, no record predicates. Useful precedent though — it is admission control by another name |
+| dirctl chart `policies:` | `install/charts/dirctl/templates/_policies.tpl` | CronJobs running `dirctl search` → `sync`/`prune`/`publish`/`unpublish` | Client-side, outside the node, best-effort, no API, no audit trail. But its **match/action shape is the right model** — see §5 |
+| Casbin authz | `server/authz/` | Which SPIFFE trust domain may call which gRPC method | Access control over *callers*, not content |
+
+The chart policies are the closest existing thing and are essentially a
+prototype of Gate B implemented outside the server. Part of this work is moving
+that capability inside the node so it gets an API, a durable configuration, and
+an audit trail.
+
+---
+
+## 3. When is each fact knowable?
+
+This table is the single most important input to the design. Everything else
+follows from it.
+
+| Fact | Available at record push? | Populated by | Default interval |
+|---|---|---|---|
+| `name`, `version`, `schema_version`, `description`, `authors` | yes | `ingest.ImportRecord` → `db.AddRecord` | — |
+| skills, domains, modules, locators, annotations | yes | same | — |
+| `oasf_created_at`, record size, CID | yes | same | — |
+| source (peer ID / trust domain / RPC) | yes, from context | — | — |
+| `signed` | **no** — signature arrives as a *separate referrer push* after the record | `ingest.ImportReferrer` | — |
+| `trusted` (signature verified) | no | signature reconciler task | 1m |
+| `verified` (name ownership) | no | name reconciler task | 1h |
+| `safe`, `max_severity` (scan) | no¹ | scan reconciler task | 6h |
+| version count for a name | no (set property) | — | — |
+
+¹ Exception: a `ScanReport` **referrer** received over sync is written straight
+into `scan_reports` (`server/ingest/ingest.go:134-155`), so scan facts can arrive
+with a synced record. That's a peer's verdict, not ours — the policy model needs
+to be able to say whether a foreign verdict counts.
+
+Anything in the "no" rows is a Gate B rule. Full stop.
+
+---
+
+## 4. Where the gates go
+
+### Gate A — admission (synchronous, deny the write)
+
+**Hook: decorate the `ingest.Ingestor` interface** (`server/ingest/ingest.go:33`).
+
+This is the right seam and it already exists and is already documented as *"a
+single, authoritative code path for persisting records and referrers"*. It is an
+interface with two methods, constructed once in `server/server.go:299`. Wrapping
+it means:
+
+```
+policyIngestor{inner: ingest.New(store, db), engine: policyEngine}
+```
+
+No call sites change. `ImportRecord` evaluates Gate A and returns a gRPC error
+instead of delegating when a policy denies.
+
+What that covers:
+
+| Ingest path | Covered by Gate A? | Notes |
+|---|---|---|
+| gRPC `StoreService.Push` | yes | via `storeCtrl.pushRecordToStore` → `ingestor.ImportRecord` (`server/controller/store.go:349`) |
+| `dirctl import --type=mcp-registry` etc. | yes | import runs client-side and pushes over gRPC (`cli/cmd/import/import.go:75`) |
+| DHT autosync | yes | `server/routing/autosync/autosync.go:282` |
+| `dirctl sync` / regsync | **no** | the regsync task shells out to the external `regsync` CLI which copies OCI blobs directly (`reconciler/tasks/regsync/worker.go:130`). Never enters Go-level ingest |
+| `skill.Publish` | no | calls `store.Push` + `db.AddRecord` directly (`skill/publisher.go:46`) — arguably a bug we should fix by routing it through the ingestor |
+
+The two gaps matter. Options in `open-questions.md` (Q3); the pragmatic answer is
+that Gate B catches them, plus a pre-filter on the CID set when a sync job is
+created.
+
+### Gate B — enforcement (asynchronous, delete/unpublish/quarantine)
+
+**Hook: a new reconciler task**, `reconciler/tasks/policy/`.
+
+The task framework is a 4-method interface (`reconciler/tasks/task.go:13`) and
+registration is one `addTask` call in `reconciler/service/service.go:135`. This
+gives us intervals, enable/disable and env-var config for free, and it runs in
+the same process as the tasks that produce the facts we depend on.
+
+Gate B evaluates against the search database, which is exactly where `trusted`,
+`safe`, `max_severity` and `verified` already live and already have working
+query builders (`server/database/gorm/record.go:583-651`).
+
+Actions: `unpublish`, `delete`, `quarantine` (see §6), `report`.
+
+```
+                    Gate A  (synchronous, in-memory, record metadata only)
+                       │
+push ─────────────►    │
+import ───────────►  ingestor ──► OCI store ──► search DB
+autosync ─────────►    │                            │
+                       │                            │
+sync/regsync ──────────┴──► OCI store ──► indexer ──┤
+   (bypasses Gate A)                                 │
+                                                     ▼
+                            signature / name / scan reconciler tasks
+                                     write derived facts
+                                                     │
+                                                     ▼
+                    Gate B  (policy reconciler task, DB-backed predicates)
+                       └──► unpublish / delete / quarantine / report
+```
+
+---
+
+## 5. Engine choice: don't invent a language, reuse `RecordQuery`
+
+We considered OPA/Rego, CEL and plain regex. Recommendation: **start with
+neither** — use the filter vocabulary Directory already has.
+
+`dirctl search` already exposes a rich, tested, versioned predicate set:
+`name` (glob), `version`, `skill`, `domain`, `module`, `module-id`, `locator`,
+`author`, `schema-version`, `annotation` (`key:value`, glob), `created-at`
+(range), plus `trusted`, `verified`, `safe`, `scan-severity`, `scan-status`,
+`scan-failure-reason` — each with an `exclude-` counterpart. On the wire these
+are `searchv1.RecordQuery` messages, and the DB-side translation already exists.
+
+So a Gate B policy is literally:
+
+```yaml
+match:            # a []RecordQuery — same thing dirctl search sends
+  trusted: false
+  scan-severity: MEDIUM
+action: delete
+```
+
+Why this beats a general-purpose engine as a starting point:
+
+- **Zero new language.** No Rego, no CEL, no regex-injection surface. The policy
+  vocabulary is the query vocabulary; every filter the CLI grows is a policy
+  predicate for free.
+- **Gate B is already implementable as SQL.** Predicates run in the database as
+  one query. A Rego engine would require loading candidate records into memory
+  and evaluating them one by one.
+- **Instant tooling parity.** Authors can prototype a policy with
+  `dirctl search <same flags>` and see exactly what it will act on before
+  enabling it. That is a genuinely large usability win and it needs no new code.
+- **The chart policies collapse into a client of this model.** Same `match`,
+  same actions. `install/charts/dirctl/values.yaml` becomes a thin wrapper over
+  the server-side API instead of a parallel implementation.
+
+The limitation is real and worth stating: `RecordQuery` is a flat conjunction of
+predicates. No `OR`, no arithmetic, no cross-field comparison, no "if the record
+has skill X then it must also have annotation Y". If we hit that wall, the
+escape hatch is a `cel:` field on a policy evaluated after the query narrows the
+candidate set — CEL rather than Rego, because it is already an indirect
+dependency, it is expression-shaped rather than rule-shaped (we need one boolean
+per record, not a rule graph), and it doesn't drag in a bundle/data-document
+model we have no use for.
+
+Gate A needs an in-memory evaluator over the record proto for the subset of
+predicates that are push-time knowable. Same `RecordQuery` types, different
+backend. Attempting a predicate that needs a derived fact must be a
+**configuration-load error**, not a silent pass — see `open-questions.md` Q1.
+
+---
+
+## 6. Two risks that will bite us
+
+### Delete/re-fetch thrash
+
+If Gate B deletes a record that is still announced in the DHT, the next
+announcement from a peer causes autosync to fetch it again, the reconciler
+re-scans it, and Gate B deletes it again. With `REPUBLISH_INTERVAL=1m` this is a
+tight loop that burns scanner budget and network.
+
+Mitigations, needed from day one:
+
+1. `delete` must **unpublish first**. Note `StoreService.Delete` does *not*
+   currently withdraw routing announcements (`server/controller/store.go:175-219`)
+   — unpublish is a separate RPC. The policy action has to do both.
+2. A **CID tombstone list** recording what policy removed, consulted before any
+   re-fetch so a re-offered record is suppressed rather than pulled, scanned and
+   deleted again. Design in `tombstones.md`. This is the piece the client-side
+   chart `prune` policy fundamentally cannot have, and the main reason to move
+   this into the server.
+
+The tombstone list is also the only protection available for the regsync ingest
+path, whose tag filter is already a CID list.
+
+### Quarantine vs delete
+
+Deleting is destructive and, for the "not trusted yet" case, often wrong: a
+record can be untrusted simply because the signature task hasn't run yet, or
+because a public key hasn't propagated. A policy that deletes on
+`trusted: false` will eat legitimate records in the window between record push
+and signature verification.
+
+So the model needs:
+
+- **Grace/age condition** on Gate B policies: don't act on a record younger than
+  N, or one whose relevant fact is still absent as opposed to negative. The
+  distinction between *"scan says unsafe"* and *"not scanned yet"* must be
+  expressible. `scan-status` already distinguishes these (`completed`/`partial`
+  are verdicts; absence is not), so the vocabulary supports it — but the default
+  must be safe.
+- **`quarantine` as the default destructive-ish action**: keep the bytes, drop it
+  out of the routing index and mark it excluded from search results, so it is
+  reversible. Needs a new column/table; cheaper than being wrong.
+
+---
+
+## 7. Suggested rollout
+
+1. **Gate B, report-only, config-file policies.** New reconciler task, `match` +
+   `action: report`, structured log lines and a Prometheus counter per policy.
+   Delivers immediate value (tells us what our nodes are actually holding) with
+   zero blast radius. Validates the vocabulary against real data.
+2. **Gate B enforcing**, actions `unpublish` → `quarantine` → `delete`, with
+   tombstones and grace conditions. Retention (`keep: 2`) lands here as its own
+   policy kind.
+3. **Gate A**, in-memory subset, `enforcement: audit` first, then `enforce`.
+   Ingestor decorator + denial errors surfaced through `dirctl push`.
+4. **`PolicyService` gRPC + DB-backed policies.** Follow the `SyncService`
+   pattern exactly: CRUD writes rows, the reconciler task executes them
+   (`server/controller/sync.go:37` + `reconciler/tasks/regsync/`). This is also
+   what solves config hot-reload — there is no config watching anywhere in the
+   repo today, so an API-managed policy store is the only way to change policy
+   without a restart.
+5. **Repoint the dirctl chart policies** at the server-side API so there is one
+   implementation.
+
+## 8. Correctness cleanups this depends on
+
+- `skill.Publish` should go through `ingest.Ingestor` rather than writing to the
+  store and DB directly, otherwise it is permanently outside Gate A.
+- `StoreService.Delete` leaving routing announcements behind is a pre-existing
+  bug that the `delete` action would inherit.

--- a/proposals/quality-gate/open-questions.md
+++ b/proposals/quality-gate/open-questions.md
@@ -1,0 +1,150 @@
+# Open questions
+
+Decisions to make before writing code. Each has a recommendation, but they are
+all genuinely arguable.
+
+### Q1 — What happens when an `admission` policy references a fact that doesn't exist yet?
+
+E.g. `kind: admission` with `match: {trusted: false}`. Options: fail to load;
+load but log a warning and never match; auto-promote it to `kind: enforcement`.
+
+*Recommendation: fail to load, naming the offending key.* Auto-promotion changes
+enforcement timing behind the operator's back, and warn-and-ignore produces a
+policy that looks active and isn't — the worst outcome for a security control.
+
+### Q2 — `match`-only, or explicit `allow`/`deny` blocks?
+
+`match` describes what to act on, so allow-listing requires `exclude-` inversion
+(`policy-model.md` example 3), which reads backwards and is easy to get wrong in
+exactly the direction that fails open.
+
+*Recommendation: keep `match` as the single primitive for `enforcement`
+(it is a "find and act" sweep, which is what `match` means), but give
+`admission` an `allow:` / `deny:` pair.* Admission is inherently a two-sided
+decision and pretending otherwise costs clarity where mistakes are most
+expensive.
+
+### Q3 — How do we cover the regsync ingest path?
+
+`dirctl sync` copies OCI blobs via the external `regsync` CLI
+(`reconciler/tasks/regsync/worker.go:130`) and never touches Go-level ingest, so
+Gate A cannot see it. Options:
+
+- (a) Accept it. Records land, Gate B cleans up. Simple, but a node can be forced
+  to briefly store anything a sync source offers.
+- (b) Pre-filter the CID set when the sync job is created. The regsync config's
+  tag filter is built from CIDs (`regsync/regsync_config.go:150-180`), so we can
+  drop CIDs — but we only know a CID at that point, not the record, so only
+  tombstone/denylist checks are possible, not content predicates.
+- (c) Post-copy gate in the indexer task, which already pulls and validates each
+  newly discovered tag (`reconciler/tasks/indexer/task.go:224-237`). Runs before
+  the record is searchable, so it is "admission" from a discovery standpoint even
+  though the bytes already landed.
+- (d) Replace the external regsync CLI with in-process pulls. Correct, large,
+  out of scope.
+
+*Recommendation: (b) + (c).* Tombstone filtering at job creation stops the
+re-fetch loop cheaply (see `tombstones.md` — the regsync tag filter is already a
+CID list, so this is the one filter that path can apply), and the indexer hook
+means synced content is policy-checked before it becomes discoverable. Revisit
+(d) separately.
+
+### Q4 — Do we trust a peer's scan verdict?
+
+A synced `ScanReport` referrer is written straight into `scan_reports`
+(`server/ingest/ingest.go:134-155`), so `safe`/`scan-severity` can be populated
+by a *remote* node's scanners. Letting that trigger a local `delete` means a peer
+can influence what we keep.
+
+*Recommendation: persist verdict provenance (local vs peer, and which peer) and
+default destructive actions to local verdicts only,* with an opt-in to honour
+verdicts from allow-listed peers. Note the scan report proto deliberately omits
+failure fields because they are node-local, so there is precedent for treating
+foreign scan data as second-class.
+
+### Q5 — Is `quarantine` worth a new state, or do we just delete?
+
+Quarantine needs a column plus honouring it in every search query path, and a
+way out. But `trusted: false` is exactly the case where being wrong is likely
+(key not yet propagated, task not yet run).
+
+*Recommendation: yes, and make it the default for trust-derived policies.*
+Cheaper than restoring deleted records from peers, and it makes report-only →
+enforce a two-step ramp rather than a cliff.
+
+### Q6 — Node-local policy or network-wide?
+
+If a node deletes records its peers still announce, its view diverges from the
+network. Is a policy a statement about *this node's storage* or about *what this
+node considers valid*?
+
+*Recommendation: node-local storage policy, explicitly.* Anything else requires
+consensus we don't have. But it means documenting that a strict policy shrinks
+what the node can serve to peers, and thinking about whether `unpublish` alone
+(keep locally, stop advertising) is the better default action for most rules.
+
+### Q7 — Does Gate A apply to referrers too?
+
+`ImportReferrer` is the other half of the `Ingestor` interface. Signature and
+scan-report referrers carry security-relevant data, and a scan referrer write is
+the one thing that can populate a derived fact from outside.
+
+*Recommendation: yes, at least a minimal referrer gate,* mostly to enforce Q4's
+provenance rule. Otherwise the answer to Q4 is unenforceable.
+
+### Q8 — What happens to `push --sign` under a `signed: true`-style rule?
+
+`dirctl push --sign` pushes the record first, then the signature as a referrer.
+Any admission rule requiring a signature would reject the record before its
+signature exists. Options: a two-phase/staged push, a grace window, or simply
+declaring that signature requirements are Gate B only.
+
+*Recommendation: Gate B only, and document it,* unless we want to change the
+push protocol. This is the clearest single illustration of why the two-gate
+split is forced on us rather than chosen.
+
+### Q9 — Retention counting: versions or records?
+
+No unique constraint on `(name, version)`, so `keep: 2` is ambiguous.
+
+*Recommendation: 2 distinct `version` values, newest CID kept within each,* which
+matches how a person reads "keep 2 versions". Needs an explicit deterministic
+tiebreak so replicas converge.
+
+### Q10 — Where does the engine live so both gates share it?
+
+Gate A runs in the server process, Gate B in the reconciler — and they can be
+deployed as separate processes (`reconciler/config/config.go` with its own
+`RECONCILER_*` prefix, standalone deployment in the chart). Two evaluators means
+two behaviours.
+
+*Recommendation: a shared `policy` package holding the schema, the loader/
+validator, and two evaluator backends (in-memory proto for A, query builder for
+B) over one predicate type.* Which module it lives in needs checking against the
+`server` / `reconciler` / `api` go.mod boundaries — probably `api` or a new
+top-level module, since `reconciler` should not depend on `server`.
+
+### Q11 — Should a tombstone block an explicit push, or only a pull?
+
+Thrash comes only from pull paths (autosync, sync), where a peer keeps offering
+the record. An explicit gRPC push is a deliberate act by an operator.
+
+*Recommendation: suppress pull ingestion silently, but on explicit push return an
+error naming the policy, with an override.* Silently discarding a push is the
+behaviour most likely to generate a "Directory lost my record" bug report. The
+retention case makes it concrete: blocking a peer's re-announcement of a
+superseded version is right; blocking the owner deliberately re-pushing that
+exact content is not. Full reasoning in `tombstones.md`.
+
+### Q12 — Which verdicts are allowed to create a tombstone?
+
+`tombstones.md` argues that only stable, content-intrinsic verdicts should, and
+that absence-of-fact conditions (`trusted: false`, not-yet-scanned) must not,
+because they resolve on their own and a tombstone would make a transient state
+permanent and invisible.
+
+*Recommendation: make it a property of the reason code, not of the action, and
+default to no tombstone.* A policy author should not be able to request a
+permanent tombstone for a transient condition. Scan verdicts sit in between —
+tombstone with a TTL, since scanner rules and CVE data change under fixed
+content.

--- a/proposals/quality-gate/policy-model.md
+++ b/proposals/quality-gate/policy-model.md
@@ -1,0 +1,239 @@
+# Policy model
+
+Draft schema for both gates. Read `README.md` first for why there are two.
+
+## Shape
+
+A policy is a named object with a kind, a scope, a predicate and an action.
+
+```yaml
+policies:
+  <name>:
+    enabled: true
+    kind: admission | enforcement | retention
+    enforcement: audit | enforce        # audit = evaluate + log, never act
+    match: {...}                        # predicate; see below
+    action: ...                         # kind-dependent
+    # enforcement/retention only:
+    interval: 30m                       # inherits the task interval if unset
+    limit: 100                          # max records acted on per run
+    minAge: 1h                          # grace period; do not act on newer records
+```
+
+Three kinds because the three have genuinely different evaluation models:
+
+| kind | evaluated | against | can deny a write | can act on the store |
+|---|---|---|---|---|
+| `admission` | synchronously in `ingest.ImportRecord` | one in-flight record proto | yes | no |
+| `enforcement` | on the policy reconciler interval | search DB, per record | no | yes |
+| `retention` | on the policy reconciler interval | search DB, per *group* of records | no | yes |
+
+## Predicate vocabulary (`match`)
+
+Keys are `dirctl search` flag names without the `--` prefix. This is deliberate:
+the policy vocabulary *is* the query vocabulary, so any filter the CLI grows
+becomes a policy predicate with no schema change, and a policy author can
+dry-run any predicate with `dirctl search <same flags>` before enabling it.
+
+Value kinds follow the CLI's flag types:
+
+- list → the predicate repeated per item, OR-ed within the key
+- bool → `trusted: false`
+- scalar → `scan-severity: MEDIUM`
+
+Distinct keys are AND-ed. Every key has an `exclude-` counterpart.
+
+| key | Gate A (admission) | Gate B (enforcement/retention) |
+|---|---|---|
+| `name` (glob) | yes | yes |
+| `version` | yes | yes |
+| `schema-version` (glob) | yes | yes |
+| `author` | yes | yes |
+| `skill`, `domain`, `module`, `module-id`, `locator` | yes | yes |
+| `annotation` (`key:value`, glob) | yes | yes |
+| `created-at` (range, e.g. `<2025-01-01`) | yes | yes |
+| `signed` | **no** — signature is a later referrer push | yes |
+| `trusted` | **no** | yes |
+| `verified` | **no** | yes |
+| `safe`, `scan-severity`, `scan-status`, `scan-failure-reason` | **no** | yes |
+| `source-peer`, `source-trust-domain` | yes (new; from context) | no |
+| `size` | yes (new) | not persisted today |
+
+Reserved and rejected in `match`: `limit`, `offset`, `format`, `output`, `sort` —
+set by the engine.
+
+A policy whose `kind: admission` uses a Gate-B-only key must **fail to load**
+with a clear error naming the key. Silently passing such a rule is the worst
+possible outcome: it looks enforced and isn't.
+
+## Actions
+
+### `kind: admission`
+
+| action | effect |
+|---|---|
+| `deny` | `ImportRecord` returns `FailedPrecondition` naming the policy; nothing is stored |
+| `report` | log + metric, store normally |
+
+Deny must produce an error a human can act on, e.g.
+
+```
+rejected by policy "require-cisco-namespace": name 'acme.com/foo' does not match any of [cisco.com/*, agntcy.org/*]
+```
+
+### `kind: enforcement`
+
+| action | effect |
+|---|---|
+| `report` | structured log + per-policy metric only |
+| `unpublish` | withdraw routing announcements, keep the record locally |
+| `quarantine` | unpublish + mark excluded from search; bytes retained, reversible |
+| `delete` | unpublish, then delete from store + search index, then tombstone the CID |
+
+`delete` without the unpublish and tombstone steps causes a re-fetch loop — see
+`README.md` §6.
+
+### `kind: retention`
+
+```yaml
+    groupBy: name                # only `name` initially
+    keep: 2
+    order: version | recency     # which 2 to keep
+    action: quarantine | delete | report
+```
+
+## Worked examples
+
+### 1. Trust gate — "only keep records whose scan says trusted"
+
+Cannot be `admission`; trust doesn't exist yet at push time.
+
+```yaml
+  drop-untrusted:
+    enabled: true
+    kind: enforcement
+    enforcement: audit          # start here, flip to enforce once the log looks right
+    minAge: 24h                 # do not judge records the signature task hasn't reached
+    match:
+      trusted: false
+    action: quarantine
+```
+
+`minAge` is doing real work: without it this policy deletes every record in the
+window between its push and the signature task's next run.
+
+A stricter variant that acts on a *positive bad verdict* rather than the absence
+of a good one — safer, because it can't fire on a record that simply hasn't been
+processed:
+
+```yaml
+  drop-unsafe:
+    enabled: true
+    kind: enforcement
+    match:
+      scan-status: completed    # we have a verdict
+      safe: false               # and it is bad
+    action: delete
+```
+
+Open question: `scan_reports` rows can arrive from a *peer* as a pushed
+ScanReport referrer (`server/ingest/ingest.go:134`). Whether a foreign verdict is
+allowed to trigger a local `delete` is Q4 in `open-questions.md`.
+
+### 2. Retention — "keep only 2 versions of the same record"
+
+```yaml
+  keep-two-versions:
+    enabled: true
+    kind: retention
+    groupBy: name
+    keep: 2
+    order: version
+    action: delete
+```
+
+Sharp edges, all of them real:
+
+- **There is no unique constraint on `(name, version)`** — record identity is the
+  CID (`server/database/gorm/record.go:46`). So one name+version can legitimately
+  have several CIDs (re-push with edited content). "2 versions" and "2 records"
+  are different counts and we must pick one. Proposal: group by `name`, collapse
+  by distinct `version`, keep the newest CID within each kept version, delete the
+  rest. That makes `keep: 2` mean two *versions*, matching the wording.
+- **`order: version` needs semver.** `version` is a free-form string in OASF, so
+  ordering is only meaningful if it parses as semver. Fall back to `recency` and
+  warn when it doesn't. `order: recency` should use `oasf_created_at`, not the DB
+  row's `created_at`, or re-syncing an old record makes it look newest.
+- **Tiebreak deterministically** (`oasf_created_at`, then row `created_at`, then
+  CID) so two nodes running the same policy converge on the same survivors.
+- **Interaction with names/aliases.** If `NamingService.Resolve` on a name
+  returns all versions, deleting versions changes resolution results. Worth
+  checking whether anything depends on a specific version staying resolvable.
+
+### 3. Namespace convention — a real Gate A policy
+
+```yaml
+  require-known-namespace:
+    enabled: true
+    kind: admission
+    enforcement: enforce
+    match:
+      exclude-name:
+        - 'cisco.com/*'
+        - 'agntcy.org/*'
+    action: deny
+```
+
+Note the inversion: `match` describes what to *act on*, so an allow-list is
+expressed as `exclude-` of the permitted patterns. This reads badly. Q2 in
+`open-questions.md` proposes `allow:` / `deny:` blocks instead.
+
+### 4. Import hygiene — bound what the MCP registry importer can bring in
+
+```yaml
+  import-must-declare-skills:
+    enabled: true
+    kind: admission
+    match:
+      exclude-skill: ['*']
+    action: deny
+
+  import-schema-floor:
+    enabled: true
+    kind: admission
+    match:
+      exclude-schema-version: ['0.8.*', '0.9.*']
+    action: deny
+```
+
+These two are the cases where a synchronous gate is clearly worth having: the
+importer gets an immediate, specific error and the bad record never lands.
+
+## Storage and API
+
+Phase 1: config file, under the reconciler config tree so it inherits the
+existing `DIRECTORY_DAEMON_*` env override plumbing (`cli/cmd/daemon/config.go:140`).
+Note there is no config watching in the repo, so file-based policies need a
+restart.
+
+Phase 2 (the "available via an API" requirement): a `PolicyService` mirroring
+`SyncService` — CRUD writes rows to a `policies` table, the reconciler task reads
+and executes them. That is the existing pattern for "API-managed thing that a
+reconciler task performs" (`server/controller/sync.go:37` +
+`reconciler/tasks/regsync/task.go:83`) and it gives hot-reload for free.
+
+`PolicyService` needs its own Casbin authz entries so policy management is not
+implicitly granted by store write access
+(`p,<trust_domain>,/agntcy.dir.policy.v1.PolicyService/*`).
+
+## Observability
+
+Non-negotiable, since Gate B deletes things:
+
+- `dir_policy_evaluations_total{policy,kind,verdict}`
+- `dir_policy_actions_total{policy,action,result}`
+- one structured log line per action with policy name, CID, record name/version
+  and the matched predicate
+- an append-only `policy_actions` audit table — "why did my record vanish" must
+  be answerable, and `delete` destroys the evidence otherwise
+- `dirctl policy test <name>` / `--dry-run` to print what a policy would act on

--- a/proposals/quality-gate/tombstones.md
+++ b/proposals/quality-gate/tombstones.md
@@ -1,0 +1,206 @@
+# CID tombstones (the anti-thrash denylist)
+
+Companion to `README.md` §6. This is the mechanism that makes Gate B's
+destructive actions safe to run on a node that participates in a network.
+
+## What problem this solves
+
+It is the classic **deletion-resurrection** problem in a replicated system: you
+delete an item locally, anti-entropy sees a replica that still has it, and the
+item comes back. Here the "anti-entropy" is DHT republish plus autosync:
+
+```
+Gate B deletes CID X
+    ↓
+peer republishes X to the DHT          (every REPUBLISH_INTERVAL — 36h default,
+    ↓                                   but 1m in our dev/demo config)
+autosync sees the announcement, X not in local store → fetches it
+    ↓
+indexer/scan/signature tasks process X  (scanner budget, LLM calls, network)
+    ↓
+Gate B deletes X again
+    ↓
+… forever
+```
+
+The standard fix is a tombstone: a durable marker that says *"this node already
+decided not to keep X"*, so a later offer of X is suppressed instead of
+re-processed. Calling it a tombstone rather than a blacklist matters, because it
+frames the semantics correctly — it is not an assertion that X is bad, it is a
+record of a local decision.
+
+## Why keying on CID is the right choice
+
+A CID is a hash of the record content, which gives the denylist two properties a
+name-based or author-based blocklist could never have:
+
+- **Unambiguous identity.** "CID X was rejected" can never be wrong about *what*
+  was rejected. No glob semantics, no aliasing, no versioning questions.
+- **Correct invalidation on change.** Any edit to the record produces a different
+  CID, so modified content is automatically re-evaluated rather than being
+  blocked by a stale rule. You get "re-check changed things, suppress unchanged
+  things" for free, which is exactly the behaviour we want.
+
+It is also the *only* thing available at the cheapest interception points — a DHT
+announcement and a regsync tag filter both carry CIDs and nothing else. So a
+CID-keyed denylist is the one design that can be consulted before any bytes move.
+
+## Where it gets consulted
+
+Ordered by how much work each check avoids.
+
+| # | Point | Location | Saves |
+|---|---|---|---|
+| 1 | Autosync enqueue | `server/routing/autosync/autosync.go:178` (`MaybeEnqueue`) | the entire fetch + validate + ingest + scan chain |
+| 2 | Sync job creation | `reconciler/tasks/regsync/regsync_config.go:150-180` | the OCI copy; drop tombstoned CIDs from the tag filter |
+| 3 | Autosync job start | `autosync.go:240` (`process`) | the pull, for jobs queued before the tombstone existed |
+| 4 | Gate A | `server/ingest/ImportRecord` | the store write; backstop for gRPC push |
+
+Points 1 and 3 are essentially free to add, because the guards already exist in
+that exact shape:
+
+```go
+// MaybeEnqueue already does, in order:
+if _, ok := m.allowSet[addrInfo.ID]; !ok { return }   // peer authorization
+if _, ok := m.inFlight[cid]; ok { return }            // in-flight dedup
+// → tombstone check belongs right here
+
+// process() already does:
+if _, err := m.store.Lookup(parentCtx, j.ref); err == nil { return }  // "do I have it?"
+// → "did I reject it?" is the natural sibling
+```
+
+Point 2 is the interesting one: it is the **only** protection available for the
+regsync path, since regsync shells out to an external CLI and bypasses Go-level
+ingest entirely (`README.md` §4). A CID denylist happens to be exactly the kind
+of filter that path *can* apply, because the tag filter is already a CID list.
+That resolves half of open question Q3.
+
+## The limitation, stated plainly
+
+Content addressing cuts both ways. Flip one character in a description and the
+record has a new CID and sails straight through.
+
+**So a CID tombstone list is a thrash brake, not a security control.** It stops
+the same bytes being re-processed in a loop. It does not stop a determined
+publisher, and it must not be documented or measured as if it did. Blocking
+*classes* of record is Gate A's job (name patterns, namespaces, source peers),
+and that is where the actual enforcement argument lives.
+
+## The hard part: staleness
+
+A tombstone outlives the reason it was created, and that is where this design can
+do real damage.
+
+Concretely: Gate B tombstones CID X for `trusted: false`. Then the publisher's
+public key propagates, or we relax the policy, or the signature task simply
+catches up. X is now perfectly acceptable — and permanently blocked, on every
+node that ran the policy. Worse, the block is invisible: the record just never
+appears.
+
+Four rules to contain this:
+
+**1. Only tombstone stable, content-intrinsic verdicts. Never absence of a fact.**
+
+| Verdict | Tombstone? | Why |
+|---|---|---|
+| name violates namespace convention | yes | function of the content, cannot change |
+| schema version below floor | yes | same |
+| no skills declared / oversized | yes | same |
+| deleted by retention (superseded version) | yes | the ideal case — the record is genuinely unwanted forever, and republish thrash is guaranteed without it |
+| scan verdict says unsafe | with a TTL | scanner rules and CVE data change, so identical content can flip to safe |
+| `trusted: false` / `verified: false` / not scanned yet | **no** | transient. This is *absence of a fact*, not a negative verdict, and it resolves on its own |
+
+That last row is the one that matters: the policy in `policy-model.md` example 1
+must **not** produce tombstones. Pair this with the `minAge` grace period —
+together they mean "don't judge a record before the facts exist, and don't make
+the judgement permanent when the input can change".
+
+**2. Record provenance and invalidate on policy change.** Each entry stores the
+policy name and a policy generation/hash. When a policy's definition changes or
+it is deleted, its tombstones are dropped so the affected records get
+re-evaluated. Without this, editing a policy leaves a permanent shadow of the old
+one.
+
+**3. TTL, not forever.** A tombstone only has to outlive the re-announcement
+cycle to stop thrash. That makes the correct default a small multiple of the
+routing republish interval (36h default → 7d), not permanence. Expiry costs one
+re-evaluation; permanence costs correctness.
+
+**4. Escape hatches.** `dirctl policy tombstone ls/rm <cid>`, plus removal via
+the eventual `PolicyService` API. Someone will need to answer "why is this record
+not showing up on this node", and the tombstone table has to be the place that
+answers it.
+
+## Pull paths vs explicit push
+
+Thrash comes exclusively from *pull* paths — autosync and sync, where the node
+re-fetches because a peer keeps offering. Nobody's automation re-pushes over gRPC
+in a tight loop the way DHT republish does.
+
+That asymmetry suggests tombstones should **suppress pull ingestion but not
+silently block an explicit push.** An operator pushing a record is a much
+stronger statement of intent than a peer announcing one, and being told "this was
+deleted by policy Y" is far better than the push appearing to succeed while the
+record stays absent, or failing with no explanation.
+
+Proposal: at Gate A, a tombstone hit on an explicit push returns an error naming
+the policy and offering an override, rather than a silent drop:
+
+```
+rejected: CID bae…szm was removed by policy "keep-two-versions" 3h ago
+          (retention: superseded version). Re-push with --force-policy-override
+          or remove the tombstone with: dirctl policy tombstone rm bae…szm
+```
+
+The retention case is the sharpest example: if retention deletes v1.0.0 and the
+owner deliberately re-pushes that exact content, blocking it silently is clearly
+wrong, even though blocking a *peer's* re-announcement of it is clearly right.
+
+## Storage and lookup
+
+```
+record_tombstones
+  record_cid      text primary key
+  policy_name     text not null       -- who decided
+  policy_gen      text not null       -- invalidate when the policy changes
+  reason          text not null       -- short code, e.g. retention-superseded
+  action          text not null       -- delete | quarantine
+  record_name     text                -- kept for forensics; the record row is gone
+  record_version  text
+  source          text                -- path/peer that offered it
+  created_at      timestamp
+  expires_at      timestamp           -- null only for content-intrinsic verdicts
+```
+
+Lookup is on the hot path (every DHT announcement), so keep an in-memory set
+refreshed periodically rather than querying per announcement. The autosync
+Manager already holds `allowSet` and `inFlight` maps under a mutex, so this fits
+the existing structure. If the set ever grows beyond what's comfortable in
+memory, a bloom filter in front of the table gives the right trade-off: false
+positives are the safe direction only if we then confirm against the table, so
+confirm on hit.
+
+Bound the growth: TTL sweep in the policy task, plus a max-entries cap with
+oldest-first eviction. A tombstone table larger than the record store is a signal
+that a policy is fighting the network, which is worth alerting on in itself.
+
+## Explicitly out of scope: gossiping tombstones
+
+Tempting — if one node decides X is unwanted, tell the others. But that lets a
+node influence what its peers store, which contradicts the node-local policy
+stance in Q6 and is an obvious abuse vector. Tombstones stay node-local. Nodes
+running the same policy converge independently, which is sufficient.
+
+## Observability
+
+- `dir_policy_tombstone_hits_total{policy,path}` — a high rate on the autosync
+  path is the direct measure of thrash avoided, and the number that justifies
+  this whole mechanism
+- `dir_policy_tombstones{state="active|expired"}` — growth
+- a log line on every tombstone creation and on removal/expiry
+
+The hit-rate metric doubles as the signal for "this policy disagrees with the
+network". If a node is suppressing the same thousand CIDs every hour forever,
+the right fix is probably to stop syncing from that source, not to keep
+suppressing.


### PR DESCRIPTION
## What this is

A **draft proposal**, not an implementation. It asks for a decision on where a
record quality gate belongs in the Directory process, and what its policy model
should look like.

Nothing here is committed to. The twelve numbered questions in
`open-questions.md` are the point of the review — each has a recommendation, and
each is genuinely arguable.

Also adds `proposals/` for design docs too large for a PR description. Kept out
of `docs/` deliberately: that tree is published with mkdocs and `docs-ci` /
`docs-deploy` trigger on `docs/**`.

## The problem

We want a configurable gate that decides which records a node is willing to
admit and keep, across push, import, sync and autosync. The two motivating
examples were:

1. only keep records whose scan says they are trusted
2. keep only 2 versions of the same record

## The three findings worth arguing about

**1. It has to be two gates, not one.** Neither example can be enforced at push
time. Trust is a *derived* fact that the signature, name and scan reconciler
tasks compute later (defaults 1m / 1h / 6h); at push the node does not even know
the record is signed, because `dirctl push --sign` sends the signature afterwards
as a separate referrer. And "keep 2 versions" is a property of a *set* grouped by
name, not of the record being admitted. So:

- **Gate A — admission (synchronous)**: decorate the existing `ingest.Ingestor`
  interface. Already an interface, constructed once, already documented as "a
  single, authoritative code path". Covers push, `dirctl import` and DHT
  autosync with no call-site changes. Can only see record metadata.
- **Gate B — enforcement (asynchronous)**: a new `reconciler/tasks/policy/`.
  Runs alongside the tasks that produce the facts, and evaluates against the
  search DB where `trusted` / `safe` / `verified` already have query builders.

**2. Reuse `RecordQuery` rather than adopting Rego or CEL.** `dirctl search`
already exposes a tested predicate vocabulary that covers exactly the facts we
care about. A policy becomes `match: {trusted: false}` + `action:`. Gate B then
compiles to one SQL query instead of loading records into memory; authors can
dry-run any predicate with `dirctl search <same flags>` before enabling it; and
the existing `dirctl` chart `policies:` collapse into a client of this model
instead of a parallel implementation. The cost is a flat AND of predicates — no
OR, no cross-field logic. `cel:` is the proposed escape hatch if we hit that.

**3. Destructive actions need CID tombstones.** Deleting a record that peers
still announce means autosync re-fetches it, the reconciler re-scans it, and
policy deletes it again — a tight loop at our 1m republish interval. `delete`
must also unpublish (note `StoreService.Delete` does not touch routing
announcements today), and a CID denylist must suppress the re-fetch. Content
addressing makes this precise and self-invalidating, and it is the *only* filter
the regsync path can apply, since that path's tag filter is already a CID list.

The sharpest sub-question there: a tombstone must **not** be created for
`trusted: false`, because that is absence of a fact rather than a negative
verdict, and it resolves on its own. Tombstoning it would permanently and
invisibly block records whose key merely had not propagated yet.

## Reading order

| File | Contents |
|---|---|
| `proposals/quality-gate/README.md` | placement in the process, phase model, engine choice, rollout |
| `proposals/quality-gate/policy-model.md` | schema, predicate vocabulary, actions, worked examples for both motivating cases |
| `proposals/quality-gate/tombstones.md` | the CID denylist, its limits, and staleness handling |
| `proposals/quality-gate/open-questions.md` | the twelve decisions |

If you only read one thing, read §3 of the main README (the fact-availability
table). Everything else follows from it.

## Two pre-existing issues this depends on

- `skill.Publish` writes to the store and DB directly instead of going through
  `ingest.Ingestor`, so it sits permanently outside Gate A.
- `StoreService.Delete` leaves routing announcements behind, which the `delete`
  action would inherit.

## Suggested rollout

Gate B in report-only mode first, with config-file policies. It tells us what
our nodes actually hold at zero blast radius and validates the vocabulary
against real data before anything is deleted. `PolicyService` and the API come
later, following the `SyncService` pattern — which is also the only way to get
hot-reload, since nothing in the repo watches config today.
