### PR TITLE
test(e2e): cover POST /v1/search parity and POST /v1/extract

### DIFF
--- a/tests/e2e/daemon/02_no_extractor_test.go
+++ b/tests/e2e/daemon/02_no_extractor_test.go
@@ -1,0 +1,110 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// Extractor-backed HTTP endpoints on a gateway with no OASF extractor.
+//
+// The "default" testenv points the daemon's extractor at an asset directory that
+// does not exist and configures no OASF-SDK server, so resolution finds no
+// backend. What that must produce is a node that still starts and serves its
+// other routes, with only the extractor-backed endpoints degraded — the reason
+// this lives in e2e rather than beside the handler unit tests, which construct a
+// controller with a nil extractor directly and cannot catch a node that fails to
+// come up at all.
+var _ = ginkgo.Describe("Extractor-backed HTTP API without an extractor", func() {
+	ginkgo.BeforeEach(func() {
+		if testEnv.Config.GatewayAddress == "" {
+			ginkgo.Skip("HTTP gateway address not configured for this environment")
+		}
+
+		if !testEnv.Config.ExpectNoExtractor {
+			ginkgo.Skip("this environment configures an extractor; 503 assertions do not apply")
+		}
+	})
+
+	ginkgo.It("serves a non-extractor endpoint, proving the gateway is up", func(ctx ginkgo.SpecContext) {
+		// Without this the 503s below are ambiguous: a gateway that never
+		// started would produce a connection error, not a 503, but a gateway
+		// that started and is broken for every route would look the same as one
+		// that is healthy apart from the extractor.
+		gomega.Eventually(func(g gomega.Gomega) {
+			status, _ := getGateway(ctx, "/v1/agents")
+			g.Expect(status).To(gomega.Equal(http.StatusOK))
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("answers POST /v1/extract with 503", func(ctx ginkgo.SpecContext) {
+		status, body := postGateway(ctx, "/v1/extract", `{"text":"an agent that reviews source code"}`)
+
+		gomega.Expect(status).To(gomega.Equal(http.StatusServiceUnavailable))
+		gomega.Expect(body).To(gomega.ContainSubstring("no OASF extractor is configured"))
+	})
+
+	ginkgo.It("answers POST /v1/search with 503", func(ctx ginkgo.SpecContext) {
+		status, body := postGateway(ctx, "/v1/search", `{"query":"an agent that reviews source code"}`)
+
+		gomega.Expect(status).To(gomega.Equal(http.StatusServiceUnavailable))
+		gomega.Expect(body).To(gomega.ContainSubstring("no OASF extractor is configured"))
+	})
+
+	ginkgo.It("rejects an invalid request before reaching the extractor", func(ctx ginkgo.SpecContext) {
+		// Argument validation runs ahead of the extractor check, so an empty
+		// query is a 400 even here. Asserting it pins the order: a handler that
+		// checked the extractor first would report an outage for a request that
+		// was never going to be served anyway.
+		status, _ := postGateway(ctx, "/v1/search", `{"query":""}`)
+
+		gomega.Expect(status).To(gomega.Equal(http.StatusBadRequest))
+	})
+})
+
+// getGateway issues a GET against the deployed HTTP gateway and returns the
+// status code and response body.
+func getGateway(ctx context.Context, path string) (int, string) {
+	ginkgo.GinkgoHelper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, testEnv.Config.GatewayAddress+path, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return doGateway(req)
+}
+
+// postGateway issues a JSON POST against the deployed HTTP gateway and returns
+// the status code and response body.
+func postGateway(ctx context.Context, path, body string) (int, string) {
+	ginkgo.GinkgoHelper()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		testEnv.Config.GatewayAddress+path, bytes.NewReader([]byte(body)))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return doGateway(req)
+}
+
+func doGateway(req *http.Request) (int, string) {
+	ginkgo.GinkgoHelper()
+
+	resp, err := http.DefaultClient.Do(req)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return resp.StatusCode, string(body)
+}

--- a/tests/e2e/daemon/config/config.go
+++ b/tests/e2e/daemon/config/config.go
@@ -16,6 +16,18 @@ type Config struct {
 	// only the external one defines such a workload.
 	RuntimeWorkloadComposeFile string `json:"runtime_workload_compose_file,omitempty" mapstructure:"runtime_workload_compose_file"`
 
+	// GatewayAddress is the base URL of the daemon's HTTP gateway (e.g.
+	// "http://localhost:18236"). Empty when the gateway is not enabled in this
+	// environment, in which case the gateway specs skip.
+	GatewayAddress string `json:"gateway_address,omitempty" mapstructure:"gateway_address"`
+
+	// ExpectNoExtractor reports that this environment deliberately runs the
+	// gateway with no OASF extractor resolvable, so the extractor-backed
+	// endpoints must answer 503 rather than serve. It is a positive assertion,
+	// not a skip: the point of the environment is that a node deployed without
+	// an extractor still starts and degrades only those routes.
+	ExpectNoExtractor bool `json:"expect_no_extractor,omitempty" mapstructure:"expect_no_extractor"`
+
 	// Client configuration for tests.
 	ClientOptions client.Config `json:"client_options" mapstructure:"client_options"`
 }

--- a/tests/e2e/daemon/testenv/default/Taskfile.testenv.yml
+++ b/tests/e2e/daemon/testenv/default/Taskfile.testenv.yml
@@ -11,3 +11,7 @@ includes:
       DIRCTL_DATA_PATH: "/tmp/e2e-daemon-default-testenv"
       DIRCTL_CONFIG_PATH: "{{.ROOT_DIR}}/tests/e2e/daemon/testenv/default/dir-daemon-config.yaml"
       DIRCTL_LOGFILE_PATH:  "{{.ROOT_DIR}}/tests/e2e/daemon/testenv/default/logs.daemon.log"
+      # This suite exercises the gateway with no extractor, and nothing here uses
+      # the CLI's extractor, so skip the ~89 MB asset download. It runs on three
+      # runners in the cross-platform workflow, none of which cache the assets.
+      DIRCTL_PROVISION_EXTRACTOR: "false"

--- a/tests/e2e/daemon/testenv/default/dir-daemon-config.yaml
+++ b/tests/e2e/daemon/testenv/default/dir-daemon-config.yaml
@@ -4,6 +4,20 @@ server:
     enabled: false
   oasf_api_validation:
     schema_url: "https://schema.oasf.outshift.com"
+  # Gateway with no extractor behind it. This is the one environment that covers
+  # a node deployed without an OASF extractor: the gateway must still start and
+  # serve its other routes, while the extractor-backed endpoints answer 503.
+  http_gateway:
+    enabled: true
+    listen_address: "localhost:18236"
+    public_url: "http://localhost:18236"
+  extractor:
+    # Deliberately a path that does not exist, so resolution finds no
+    # provisioned assets and the gateway comes up with no extractor. Pointing at
+    # a missing directory rather than relying on an unprovisioned home keeps the
+    # result the same on a developer machine that has run `dirctl init`. Nothing
+    # creates or writes this path.
+    asset_dir: "/nonexistent-oasf-extractor-assets-e2e"
   store:
     provider: "oci"
     oci:

--- a/tests/e2e/daemon/testenv/default/test-config.yaml
+++ b/tests/e2e/daemon/testenv/default/test-config.yaml
@@ -1,5 +1,7 @@
 daemon:
   run_runtime_discovery_tests: false
+  gateway_address: "http://localhost:18236"
+  expect_no_extractor: true
   client_options:
     server_address: "localhost:18234"
     auth_mode: "insecure"

--- a/tests/e2e/local/13_ai_finder_test.go
+++ b/tests/e2e/local/13_ai_finder_test.go
@@ -5,7 +5,6 @@ package local
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -97,21 +96,7 @@ var _ = ginkgo.Describe("AI Finder ListAgents HTTP API", func() {
 // getAgents issues GET /v1/agents against the deployed HTTP gateway and
 // returns the status code and response body.
 func getAgents(ctx context.Context, rawQuery string) (int, string) {
-	target := testEnv.Config.GatewayAddress + "/v1/agents"
-	if rawQuery != "" {
-		target += "?" + rawQuery
-	}
+	ginkgo.GinkgoHelper()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	resp, err := http.DefaultClient.Do(req)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	return resp.StatusCode, string(body)
+	return gatewayGet(ctx, "/v1/agents", rawQuery)
 }

--- a/tests/e2e/local/15_nl_search_test.go
+++ b/tests/e2e/local/15_nl_search_test.go
@@ -30,6 +30,19 @@ var _ = ginkgo.Describe("Natural-language search", func() {
 			home, homeErr := os.UserHomeDir()
 			gomega.Expect(homeErr).NotTo(gomega.HaveOccurred())
 
+			// NOTE: this path is missing the "extractor" subdirectory that
+			// extractor.DefaultAssetDir provisions into, so the check never
+			// finds the manifest and this spec always skips. Correcting it makes
+			// the spec run and push testdata/directory-record.json, which then
+			// contends with 14_skill_record_test.go: both use the record name
+			// "org.agntcy/directory", that testdata carries a stale
+			// "application/agentskill+md" artifact media type where the daemon
+			// now emits "application/agent-skills+md", and spec 14 resolves the
+			// name with --limit 1. Fixing this needs the testdata corrected and
+			// spec 14 taught to pick the record it means, so it is left alone
+			// here rather than half-done. The CLI free-text path is meanwhile
+			// covered by the parity spec in 18_ai_finder_search_test.go, which
+			// runs `dirctl search` against the same query as POST /v1/search.
 			manifest := filepath.Join(home, ".agntcy", "oasf-sdk", "manifest.json")
 			if _, err := os.Stat(manifest); err != nil {
 				ginkgo.Skip("OASF extractor not provisioned — run `dirctl init` to enable natural-language search tests")

--- a/tests/e2e/local/18_ai_finder_search_test.go
+++ b/tests/e2e/local/18_ai_finder_search_test.go
@@ -1,0 +1,323 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agntcy/dir/tests/e2e/shared/testdata"
+	"github.com/agntcy/dir/tests/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// Natural-language search over the HTTP gateway (POST /v1/search).
+//
+// These run against a real node with a real extractor, in whichever backend the
+// environment deploys — in-process assets or an OASF-SDK server. That is the
+// point: the handler unit tests drive a fake extractor and cannot catch a
+// gateway that resolved no backend, dialed the wrong address, or ranks
+// differently from `dirctl search`.
+//
+// searchQuery decomposes into seven signals, identically on both extractor
+// backends: the skills "software_engineering/code_quality/code_review" (0.573)
+// and "natural_language_processing/natural_language_generation" (0.436), plus the
+// keywords *code*, *review*, *understands*, *natural* and *language*, each
+// scoring 1.0. The seeds below are built against that signal set.
+const searchQuery = "a code review agent that understands natural language and integrates with MCP servers"
+
+// rankingDescription matches four of searchQuery's five keyword signals
+// (*understands*, *natural*, *language*, *code*) and is shared verbatim by the
+// two ranking seeds, so their keyword surface is identical and the only thing
+// separating them is whether they carry a matching skill.
+const rankingDescription = "Understands natural language questions about source code"
+
+// rankingSkill is the skill searchQuery extracts with the highest score. A
+// record carrying it matches one signal more than an otherwise identical record.
+const rankingSkill = "software_engineering/code_quality/code_review"
+
+const rankingSkillID = 60701
+
+// queryOverMaxLen is one rune past the max_len the handler enforces on
+// SearchAgentsRequest.query.
+const queryOverMaxLen = 1025
+
+var _ = ginkgo.Describe("AI Finder SearchAgents HTTP API", func() {
+	ginkgo.BeforeEach(func() {
+		utils.ResetCLIState()
+	})
+
+	var (
+		tempDir string
+
+		// CIDs of the seeded records, by role in the ranking.
+		skillMatchCID  string
+		keywordOnlyCID string
+		unrelatedCID   string
+		seededCIDs     []string
+	)
+
+	ginkgo.Context("with a seeded record set", ginkgo.Ordered, func() {
+		ginkgo.BeforeAll(func() {
+			skipUnlessExtractorGateway()
+
+			var err error
+
+			tempDir, err = os.MkdirTemp("", "ai-finder-search-test")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			// Each seed renames the record it is built from, which changes its
+			// CID, so these never collide with the same testdata pushed by
+			// another spec. All three keep an integration module, without which
+			// the catalog cannot project them and search would not consider
+			// them candidates at all.
+			//
+			// The two ranking seeds share a description and carry names holding
+			// none of the query's keywords, so they match exactly the same
+			// keyword signals. Ranking is by number of signals matched, ties
+			// broken on summed signal score, and a keyword scores 1.0 against a
+			// skill's 0.573 — so a record cannot be shown to rank above another
+			// by carrying a matching skill unless the keyword surface is held
+			// equal. Varying the descriptions instead lets the extra keyword hit
+			// outweigh the skill hit, which is correct behaviour and tells us
+			// nothing about the skill.
+
+			// Matches the four keywords plus rankingSkill: five signals.
+			skillMatchCID = pushSeedRecord(tempDir, "skill-match", testdata.ExpectedRecordV110JSON, map[string]any{
+				"name":        "e2e_search_ranking_alpha",
+				"description": rankingDescription,
+				"skills": []map[string]any{
+					{"name": rankingSkill, "id": rankingSkillID},
+				},
+			})
+
+			// The same four keywords, and skills the query does not extract, so
+			// it matches four signals — one fewer than the record above.
+			keywordOnlyCID = pushSeedRecord(tempDir, "keyword-only", testdata.ExpectedRecordV110JSON, map[string]any{
+				"name":        "e2e_search_ranking_beta",
+				"description": rankingDescription,
+			})
+
+			// Matches no signal at all: its name and description hold none of the
+			// keywords and its skill is not one the query extracts. It is here to
+			// check that the ranked set leaves such a record out.
+			unrelatedCID = pushSeedRecord(tempDir, "unrelated", testdata.ExpectedRecordV100JSON, map[string]any{
+				"name": "e2e_search_burger_agent",
+			})
+
+			seededCIDs = []string{skillMatchCID, keywordOnlyCID, unrelatedCID}
+		})
+
+		ginkgo.AfterAll(func() {
+			for _, cid := range seededCIDs {
+				if cid != "" {
+					_, _ = testEnv.CLI.Delete(cid).Execute()
+				}
+			}
+
+			if tempDir != "" {
+				_ = os.RemoveAll(tempDir)
+			}
+		})
+
+		ginkgo.It("returns relevance-ranked entries for a free-text query", func(ctx ginkgo.SpecContext) {
+			resp := postSearch(ctx, searchRequest{Query: searchQuery, PageSize: 100})
+
+			gomega.Expect(resp.TotalCount).To(gomega.BeNumerically(">=", 2),
+				"the seeded records should give the ranking at least two entries to order")
+			gomega.Expect(resp.cids()).To(gomega.ContainElement(skillMatchCID))
+			gomega.Expect(resp.cids()).To(gomega.ContainElement(keywordOnlyCID))
+			gomega.Expect(resp.cids()).NotTo(gomega.ContainElement(unrelatedCID),
+				"a record matching no signal should not be in the ranked set")
+
+			// Every entry is a catalog projection, identified by URN rather than
+			// a bare CID. Asserting it here pins the hydration step: a handler
+			// returning raw CIDs would still satisfy the assertions above.
+			for _, entry := range resp.Results {
+				gomega.Expect(entry.Identifier).To(gomega.ContainSubstring(":cid:"),
+					"entry identifier should be a urn:ai:<host>:cid:<cid> URN")
+				gomega.Expect(entry.DisplayName).NotTo(gomega.BeEmpty())
+			}
+		})
+
+		ginkgo.It("ranks by the number of signals a record matches", func(ctx ginkgo.SpecContext) {
+			// The two seeds differ by exactly one matched signal, so this
+			// asserts the ordering rule itself rather than a property of any
+			// particular query.
+			cids := postSearch(ctx, searchRequest{Query: searchQuery, PageSize: 100}).cids()
+
+			skillRank := indexOf(cids, skillMatchCID)
+			keywordRank := indexOf(cids, keywordOnlyCID)
+
+			gomega.Expect(skillRank).To(gomega.BeNumerically(">=", 0), "the five-signal record should be ranked")
+			gomega.Expect(keywordRank).To(gomega.BeNumerically(">=", 0), "the four-signal record should be ranked")
+			gomega.Expect(skillRank).To(gomega.BeNumerically("<", keywordRank),
+				"the record matching five signals should outrank the otherwise identical one matching four")
+		})
+
+		ginkgo.It("returns a stable ranking across repeated identical requests", func(ctx ginkgo.SpecContext) {
+			// Ranking ties break on summed signal score then CID, giving a total
+			// order. Without it a paginated caller would see records repeat or
+			// vanish between pages.
+			first := postSearch(ctx, searchRequest{Query: searchQuery, PageSize: 100}).cids()
+			gomega.Expect(first).NotTo(gomega.BeEmpty())
+
+			for range 2 {
+				gomega.Expect(postSearch(ctx, searchRequest{Query: searchQuery, PageSize: 100}).cids()).
+					To(gomega.Equal(first), "repeated identical requests should return the same order")
+			}
+		})
+
+		ginkgo.It("pages the ranked set into disjoint pages", func(ctx ginkgo.SpecContext) {
+			full := postSearch(ctx, searchRequest{Query: searchQuery, PageSize: 100})
+			gomega.Expect(len(full.cids())).To(gomega.BeNumerically(">=", 2),
+				"paging assertions need at least two ranked entries")
+
+			pageOne := postSearch(ctx, searchRequest{Query: searchQuery, PageSize: 1})
+			gomega.Expect(pageOne.cids()).To(gomega.Equal(full.cids()[:1]))
+			gomega.Expect(pageOne.NextPageToken).NotTo(gomega.BeEmpty())
+
+			pageTwo := postSearch(ctx, searchRequest{
+				Query:     searchQuery,
+				PageSize:  1,
+				PageToken: pageOne.NextPageToken,
+			})
+			gomega.Expect(pageTwo.cids()).To(gomega.Equal(full.cids()[1:2]))
+			gomega.Expect(pageTwo.cids()).NotTo(gomega.ContainElement(pageOne.cids()[0]),
+				"consecutive pages should be disjoint")
+
+			// A page covering the whole ranked set reports no continuation, so a
+			// caller following the tokens terminates.
+			if full.TotalCount <= 100 {
+				gomega.Expect(full.NextPageToken).To(gomega.BeEmpty())
+			}
+		})
+
+		ginkgo.It("returns the same CIDs in the same order as `dirctl search`", func(ctx ginkgo.SpecContext) {
+			// Only the local backend is shared: the CLI loads the same
+			// provisioned assets the gateway does. Under kind the OASF-SDK
+			// Service is ClusterIP-only, so the CLI cannot reach the backend the
+			// gateway uses and the two rankings are not comparable.
+			if testEnv.Config.ExtractorMode != "local" {
+				ginkgo.Skip("this environment's CLI and gateway do not share an extractor, so their rankings are not comparable")
+			}
+
+			// Both paths run the same nlsearch decomposition and fan-out, so the
+			// same query must produce the same order. They do not see the same
+			// record universe: the gateway restricts candidates to records the
+			// catalog can project, the CLI does not. Comparing the two lists
+			// filtered to the seeded records asserts the shared ordering without
+			// depending on what else the store holds.
+			apiOrder := postSearch(ctx, searchRequest{Query: searchQuery, PageSize: 100}).cids()
+
+			raw := testEnv.CLI.Command("search").WithArgs(
+				searchQuery,
+				"--format", "cid",
+				"--limit", "100",
+				"--output", "jsonl",
+			).ShouldSucceed()
+
+			gomega.Expect(retain(cliCIDs(raw), seededCIDs)).To(gomega.Equal(retain(apiOrder, seededCIDs)),
+				"`dirctl search` and POST /v1/search should rank the seeded records identically")
+		})
+
+		ginkgo.It("rejects an empty query with HTTP 400", func(ctx ginkgo.SpecContext) {
+			status, _ := gatewayPostJSON(ctx, "/v1/search", searchRequest{Query: "   "})
+
+			gomega.Expect(status).To(gomega.Equal(http.StatusBadRequest))
+		})
+
+		ginkgo.It("rejects an over-long query with HTTP 400", func(ctx ginkgo.SpecContext) {
+			// The service registers no protovalidate interceptor, so the proto's
+			// max_len is enforced in handler code. This is the e2e check that it
+			// actually is.
+			status, _ := gatewayPostJSON(ctx, "/v1/search", searchRequest{
+				Query: strings.Repeat("a", queryOverMaxLen),
+			})
+
+			gomega.Expect(status).To(gomega.Equal(http.StatusBadRequest))
+		})
+	})
+})
+
+// pushSeedRecord writes a record built from base with the given top-level fields
+// replaced, pushes it, and returns its CID. Renaming a record changes its CID,
+// which is what keeps these seeds distinct from the same testdata pushed
+// elsewhere in the suite.
+func pushSeedRecord(dir, label string, base []byte, overrides map[string]any) string {
+	ginkgo.GinkgoHelper()
+
+	var doc map[string]any
+	gomega.Expect(json.Unmarshal(base, &doc)).To(gomega.Succeed())
+
+	maps.Copy(doc, overrides)
+
+	data, err := json.Marshal(doc)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	path := filepath.Join(dir, label+".json")
+	gomega.Expect(os.WriteFile(path, data, 0o600)).To(gomega.Succeed())
+
+	cid := testEnv.CLI.Push(path).WithArgs("--output", "raw").ShouldSucceed()
+	gomega.Expect(cid).NotTo(gomega.BeEmpty(), "pushing seed record %q should return a CID", label)
+
+	return cid
+}
+
+// cliCIDs parses the CIDs out of `dirctl search --format cid --output jsonl`,
+// which prints one JSON-quoted CID per line, in rank order.
+func cliCIDs(raw string) []string {
+	ginkgo.GinkgoHelper()
+
+	var out []string
+
+	for line := range strings.SplitSeq(strings.TrimSpace(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "[]" {
+			continue
+		}
+
+		var cid string
+		gomega.Expect(json.Unmarshal([]byte(line), &cid)).To(gomega.Succeed(),
+			"unexpected line in `dirctl search` jsonl output: %q", line)
+
+		out = append(out, cid)
+	}
+
+	return out
+}
+
+// retain filters cids down to the members of keep, preserving the order of cids.
+func retain(cids, keep []string) []string {
+	wanted := make(map[string]struct{}, len(keep))
+	for _, cid := range keep {
+		wanted[cid] = struct{}{}
+	}
+
+	out := make([]string, 0, len(keep))
+
+	for _, cid := range cids {
+		if _, ok := wanted[cid]; ok {
+			out = append(out, cid)
+		}
+	}
+
+	return out
+}
+
+// indexOf returns the position of cid in cids, or -1 when absent.
+func indexOf(cids []string, cid string) int {
+	for i, c := range cids {
+		if c == cid {
+			return i
+		}
+	}
+
+	return -1
+}

--- a/tests/e2e/local/19_remote_extractor_test.go
+++ b/tests/e2e/local/19_remote_extractor_test.go
@@ -32,12 +32,12 @@ var _ = ginkgo.Describe("Remote extractor HTTP API", ginkgo.Ordered, ginkgo.Labe
 	var recordCID string
 
 	ginkgo.BeforeAll(func() {
-		if !testEnv.Config.RemoteExtractorEnabled {
+		if testEnv.Config.ExtractorMode != "remote" {
 			ginkgo.Skip("remote extractor not enabled for this environment")
 		}
 
 		gomega.Expect(testEnv.Config.GatewayAddress).NotTo(gomega.BeEmpty(),
-			"remote_extractor_enabled requires gateway_address")
+			`extractor_mode: "remote" requires gateway_address`)
 		utils.ResetCLIState()
 
 		tempDir, err := os.MkdirTemp("", "remote-extractor-e2e-*")

--- a/tests/e2e/local/20_ai_finder_extract_test.go
+++ b/tests/e2e/local/20_ai_finder_extract_test.go
@@ -1,0 +1,209 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agntcy/dir/tests/e2e/shared/testdata"
+	"github.com/agntcy/dir/tests/e2e/shared/utils"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// Taxonomy extraction over the HTTP gateway (POST /v1/extract).
+//
+// extractText describes an agent concretely enough that both extractor backends
+// return skills and domains above the score floor rather than keywords alone.
+const extractText = "an agent that reviews source code, files defects and answers questions about a codebase"
+
+// textOverMaxLen is one rune past the max_len the handler enforces on
+// ExtractTaxonomyRequest.text.
+const textOverMaxLen = 1025
+
+// taxonomyVersions are the OASF schema versions the extractor draws classes
+// from, newest first, kept in step with taxonomy_versions in the extractor asset
+// manifest. Each maps to a testdata record that already validates under it.
+//
+// One extraction mixes versions freely, and ExtractTaxonomyRequest carries no
+// version, so each returned class is checked against every version and has to be
+// recognised by at least one. OASF renamed whole trees between 1.0.0 and 1.1.0,
+// so a single response can hold classes no single version accepts together: for
+// the phrase below, the skills split across 1.1.0 and 1.0.0 and so do the
+// domains. Probing classes together would make this spec fail whenever the
+// extractor's picks happen to straddle that boundary.
+var taxonomyVersions = []string{"1.1.0", "1.0.0", "0.8.0", "0.7.0"}
+
+// probeBase returns a testdata record that validates under the given schema
+// version. Building each probe on one of these keeps every version's own record
+// shape out of this test — locators, for one, took a single `url` before 1.0.0
+// and a `urls` list after — so the class under test is the only thing a
+// rejection can be about.
+func probeBase(version string) []byte {
+	switch version {
+	case "1.1.0":
+		return testdata.ExpectedRecordV110JSON
+	case "1.0.0":
+		return testdata.ExpectedRecordV100JSON
+	case "0.8.0":
+		return testdata.ExpectedRecordV080V4JSON
+	case "0.7.0":
+		return testdata.ExpectedRecordV070JSON
+	}
+
+	return nil
+}
+
+var _ = ginkgo.Describe("AI Finder ExtractTaxonomy HTTP API", func() {
+	ginkgo.BeforeEach(func() {
+		utils.ResetCLIState()
+		skipUnlessExtractorGateway()
+	})
+
+	ginkgo.It("returns scored skills and domains for a descriptive phrase", func(ctx ginkgo.SpecContext) {
+		resp := postExtract(ctx, extractText)
+
+		gomega.Expect(resp.Skills).NotTo(gomega.BeEmpty(), "extractor should return at least one skill")
+		gomega.Expect(resp.Domains).NotTo(gomega.BeEmpty(), "extractor should return at least one domain")
+
+		assertScoredClasses(resp.Skills, "skill")
+		assertScoredClasses(resp.Domains, "domain")
+	})
+
+	ginkgo.It("returns class names that exist in the OASF taxonomy", func(ctx ginkgo.SpecContext) {
+		// The extractor's own tests can only check it against its own assets.
+		// Pushing a record built from what it returned checks it against the
+		// node's configured OASF schema endpoint instead, which rejects an
+		// unknown class id or name outright. That is the property that makes the
+		// suggestions usable: a class the schema does not recognise cannot be
+		// put on a record, so offering it would be a dead end.
+		//
+		// Every returned class is checked, not just the best one. The endpoint
+		// offers the whole list, so a bogus class at any rank is a bogus
+		// suggestion, and the lower ranks are where the taxonomy versions mix.
+		resp := postExtract(ctx, extractText)
+
+		gomega.Expect(resp.Skills).NotTo(gomega.BeEmpty())
+		gomega.Expect(resp.Domains).NotTo(gomega.BeEmpty())
+
+		tempDir, err := os.MkdirTemp("", "ai-finder-extract-test")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		defer func() { _ = os.RemoveAll(tempDir) }()
+
+		for i, skill := range resp.Skills {
+			assertClassIsInTaxonomy(tempDir, "skill", i, skill)
+		}
+
+		for i, domain := range resp.Domains {
+			assertClassIsInTaxonomy(tempDir, "domain", i, domain)
+		}
+	})
+
+	ginkgo.It("rejects empty text with HTTP 400", func(ctx ginkgo.SpecContext) {
+		status, _ := gatewayPostJSON(ctx, "/v1/extract", map[string]string{"text": "   "})
+
+		gomega.Expect(status).To(gomega.Equal(http.StatusBadRequest))
+	})
+
+	ginkgo.It("rejects over-long text with HTTP 400", func(ctx ginkgo.SpecContext) {
+		status, _ := gatewayPostJSON(ctx, "/v1/extract", map[string]string{
+			"text": strings.Repeat("a", textOverMaxLen),
+		})
+
+		gomega.Expect(status).To(gomega.Equal(http.StatusBadRequest))
+	})
+})
+
+// assertScoredClasses checks the shape and ordering of one returned class list:
+// hierarchical names, real ids, scores inside (0,1], tiers starting at 1, and
+// descending score, which is the order callers rank suggestions by.
+func assertScoredClasses(classes []scoredClass, kind string) {
+	ginkgo.GinkgoHelper()
+
+	for i, cl := range classes {
+		gomega.Expect(cl.Name).NotTo(gomega.BeEmpty(), "%s %d should have a name", kind, i)
+		gomega.Expect(cl.Name).To(gomega.ContainSubstring("/"),
+			"%s %q should be a hierarchical OASF class name", kind, cl.Name)
+		gomega.Expect(cl.ID).To(gomega.BeNumerically(">", 0), "%s %q should have an OASF uid", kind, cl.Name)
+		gomega.Expect(cl.Score).To(gomega.BeNumerically(">", 0), "%s %q should have a positive score", kind, cl.Name)
+		gomega.Expect(cl.Score).To(gomega.BeNumerically("<=", 1), "%s %q score should be normalised", kind, cl.Name)
+		gomega.Expect(cl.Tier).To(gomega.BeNumerically(">=", 1), "%s %q should have a tier", kind, cl.Name)
+
+		if i > 0 {
+			gomega.Expect(cl.Score).To(gomega.BeNumerically("<=", classes[i-1].Score),
+				"%ss should be returned in descending score order", kind)
+		}
+	}
+}
+
+// assertClassIsInTaxonomy pushes a record carrying one extracted class and
+// requires at least one OASF schema version to accept it. The node validates a
+// push against its configured schema endpoint, which rejects an unknown class id
+// or name, so a class no version defines fails every attempt. Accepted records
+// are deleted again.
+//
+// One class per record, because a response can hold classes that no single
+// version accepts together. rank is the class's position in the response, so a
+// failure names which suggestion was bad.
+func assertClassIsInTaxonomy(dir, kind string, rank int, class scoredClass) {
+	ginkgo.GinkgoHelper()
+
+	label := fmt.Sprintf("%s-%d", kind, rank)
+
+	for _, version := range taxonomyVersions {
+		path := filepath.Join(dir, label+"-"+version+".json")
+		writeTaxonomyProbeRecord(path, version, label, kind+"s", class)
+
+		cid, err := testEnv.CLI.Push(path).WithArgs("--output", "raw").SuppressStderr().Execute()
+		if err == nil && strings.TrimSpace(cid) != "" {
+			_, _ = testEnv.CLI.Delete(strings.TrimSpace(cid)).Execute()
+
+			return
+		}
+	}
+
+	ginkgo.Fail(fmt.Sprintf(
+		"extracted %s %d, %q (id %d), was rejected by every OASF version tried (%s), "+
+			"so it is not a class any of them define",
+		kind, rank, class.Name, class.ID, strings.Join(taxonomyVersions, ", ")))
+}
+
+// writeTaxonomyProbeRecord writes a probe record for one class, built from the
+// testdata record that already validates under this schema version so nothing
+// but the class can be rejected. field is "skills" or "domains" and is replaced
+// wholesale; the base record's own value for the other one is left in place,
+// which is what gives a domain probe a skill the same version recognises —
+// skills are required, and the base's are valid there by construction.
+//
+// Modules are dropped. The record only has to validate, and without one it has
+// no catalog projection, so a probe can never turn up in the search specs'
+// results even if a delete is lost.
+func writeTaxonomyProbeRecord(path, schemaVersion, label, field string, class scoredClass) {
+	ginkgo.GinkgoHelper()
+
+	base := probeBase(schemaVersion)
+	gomega.Expect(base).NotTo(gomega.BeNil(), "no probe base record for OASF version %s", schemaVersion)
+
+	var doc map[string]any
+	gomega.Expect(json.Unmarshal(base, &doc)).To(gomega.Succeed())
+
+	// Renamed so the probe never shares a CID with the same testdata pushed
+	// elsewhere in the suite, and so a leaked probe is identifiable.
+	doc["name"] = "e2e_extract_taxonomy_probe_" + label + "_" + strings.ReplaceAll(schemaVersion, ".", "_")
+	doc["description"] = "Record used only to check an extracted OASF class against the schema"
+	doc[field] = []map[string]any{{"name": class.Name, "id": class.ID}}
+
+	delete(doc, "modules")
+
+	data, err := json.Marshal(doc)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	gomega.Expect(os.WriteFile(path, data, 0o600)).To(gomega.Succeed())
+}

--- a/tests/e2e/local/ai_finder_http_test.go
+++ b/tests/e2e/local/ai_finder_http_test.go
@@ -1,0 +1,205 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+// HTTP helpers shared by the AI Finder gateway specs (13, 18 and 19).
+//
+// The gateway marshals with UseProtoNames disabled, so response fields arrive
+// camelCased ("nextPageToken", "totalCount", "displayName") rather than under
+// their proto names. The structs below follow the wire, not the proto.
+
+// searchResponse is the JSON shape of catalogv1.SearchAgentsResponse.
+type searchResponse struct {
+	Results       []catalogEntry `json:"results"`
+	NextPageToken string         `json:"nextPageToken"`
+	TotalCount    uint32         `json:"totalCount"`
+}
+
+// catalogEntry is the subset of catalogv1.CatalogEntry the search specs assert on.
+type catalogEntry struct {
+	Identifier  string `json:"identifier"`
+	DisplayName string `json:"displayName"`
+}
+
+// scoredClass is the JSON shape of catalogv1.ScoredClass.
+type scoredClass struct {
+	ID    uint32  `json:"id"`
+	Name  string  `json:"name"`
+	Score float64 `json:"score"`
+	Tier  uint32  `json:"tier"`
+}
+
+// extractResponse is the JSON shape of catalogv1.ExtractTaxonomyResponse.
+type extractResponse struct {
+	Skills   []scoredClass `json:"skills"`
+	Domains  []scoredClass `json:"domains"`
+	Keywords []string      `json:"keywords"`
+}
+
+// cids returns the record CIDs of the results, in the order the endpoint
+// returned them. Rank order is the contract for POST /v1/search, so the specs
+// compare these slices rather than sets.
+func (r searchResponse) cids() []string {
+	out := make([]string, 0, len(r.Results))
+	for _, e := range r.Results {
+		out = append(out, entryCID(e.Identifier))
+	}
+
+	return out
+}
+
+// entryCID recovers the record CID from a catalog entry identifier URN
+// ("urn:ai:<host>:cid:<cid>"), returning the input unchanged when it is not a URN.
+func entryCID(identifier string) string {
+	if _, after, ok := strings.Cut(identifier, ":cid:"); ok {
+		return after
+	}
+
+	return identifier
+}
+
+// gatewayGet issues a GET against the deployed HTTP gateway and returns the
+// status code and raw response body. rawQuery is appended as the query string
+// when non-empty.
+func gatewayGet(ctx context.Context, path, rawQuery string) (int, string) {
+	ginkgo.GinkgoHelper()
+
+	target := testEnv.Config.GatewayAddress + path
+	if rawQuery != "" {
+		target += "?" + rawQuery
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return doGateway(req)
+}
+
+// gatewayPostJSON issues a JSON POST against the deployed HTTP gateway and
+// returns the status code and raw response body.
+func gatewayPostJSON(ctx context.Context, path string, payload any) (int, string) {
+	ginkgo.GinkgoHelper()
+
+	body, err := json.Marshal(payload)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		testEnv.Config.GatewayAddress+path, bytes.NewReader(body))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return doGateway(req)
+}
+
+func doGateway(req *http.Request) (int, string) {
+	ginkgo.GinkgoHelper()
+
+	status, body, err := tryGateway(req)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return status, body
+}
+
+// tryGateway performs the request and returns the transport error instead of
+// failing, for callers polling an endpoint that may not be serving yet. The
+// asserting helpers above would abort a gomega.Eventually on the first refused
+// connection rather than retry.
+func tryGateway(req *http.Request) (int, string, error) {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", fmt.Errorf("%s %s: %w", req.Method, req.URL, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, "", fmt.Errorf("read %s %s response: %w", req.Method, req.URL, err)
+	}
+
+	return resp.StatusCode, string(body), nil
+}
+
+// tryGatewayPostJSON is gatewayPostJSON for pollers: it reports a transport
+// failure as an error rather than failing the spec outright.
+func tryGatewayPostJSON(ctx context.Context, path string, payload any) (int, string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		testEnv.Config.GatewayAddress+path, bytes.NewReader(body))
+	if err != nil {
+		return 0, "", fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return tryGateway(req)
+}
+
+// postSearch calls POST /v1/search and requires HTTP 200, returning the decoded
+// response. Specs asserting on failures use gatewayPostJSON directly.
+func postSearch(ctx context.Context, req searchRequest) searchResponse {
+	ginkgo.GinkgoHelper()
+
+	status, body := gatewayPostJSON(ctx, "/v1/search", req)
+	gomega.Expect(status).To(gomega.Equal(http.StatusOK), "POST /v1/search failed: %s", body)
+
+	var out searchResponse
+	gomega.Expect(json.Unmarshal([]byte(body), &out)).To(gomega.Succeed())
+
+	return out
+}
+
+// searchRequest is the JSON shape of catalogv1.SearchAgentsRequest. pageSize and
+// pageToken are omitted when unset so the server applies its own defaults.
+type searchRequest struct {
+	Query     string `json:"query"`
+	PageSize  uint32 `json:"pageSize,omitempty"`
+	PageToken string `json:"pageToken,omitempty"`
+}
+
+// postExtract calls POST /v1/extract and requires HTTP 200, returning the
+// decoded response.
+func postExtract(ctx context.Context, text string) extractResponse {
+	ginkgo.GinkgoHelper()
+
+	status, body := gatewayPostJSON(ctx, "/v1/extract", map[string]string{"text": text})
+	gomega.Expect(status).To(gomega.Equal(http.StatusOK), "POST /v1/extract failed: %s", body)
+
+	var out extractResponse
+	gomega.Expect(json.Unmarshal([]byte(body), &out)).To(gomega.Succeed())
+
+	return out
+}
+
+// skipUnlessExtractorGateway skips a spec unless this environment deploys the
+// HTTP gateway with an OASF extractor behind it.
+func skipUnlessExtractorGateway() {
+	ginkgo.GinkgoHelper()
+
+	if testEnv.Config.GatewayAddress == "" {
+		ginkgo.Skip("HTTP gateway address not configured for this environment")
+	}
+
+	if testEnv.Config.ExtractorMode == "" {
+		ginkgo.Skip("no OASF extractor configured for this environment's gateway")
+	}
+}

--- a/tests/e2e/local/config/config.go
+++ b/tests/e2e/local/config/config.go
@@ -15,9 +15,28 @@ type Config struct {
 	// this environment, in which case AI Finder HTTP tests are skipped.
 	GatewayAddress string `json:"gateway_address,omitempty" mapstructure:"gateway_address"`
 
-	// RemoteExtractorEnabled requires the gateway to use a deployed OASF extractor.
-	// Disabled environments skip the remote extractor HTTP tests.
-	RemoteExtractorEnabled bool `json:"remote_extractor_enabled,omitempty" mapstructure:"remote_extractor_enabled"`
+	// ExtractorMode names the OASF extractor backend the deployed gateway
+	// resolves in this environment: "local" for in-process assets provisioned
+	// by `dirctl init`, "remote" for a gRPC OASF-SDK server. Empty means the
+	// environment declares no extractor, so extractor-backed specs skip.
+	//
+	// The extractor-backed specs read this rather than probing the asset
+	// directory. Probing cannot tell the two apart: a developer machine that has
+	// run `dirctl init` has local assets on disk even when the gateway under
+	// test is wired to a remote server.
+	//
+	// It also decides whether the search parity spec can run. Comparing
+	// `dirctl search` against POST /v1/search only means something when both
+	// reach the same extractor, which is true in "local" mode and not under
+	// kind, where the OASF-SDK Service is ClusterIP-only and the CLI cannot
+	// reach the backend the gateway uses.
+	//
+	// This replaces the earlier remote_extractor_enabled boolean, which said
+	// only whether the backend was remote. Two fields for one fact let an
+	// environment set one and not the other, and the specs disagree about
+	// whether to skip; the mode also has to distinguish "local" from "no
+	// extractor", which a boolean cannot.
+	ExtractorMode string `json:"extractor_mode,omitempty" mapstructure:"extractor_mode"`
 
 	// CliPath is the path to the CLI binary.
 	CliPath string `json:"cli_path,omitempty" mapstructure:"cli_path"`

--- a/tests/e2e/local/local_suite_test.go
+++ b/tests/e2e/local/local_suite_test.go
@@ -5,7 +5,9 @@ package local
 
 import (
 	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	localconfig "github.com/agntcy/dir/tests/e2e/local/config"
 	"github.com/agntcy/dir/tests/e2e/shared/config"
@@ -43,6 +45,42 @@ func TestLocalE2E(t *testing.T) {
 	ginkgo.RunSpecs(t, "Local E2E Test Suite")
 }
 
+// extractorReadyTimeout bounds the wait for the gateway's extractor to answer.
+// The remote backend fetches the taxonomy from the OASF schema endpoint on every
+// start and cannot serve until it finishes, which takes roughly a minute. The
+// local backend answers as soon as the daemon is up, so this only ever costs
+// time under kind.
+//
+// Waiting once here rather than per spec keeps a cold extractor pod from
+// failing whichever extractor-backed spec happens to run first.
+const extractorReadyTimeout = 3 * time.Minute
+
 var _ = ginkgo.BeforeSuite(func(ctx context.Context) {
 	utils.WaitForGrpcServerReady(ctx, testEnv.Config.ServerAddress, "")
+
+	waitForExtractorReady(ctx)
 })
+
+// waitForExtractorReady blocks until POST /v1/extract answers, so the
+// extractor-backed specs fail on behaviour rather than on a backend that had not
+// finished starting. It is a no-op in environments with no gateway or no
+// declared extractor.
+func waitForExtractorReady(ctx context.Context) {
+	if testEnv.Config.GatewayAddress == "" || testEnv.Config.ExtractorMode == "" {
+		return
+	}
+
+	ginkgo.GinkgoWriter.Printf("waiting for the %s OASF extractor behind %s\n",
+		testEnv.Config.ExtractorMode, testEnv.Config.GatewayAddress)
+
+	gomega.Eventually(func(g gomega.Gomega) {
+		status, body, err := tryGatewayPostJSON(ctx, "/v1/extract", map[string]string{
+			"text": "an agent that reviews source code",
+		})
+		g.Expect(err).NotTo(gomega.HaveOccurred(), "gateway not reachable yet")
+		g.Expect(status).To(gomega.Equal(http.StatusOK), "extractor not ready yet: %s", body)
+	}).WithContext(ctx).
+		WithTimeout(extractorReadyTimeout).
+		WithPolling(5*time.Second).
+		Should(gomega.Succeed(), "the gateway's %s extractor never became ready", testEnv.Config.ExtractorMode)
+}

--- a/tests/e2e/local/testenv/kind/test-config.yaml
+++ b/tests/e2e/local/testenv/kind/test-config.yaml
@@ -1,8 +1,18 @@
 local:
   server_address: "localhost:18888"
   metrics_address: "http://localhost:18889/metrics"
+  # The chart deploys the gateway on nodePort 30889, which kind-cluster.yaml maps
+  # to host port 18892.
   gateway_address: "http://localhost:18892"
-  remote_extractor_enabled: true
+  # dir-chart-values.yaml sets oasf-sdk.enabled, and the chart auto-wires
+  # extractor.remote_addr to that Service, so the gateway resolves the remote
+  # backend.
+  # This is the only environment covering the remote backend. The search parity
+  # spec skips here: the OASF-SDK Service is ClusterIP-only, so the host CLI
+  # cannot reach the backend the gateway uses and the two rankings are not
+  # comparable. Parity is asserted in the "local" environment, where both sides
+  # load the same provisioned assets.
+  extractor_mode: "remote"
   # cli_path: "/path/to/cli"
   cli_extra_args:
   - "--server-addr=localhost:18888"

--- a/tests/e2e/local/testenv/local/Taskfile.testenv.yml
+++ b/tests/e2e/local/testenv/local/Taskfile.testenv.yml
@@ -11,6 +11,16 @@ includes:
       DIRCTL_DATA_PATH: "/tmp/e2e-local-local-testenv"
       DIRCTL_CONFIG_PATH: "{{.ROOT_DIR}}/tests/e2e/local/testenv/local/dir-daemon-config.yaml"
       DIRCTL_LOGFILE_PATH:  "{{.ROOT_DIR}}/tests/e2e/local/testenv/local/logs.daemon.log"
+      # Pin the CLI to the same extractor this daemon resolves. The daemon reads
+      # its own from dir-daemon-config.yaml, which sets no extractor block and so
+      # takes the default asset dir and OASF URL. `dirctl init` fills any flag
+      # left unset from the machine-wide saved config — asset dir, OASF URL and
+      # remote address alike — so on a machine carrying custom saved values a
+      # bare init would provision and load a different extractor than the daemon
+      # uses. Passing all three empty resolves each back to its default, which is
+      # what the daemon has. The readiness gate and the search parity spec both
+      # depend on the two sides agreeing.
+      DIRCTL_INIT_ARGS: "--extractor-remote-addr= --asset-dir= --oasf-url="
 
 tasks:
   up:

--- a/tests/e2e/local/testenv/local/test-config.yaml
+++ b/tests/e2e/local/testenv/local/test-config.yaml
@@ -2,6 +2,10 @@ local:
   server_address: "localhost:19888"
   metrics_address: "http://localhost:19889/metrics"
   gateway_address: "http://localhost:19892"
+  # The daemon resolves the in-process extractor from the assets `dirctl init`
+  # provisions (the testenv runs it), and the CLI reads the same saved config,
+  # so both sides of the search parity spec share one backend.
+  extractor_mode: "local"
   # cli_path: "/path/to/cli"
   cli_extra_args:
   - "--server-addr=localhost:19888"

--- a/tests/modules/Taskfile.setup-dir-node.yml
+++ b/tests/modules/Taskfile.setup-dir-node.yml
@@ -15,6 +15,13 @@ version: "3"
 #   DIRCTL_LOGFILE_PATH: (Optional) Path to a log file for the Directory daemon output (default: logs to stdout)
 #   GOCOVERDIR: (Optional) If set, this environment variable will be passed to the daemon process
 #               to enable Go test coverage collection.
+#   DIRCTL_PROVISION_EXTRACTOR: (Optional) Set to "false" to skip `dirctl init` entirely
+#               (default: "true").
+#   DIRCTL_INIT_ARGS: (Optional) Extra flags for `dirctl init`. Use this to pin the
+#               extractor explicitly, e.g. "--extractor-remote-addr= --asset-dir= --oasf-url="
+#               to force the defaults. Being explicit matters: `dirctl init` fills every
+#               extractor flag left unset from the machine-wide saved config, so a bare run
+#               inherits whatever that machine was last pointed at.
 #
 
 tasks:
@@ -32,6 +39,9 @@ tasks:
 
       # Set to "false" to skip OASF extractor provisioning.
       DIRCTL_PROVISION_EXTRACTOR: '{{ .DIRCTL_PROVISION_EXTRACTOR | default "true" }}'
+
+      # Extra flags for `dirctl init` (see header).
+      DIRCTL_INIT_ARGS: '{{ .DIRCTL_INIT_ARGS | default "" }}'
     env:
       GOCOVERDIR: '{{ .GOCOVERDIR }}'
     cmds:
@@ -39,9 +49,11 @@ tasks:
           # Ensure the coverage directory exists
           {{ if .GOCOVERDIR }}mkdir -p {{ .GOCOVERDIR }}{{end}}
 
-          # Provision the OASF extractor model for natural-language search tests.
-          # Skipped when DIRCTL_PROVISION_EXTRACTOR=false.
-          {{ if eq .DIRCTL_PROVISION_EXTRACTOR "true" }}{{ .DIRCTL_BIN }} init --yes{{end}}
+          # Configure the OASF extractor for natural-language search tests.
+          # Skipped when DIRCTL_PROVISION_EXTRACTOR=false. With
+          # --extractor-remote-addr in DIRCTL_INIT_ARGS this only saves the
+          # address and downloads nothing.
+          {{ if eq .DIRCTL_PROVISION_EXTRACTOR "true" }}{{ .DIRCTL_BIN }} init --yes {{ .DIRCTL_INIT_ARGS }}{{end}}
 
           # Ensure the data directory exists
           mkdir -p {{ .DIRCTL_DATA_PATH }}


### PR DESCRIPTION
Adds end-to-end coverage for the two extractor-backed gateway endpoints against a real node. The handler unit tests drive a fake extractor, so they cannot catch a gateway that resolved no backend, dialed the wrong address, or ranks differently from `dirctl search`.

## `POST /v1/search` — `18_ai_finder_search_test.go`

- Relevance-ranked entries for a free-text query, each identified by catalog URN, with a record matching no signal left out of the ranked set.
- Ranking by number of signals matched. The two seeds share a description and carry names holding none of the query's keywords, so their keyword surface is identical and the only difference is whether they carry the extracted skill. Holding that equal is load-bearing: a keyword signal scores 1.0 against this skill's 0.573, so varying the descriptions instead lets an extra keyword hit outweigh the skill hit — correct behaviour, but it tells you nothing about the skill.
- Stable ranking across repeated identical requests, guarding the tie-determinism total order.
- Pagination: page 1 and page 2 are disjoint and reconstruct a prefix of the unpaged order, and the last page carries no continuation token.
- **Parity with `dirctl search`**, compared over the seeded records only. The two do not see the same record universe — `recordSearcher` restricts candidates to `KnownCatalogModuleNames()` while the CLI's `clientSearcher` does not — so the CLI legitimately returns extra non-projectable CIDs. Scoring is per-CID, so the relative order of the shared records is preserved, and that shared ordering is the assertable contract.
- Empty and over-long queries rejected with 400.

## `POST /v1/extract` — `20_ai_finder_extract_test.go`

- Scored skills and domains with hierarchical names, real OASF uids, normalised scores and descending order.
- Returned classes checked against the node's own configured OASF schema endpoint by pushing a record built from them. Verified out of band that validation does reject an unknown class (`id_unknown` / `name_unknown`), so this is a real assertion rather than a shape check. Class names are version-scoped — `software_engineering/code_quality/code_review` validates only under 1.1.0, its `natural_language_processing/…` predecessor only under 1.0.0 — and `ExtractTaxonomyRequest` carries no version, so the probe tries each of the four taxonomy versions the extractor draws from and requires one to accept. Only the top skill and domain are probed together: a single extraction mixes versions at lower ranks, but the best match in each list comes from the same taxonomy.
- Empty and over-long text rejected with 400.

## Where each backend is covered

| Backend | Environment | Covers |
|---|---|---|
| local | `local:local` | in-process assets, plus the parity assertion |
| remote | `local:kind` | the OASF-SDK Service the chart wires up, added by #2118 |
| none | `daemon:default` | both endpoints must answer 503 |

Both spec files run wherever the environment declares an extractor, so they exercise the local backend under `local:local` and the remote one under the Kind job. The parity spec skips outside local mode: under Kind the OASF-SDK Service is ClusterIP-only and the CLI cannot reach the gateway's backend, so the two rankings are not comparable.

An earlier revision of this PR added a third environment that reached a remote extractor through a plain `oasf-sdk` container, with no cluster. It was dropped: it duplicated the remote coverage the Kind job already provides, and the two backends were measured returning byte-identical scores, tiers and ids for the same query, so re-asserting the contract against a container added little.

For the no-extractor case, `daemon/default` now enables the gateway with its extractor asset dir pointed at a path that does not exist. `02_no_extractor_test.go` asserts both endpoints answer 503 with the "no OASF extractor is configured" message, that `GET /v1/agents` still serves — so a 503 means the extractor is missing rather than the gateway being down — and that an empty query is still a 400, pinning argument validation ahead of the extractor check.

## Rebase onto #2118

That PR landed overlapping Kind coverage while this was in review, and the resolution is not purely textual:

- Collapses its `remote_extractor_enabled` boolean into `extractor_mode`, updating the single call site in `19_remote_extractor_test.go`. Two fields for one fact let an environment set only one and have the specs disagree about skipping, and the mode also has to tell "local" apart from "no extractor", which a boolean cannot.
- Numbers the extract specs `20_` so #2118 keeps the `19_` slot.
- The suite-level readiness gate added here also covers Kind, so its specs no longer wait on a cold extractor pod one spec at a time.

## Also

- `setup-dir-node` gains `DIRCTL_INIT_ARGS`, and `local:local` uses it to force the in-process backend for the CLI. `dirctl init` inherits the machine-wide saved remote address whenever the flag is left unset, which would otherwise leave the CLI dialing an OASF-SDK server while the daemon uses local assets — and the parity spec compares the two.
- `daemon/default` skips extractor provisioning, dropping an 89 MB download from three cross-platform runners that never used it.

## Two deviations from the issue

- **"Empty-extraction fallback returns name-substring matches" is stale.** `SearchAgents` now rejects an empty extraction with `InvalidArgument`, per `TestSearchAgents_EmptyExtractionIsRejected`. The invalid-input specs assert the real contract. Driving that branch through a real extractor is not possible either — every non-empty text yields keyword signals — so it stays covered by the unit test.
- **Parity is asserted only where the CLI and gateway share an extractor**, which is local mode.

## Verification

| Suite | Result |
|---|---|
| `e2e:test:local:local` | 231 passed, 4 skipped |
| `e2e:test:daemon:default` | 8 passed, 2 skipped |
| `e2e:test:daemon:external` | 6 passed, 4 skipped |
| `task test` | 72 packages ok |
| `task lint` | 0 issues |

`e2e:test:local:kind` was not run locally — it needs locally built images and the Kind toolchain. Its two new callers are the spec files here, which pass against the same `oasf-sdk:v1.3.0` image under `local:local` and against a container during development of the dropped environment; CI runs the job on this PR.

## Noted, not fixed

`15_nl_search_test.go` gates on `~/.agntcy/oasf-sdk/manifest.json`, which is missing the `extractor` subdirectory `extractor.DefaultAssetDir` provisions into, so that spec has always skipped — including in CI. Correcting the path makes it run and push `testdata/directory-record.json`, which then contends with `14_skill_record_test.go`: both use the record name `org.agntcy/directory`, that testdata carries a stale `application/agentskill+md` artifact media type where the daemon now emits `application/agent-skills+md`, and spec 14 resolves the name with `--limit 1`. Ginkgo randomises top-level containers, so the collision is order-dependent. Fixing it properly needs the testdata corrected and spec 14 taught to pick the record it means, so it is left alone here with a comment rather than half-done. The CLI free-text path is meanwhile covered by the parity spec.

Closes #1909
