### PR TITLE
feat(cli/dir): add semver comparison and the install manifest

### DIFF
--- a/api/exportfmt/exportfmt_test.go
+++ b/api/exportfmt/exportfmt_test.go
@@ -434,6 +434,78 @@ func TestSkillMarkdownFromArchive(t *testing.T) {
 	assert.Equal(t, string(plain), md)
 }
 
+func TestSkillBundleFiles(t *testing.T) {
+	t.Run("lists a bundle's regular files in archive order", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		gzw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gzw)
+
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: "references/", Mode: 0o755, Typeflag: tar.TypeDir,
+		}))
+
+		for _, name := range []string{"SKILL.md", "references/api.md"} {
+			content := []byte("body of " + name)
+			require.NoError(t, tw.WriteHeader(&tar.Header{
+				Name: name, Mode: 0o600, Size: int64(len(content)), Typeflag: tar.TypeReg,
+			}))
+			_, err := tw.Write(content)
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, tw.Close())
+		require.NoError(t, gzw.Close())
+
+		files, err := exportfmt.SkillBundleFiles(buf.Bytes())
+		require.NoError(t, err)
+		// The directory entry is not a file, so it is not listed.
+		assert.Equal(t, []string{"SKILL.md", filepath.Join("references", "api.md")}, files)
+	})
+
+	t.Run("reports the one file a plain SKILL.md artifact extracts to", func(t *testing.T) {
+		files, err := exportfmt.SkillBundleFiles([]byte("---\nname: plain\n---\n"))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"SKILL.md"}, files)
+	})
+
+	t.Run("rejects an empty archive", func(t *testing.T) {
+		_, err := exportfmt.SkillBundleFiles(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("rejects a bundle with no regular files", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		gzw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gzw)
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: "refs/", Mode: 0o755, Typeflag: tar.TypeDir}))
+		require.NoError(t, tw.Close())
+		require.NoError(t, gzw.Close())
+
+		_, err := exportfmt.SkillBundleFiles(buf.Bytes())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no regular files")
+	})
+
+	t.Run("rejects a path that escapes the extraction directory", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		gzw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gzw)
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: "../escape.txt", Mode: 0o600, Size: 0, Typeflag: tar.TypeReg,
+		}))
+		require.NoError(t, tw.Close())
+		require.NoError(t, gzw.Close())
+
+		_, err := exportfmt.SkillBundleFiles(buf.Bytes())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "non-local")
+	})
+}
+
 func TestSkillBundleMatchesDir(t *testing.T) {
 	archive, err := base64.StdEncoding.DecodeString(skillBundleArchiveBase64(t))
 	require.NoError(t, err)

--- a/api/exportfmt/skill_bundle_extract.go
+++ b/api/exportfmt/skill_bundle_extract.go
@@ -50,6 +50,52 @@ func SkillMarkdownFromArchive(archive []byte) (string, error) {
 	return "", fmt.Errorf("archive does not contain %q", skillManifestFile)
 }
 
+// SkillBundleFiles lists the regular files a skill artifact holds, as paths
+// relative to the directory ExtractSkillBundleArchive writes them into, in
+// archive order. A plain-text SKILL.md artifact reports the single file the
+// extractor creates for it, so both artifact shapes answer the same question.
+//
+// TarEntry's fields are unexported, so this is the one accessor callers outside
+// this package have for entry names. `dirctl install` records the list in its
+// install manifest, which is what lets a later uninstall or upgrade remove
+// exactly the files that were written without re-fetching a record that may
+// since have been garbage-collected upstream.
+func SkillBundleFiles(archive []byte) ([]string, error) {
+	if len(archive) == 0 {
+		return nil, fmt.Errorf("skill bundle archive is empty")
+	}
+
+	if !isGzipArchive(archive) {
+		return []string{skillManifestFile}, nil
+	}
+
+	iterator, err := NewTarIterator(archive, WithTypeflag(tar.TypeReg))
+	if err != nil {
+		return nil, fmt.Errorf("invalid gzip archive: %w", err)
+	}
+
+	var files []string
+
+	for entry, err := range iterator {
+		if err != nil {
+			return nil, fmt.Errorf("read tar entry: %w", err)
+		}
+
+		rel, err := localTarEntryPath(entry.header.Name)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tar entry %q: %w", entry.header.Name, err)
+		}
+
+		files = append(files, rel)
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("archive contains no regular files")
+	}
+
+	return files, nil
+}
+
 // SkillBundleMatchesDir reports whether dir already contains the same files as archive.
 func SkillBundleMatchesDir(archive []byte, dir string) (bool, error) {
 	if len(archive) == 0 {

--- a/api/exportfmt/skill_bundle_extract.go
+++ b/api/exportfmt/skill_bundle_extract.go
@@ -57,9 +57,9 @@ func SkillMarkdownFromArchive(archive []byte) (string, error) {
 //
 // TarEntry's fields are unexported, so this is the one accessor callers outside
 // this package have for entry names. `dirctl install` records the list in its
-// install manifest, which is what lets a later uninstall or upgrade remove
-// exactly the files that were written without re-fetching a record that may
-// since have been garbage-collected upstream.
+// install manifest, so that a later manifest-driven uninstall or upgrade can
+// remove exactly the files that were written without re-fetching a record that
+// may since have been garbage-collected upstream.
 func SkillBundleFiles(archive []byte) ([]string, error) {
 	if len(archive) == 0 {
 		return nil, fmt.Errorf("skill bundle archive is empty")

--- a/cli/cmd/install/batch.go
+++ b/cli/cmd/install/batch.go
@@ -99,29 +99,45 @@ func formatSkippedSummary(skipped []skippedRecord) string {
 }
 
 type installTarget struct {
-	label string
-	arts  agentinstall.Artifacts
+	label  string
+	record *corev1.Record
+	arts   agentinstall.Artifacts
 }
 
 type recordApplyFn func(env agentcfg.Env, arts agentinstall.Artifacts, agents []agentcfg.Agent, scope agentcfg.Scope, dryRun bool) []agentcfg.Outcome
 
-func buildTaggedOutcomes(
+// applyTargets applies every target and returns the outcomes twice over: kept
+// per record, which is what a manifest row is built from, and flattened for the
+// plan and summary. Both views come from one pass, so what gets recorded is
+// exactly what the user was shown.
+func applyTargets(
 	env agentcfg.Env,
 	targets []installTarget,
 	selected []agentcfg.Agent,
 	scope agentcfg.Scope,
 	dryRun bool,
 	apply recordApplyFn,
-) []agentcfg.Outcome {
+) ([]applied, []agentcfg.Outcome) {
+	items := make([]applied, 0, len(targets))
+
 	var outcomes []agentcfg.Outcome
 
 	for _, target := range targets {
 		recordOutcomes := apply(env, target.arts, selected, scope, dryRun)
 		tagOutcomes(recordOutcomes, target.label)
+
+		items = append(items, applied{
+			record: target.record,
+			arts:   target.arts,
+			// Batch mode installs whatever the search matched, so there is no
+			// explicit :version to imply a pin; only --pin can ask for one.
+			pinned:   opts.pin,
+			outcomes: recordOutcomes,
+		})
 		outcomes = append(outcomes, recordOutcomes...)
 	}
 
-	return outcomes
+	return items, outcomes
 }
 
 func pullBatchRecords(cmd *cobra.Command, queries []*searchv1.RecordQuery) ([]*corev1.Record, error) {
@@ -154,7 +170,7 @@ func buildBatchTargets(cmd *cobra.Command, recs []*corev1.Record) ([]installTarg
 			continue
 		}
 
-		targets = append(targets, installTarget{label: label, arts: arts})
+		targets = append(targets, installTarget{label: label, record: record, arts: arts})
 	}
 
 	return targets, skipped
@@ -193,7 +209,12 @@ func confirmBatchUninstall(cmd *cobra.Command) (bool, error) {
 	return confirmBatch(cmd, "\nRemove these artifacts?")
 }
 
-func runBatch(cmd *cobra.Command, apply recordApplyFn, confirmFn func(*cobra.Command) (bool, error)) error {
+func runBatch(
+	cmd *cobra.Command,
+	apply recordApplyFn,
+	record manifestRecordFn,
+	confirmFn func(*cobra.Command) (bool, error),
+) error {
 	queries, err := requireBatchQueries()
 	if err != nil {
 		return err
@@ -221,7 +242,7 @@ func runBatch(cmd *cobra.Command, apply recordApplyFn, confirmFn func(*cobra.Com
 	printScope(cmd)
 
 	targets, skipped := buildBatchTargets(cmd, selectRecords(recs))
-	plan := buildTaggedOutcomes(env, targets, selected, scope, true, apply)
+	_, plan := applyTargets(env, targets, selected, scope, true, apply)
 
 	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 	printSkippedSummary(cmd, skipped)
@@ -239,19 +260,26 @@ func runBatch(cmd *cobra.Command, apply recordApplyFn, confirmFn func(*cobra.Com
 		return nil
 	}
 
-	outcomes := buildTaggedOutcomes(env, targets, selected, scope, opts.dryRun, apply)
+	items, outcomes := applyTargets(env, targets, selected, scope, opts.dryRun, apply)
 	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
 	printSkippedSummary(cmd, skipped)
+
+	// A dry run touched nothing, so there is nothing to record.
+	if opts.dryRun {
+		return nil
+	}
+
+	record(cmd, items, selected, scope)
 
 	return nil
 }
 
 // runBatchInstall searches for records and installs each into the selected agents.
 func runBatchInstall(cmd *cobra.Command) error {
-	return runBatch(cmd, agentinstall.Install, confirmBatchChanges)
+	return runBatch(cmd, agentinstall.Install, recordInstalls, confirmBatchChanges)
 }
 
 // runBatchUninstall searches for records and removes each from the selected agents.
 func runBatchUninstall(cmd *cobra.Command) error {
-	return runBatch(cmd, agentinstall.Uninstall, confirmBatchUninstall)
+	return runBatch(cmd, agentinstall.Uninstall, recordUninstalls, confirmBatchUninstall)
 }

--- a/cli/cmd/install/batch_test.go
+++ b/cli/cmd/install/batch_test.go
@@ -4,11 +4,14 @@
 package install
 
 import (
+	"fmt"
 	"testing"
 
 	oasfv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1alpha1"
 	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/internal/agentcfg"
 	"github.com/agntcy/dir/cli/internal/agentinstall"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,6 +93,69 @@ func TestFormatSkippedSummary(t *testing.T) {
 	require.Contains(t, out, "Skipped records")
 	require.Contains(t, out, "bare")
 	require.Contains(t, out, "no installable module")
+}
+
+func TestApplyTargetsKeepsOutcomesPerRecord(t *testing.T) {
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	opts.pin = false
+
+	targets := []installTarget{
+		{label: "a:1.0.0", record: corev1.New(&oasfv1alpha1.Record{Name: "a", Version: "1.0.0"})},
+		{label: "b:1.0.0", record: corev1.New(&oasfv1alpha1.Record{Name: "b", Version: "1.0.0"})},
+	}
+
+	// A stub apply: one outcome per call, so each record's outcomes are
+	// distinguishable in the result.
+	calls := 0
+	apply := func(_ agentcfg.Env, _ agentinstall.Artifacts, _ []agentcfg.Agent, _ agentcfg.Scope, _ bool) []agentcfg.Outcome {
+		calls++
+
+		return []agentcfg.Outcome{{
+			Agent:    "Claude Code",
+			Artifact: agentcfg.ArtifactSkill,
+			Path:     fmt.Sprintf("/skills/%d", calls),
+			Action:   agentcfg.ActionAdded,
+		}}
+	}
+
+	items, outcomes := applyTargets(agentcfg.Env{}, targets, nil, agentcfg.Global, false, apply)
+
+	// Per record, so a manifest row is built from that record's own outcomes.
+	require.Len(t, items, 2)
+	require.Len(t, items[0].outcomes, 1)
+	assert.Equal(t, "a", items[0].record.GetName())
+	assert.Equal(t, "/skills/1", items[0].outcomes[0].Path)
+	assert.Equal(t, "/skills/2", items[1].outcomes[0].Path)
+
+	// Flattened and label-tagged, which is what the plan and summary group on.
+	require.Len(t, outcomes, 2)
+	assert.Equal(t, "a:1.0.0", outcomes[0].Record)
+	assert.Equal(t, "b:1.0.0", outcomes[1].Record)
+}
+
+func TestApplyTargetsPinsOnlyWhenAsked(t *testing.T) {
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	targets := []installTarget{{label: "a", record: corev1.New(&oasfv1alpha1.Record{Name: "a"})}}
+	apply := func(_ agentcfg.Env, _ agentinstall.Artifacts, _ []agentcfg.Agent, _ agentcfg.Scope, _ bool) []agentcfg.Outcome {
+		return nil
+	}
+
+	// Batch mode has no explicit :version to imply a pin.
+	opts.pin = false
+	items, _ := applyTargets(agentcfg.Env{}, targets, nil, agentcfg.Global, false, apply)
+	require.Len(t, items, 1)
+	assert.False(t, items[0].pinned)
+
+	opts.pin = true
+	items, _ = applyTargets(agentcfg.Env{}, targets, nil, agentcfg.Global, false, apply)
+	require.Len(t, items, 1)
+	assert.True(t, items[0].pinned)
 }
 
 func TestBatchInstallSkipsUnsuitableRecords(t *testing.T) {

--- a/cli/cmd/install/flags.go
+++ b/cli/cmd/install/flags.go
@@ -27,6 +27,19 @@ func addSelectionFlags(cmd *cobra.Command, opts *options) {
 	flags.BoolVarP(&opts.yes, "yes", "y", false, "Skip the confirmation prompt")
 }
 
+// addPinFlag registers --pin on an install entry point. It is a local flag, not
+// a persistent one, so it does not appear on `install uninstall`, where holding
+// a version has no meaning.
+//
+// The usage text carries no backquotes on purpose: pflag reads a backquoted
+// word as the flag's value-type name, so "`upgrade`" would render the boolean
+// as "--pin upgrade".
+func addPinFlag(cmd *cobra.Command, opts *options) {
+	cmd.Flags().BoolVar(&opts.pin, "pin", false,
+		"Hold this package at the installed version, so a bare upgrade skips it "+
+			"(implied when the reference names an explicit :version)")
+}
+
 // scopeFromOpts maps the --project flag to the placement scope.
 func scopeFromOpts() agentcfg.Scope {
 	if opts.project {

--- a/cli/cmd/install/install.go
+++ b/cli/cmd/install/install.go
@@ -35,8 +35,12 @@ directly into the configuration of detected AI coding agents.
 
   dirctl install <cid-or-name>            detect agents, preview, confirm, install
   dirctl install run <cid-or-name>        same as above
+  dirctl install <cid-or-name> --pin      install and hold at this version
   dirctl install uninstall <cid-or-name>  remove what install added
   dirctl install list                     show detected agents and target paths
+
+Every install records what it wrote — record, version, agent, and the exact
+files and MCP server keys — in $XDG_CONFIG_HOME/dirctl/installed.json.
 
 Batch install from search filters (no positional argument):
 
@@ -78,6 +82,7 @@ Examples:
 func init() {
 	addSelectionFlags(Command, &opts)
 	addBatchFlags(Command, &opts)
+	addPinFlag(Command, &opts)
 
 	Command.AddCommand(runCmd)
 	Command.AddCommand(uninstallCmd)
@@ -103,35 +108,56 @@ func selectAgents(cmd *cobra.Command, env agentcfg.Env) ([]agentcfg.Agent, error
 }
 
 // pullAndDerive resolves the ref, pulls the record, and derives its artifacts.
-func pullAndDerive(cmd *cobra.Command, input string) (agentinstall.Artifacts, error) {
+// The record itself comes back too, because the manifest row needs the name,
+// version, and CID that Artifacts does not carry.
+func pullAndDerive(cmd *cobra.Command, input string) (applied, error) {
 	c, ok := ctxUtils.GetClientFromContext(cmd.Context())
 	if !ok {
-		return agentinstall.Artifacts{}, errors.New("failed to get client from context")
+		return applied{}, errors.New("failed to get client from context")
 	}
 
 	cid, err := reference.ResolveToCID(cmd.Context(), c, input)
 	if err != nil {
-		return agentinstall.Artifacts{}, fmt.Errorf("resolve reference: %w", err)
+		return applied{}, fmt.Errorf("resolve reference: %w", err)
 	}
 
-	record, err := c.Pull(cmd.Context(), &corev1.RecordRef{Cid: cid})
+	rec, err := c.Pull(cmd.Context(), &corev1.RecordRef{Cid: cid})
 	if err != nil {
-		return agentinstall.Artifacts{}, fmt.Errorf("failed to pull record: %w", err)
+		return applied{}, fmt.Errorf("failed to pull record: %w", err)
 	}
 
-	return agentinstall.DeriveArtifacts(record)
+	arts, err := agentinstall.DeriveArtifacts(rec)
+	if err != nil {
+		return applied{}, err
+	}
+
+	return applied{record: rec, arts: arts, pinned: pinRequested(input)}, nil
+}
+
+// pinRequested reports whether this install should hold the package at the
+// version it resolved to. An explicit `:version` in the reference is the same
+// statement as --pin made a different way, so it implies the pin.
+func pinRequested(input string) bool {
+	return opts.pin || reference.Parse(input).Version != ""
 }
 
 // runInstallCmd is the shared body for the parent's bare-positional form and the
 // `run` subcommand.
 func runInstallCmd(cmd *cobra.Command, input string) error {
-	return runApplyCmd(cmd, input, agentinstall.Install, "\nProceed with these changes?")
+	return runApplyCmd(cmd, input, agentinstall.Install, recordInstalls, "\nProceed with these changes?")
 }
 
 // runApplyCmd is the single-record flow shared by install and uninstall: pull +
-// derive, dry-run plan, confirm, apply, summary. apply is Install or Uninstall.
-func runApplyCmd(cmd *cobra.Command, input string, apply recordApplyFn, confirmPrompt string) error {
-	arts, err := pullAndDerive(cmd, input)
+// derive, dry-run plan, confirm, apply, summary, manifest. apply is Install or
+// Uninstall, and record is the matching manifest update.
+func runApplyCmd(
+	cmd *cobra.Command,
+	input string,
+	apply recordApplyFn,
+	record manifestRecordFn,
+	confirmPrompt string,
+) error {
+	item, err := pullAndDerive(cmd, input)
 	if err != nil {
 		return err
 	}
@@ -146,7 +172,7 @@ func runApplyCmd(cmd *cobra.Command, input string, apply recordApplyFn, confirmP
 
 	printScope(cmd)
 
-	plan := apply(env, arts, selected, scope, true)
+	plan := apply(env, item.arts, selected, scope, true)
 	presenter.Printf(cmd, "%s", agentcfg.FormatPlan(plan))
 
 	if len(plan) == 0 {
@@ -166,8 +192,15 @@ func runApplyCmd(cmd *cobra.Command, input string, apply recordApplyFn, confirmP
 		}
 	}
 
-	outcomes := apply(env, arts, selected, scope, opts.dryRun)
-	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(outcomes, opts.dryRun))
+	item.outcomes = apply(env, item.arts, selected, scope, opts.dryRun)
+	presenter.Printf(cmd, "%s", agentcfg.FormatSummary(item.outcomes, opts.dryRun))
+
+	// A dry run touched nothing, so there is nothing to record.
+	if opts.dryRun {
+		return nil
+	}
+
+	record(cmd, []applied{item}, selected, scope)
 
 	return nil
 }

--- a/cli/cmd/install/install_test.go
+++ b/cli/cmd/install/install_test.go
@@ -64,6 +64,37 @@ func TestScopeFromOptsProject(t *testing.T) {
 	assert.Equal(t, agentcfg.Project, scopeFromOpts())
 }
 
+// --- pin tests ---
+
+func TestPinFlagIsLocalToInstallEntryPoints(t *testing.T) {
+	// Local, not persistent, so it never shows up on `install uninstall`, where
+	// holding a version has no meaning.
+	require.NotNil(t, Command.Flags().Lookup("pin"))
+	require.NotNil(t, runCmd.Flags().Lookup("pin"))
+	require.Nil(t, Command.PersistentFlags().Lookup("pin"))
+	require.Nil(t, uninstallCmd.Flags().Lookup("pin"))
+}
+
+func TestPinRequested(t *testing.T) {
+	orig := opts
+
+	defer func() { opts = orig }()
+
+	opts.pin = false
+
+	// A bare name resolves to whatever is newest, so nothing is held.
+	assert.False(t, pinRequested("cisco.com/agent"))
+	assert.False(t, pinRequested("bafyreibsomecid"))
+
+	// An explicit :version is the same statement --pin makes.
+	assert.True(t, pinRequested("cisco.com/agent:1.0.0"))
+	assert.True(t, pinRequested("cisco.com/agent:v2.1.0@bafyreibsomecid"))
+
+	opts.pin = true
+
+	assert.True(t, pinRequested("cisco.com/agent"))
+}
+
 // --- selectAgents tests ---
 
 func TestSelectAgentsAllDetected(t *testing.T) {

--- a/cli/cmd/install/manifest.go
+++ b/cli/cmd/install/manifest.go
@@ -1,0 +1,155 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"time"
+
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/internal/agentinstall"
+	"github.com/agntcy/dir/cli/internal/pkgstate"
+	"github.com/agntcy/dir/cli/presenter"
+	"github.com/spf13/cobra"
+)
+
+// applied is one record that an install or uninstall acted on, paired with the
+// outcomes it produced. The record identity travels alongside the artifacts
+// because a manifest row needs the name, version, and CID that Artifacts does
+// not itself carry.
+type applied struct {
+	record   *corev1.Record
+	arts     agentinstall.Artifacts
+	pinned   bool
+	outcomes []agentcfg.Outcome
+}
+
+// manifestRecordFn updates the install manifest after an apply. Install and
+// uninstall pass their own; a dry run passes neither, because it writes nothing
+// to record.
+type manifestRecordFn func(cmd *cobra.Command, items []applied, agents []agentcfg.Agent, scope agentcfg.Scope)
+
+// recordInstalls adds or replaces one manifest row per agent that actually
+// received an artifact. Agents whose outcomes were all skipped or failed are
+// left out, so a later listing never claims an install that did not happen.
+func recordInstalls(cmd *cobra.Command, items []applied, agents []agentcfg.Agent, scope agentcfg.Scope) {
+	if !recordable(scope) {
+		return
+	}
+
+	now := time.Now().UTC()
+
+	withManifest(cmd, func(m *pkgstate.Manifest) bool {
+		changed := false
+
+		for _, item := range items {
+			name := item.record.GetName()
+			if name == "" {
+				// Nothing to key a row on. A nameless record can still be
+				// installed by CID; it just cannot be tracked.
+				continue
+			}
+
+			for _, agent := range agents {
+				entry, ok := agentinstall.BuildEntry(item.arts, agent, item.outcomes)
+				if !ok {
+					continue
+				}
+
+				entry.Name = name
+				entry.Version = item.record.GetVersion()
+				entry.CID = item.record.GetCid()
+				entry.Scope = pkgstate.ScopeGlobal
+				entry.Origin = pkgstate.OriginDirectory
+				entry.Pinned = item.pinned
+				entry.InstalledAt = now
+
+				m.Upsert(entry)
+
+				changed = true
+			}
+		}
+
+		return changed
+	})
+}
+
+// recordUninstalls drops the manifest row for every agent the record's
+// artifacts were removed from. An agent whose removal failed keeps its row,
+// because its artifacts are still on disk.
+func recordUninstalls(cmd *cobra.Command, items []applied, agents []agentcfg.Agent, scope agentcfg.Scope) {
+	if !recordable(scope) {
+		return
+	}
+
+	withManifest(cmd, func(m *pkgstate.Manifest) bool {
+		changed := false
+
+		for _, item := range items {
+			name := item.record.GetName()
+			if name == "" {
+				continue
+			}
+
+			for _, agent := range agents {
+				if !agentinstall.Cleared(agent, item.outcomes) {
+					continue
+				}
+
+				if m.Remove(pkgstate.Key{Name: name, Agent: agent.ID, Scope: pkgstate.ScopeGlobal}) {
+					changed = true
+				}
+			}
+		}
+
+		return changed
+	})
+}
+
+// recordable reports whether artifacts written at this scope go into the
+// manifest. Only global installs are tracked for now; the row shape already
+// carries `scope`, so a committed per-project manifest is a later addition
+// rather than a rewrite.
+func recordable(scope agentcfg.Scope) bool {
+	return scope == agentcfg.Global
+}
+
+// withManifest loads the manifest, applies mutate, and saves it when mutate
+// reports something changed.
+//
+// Every failure here is a warning on stderr, never a returned error: the
+// manifest is bookkeeping, not the product, so losing it must not fail an
+// install the user just watched succeed.
+func withManifest(cmd *cobra.Command, mutate func(*pkgstate.Manifest) bool) {
+	path, err := pkgstate.DefaultPath()
+	if err != nil {
+		warnManifest(cmd, err)
+
+		return
+	}
+
+	m, err := pkgstate.Load(path)
+	if err != nil {
+		warnManifest(cmd, err)
+	}
+
+	// A frozen manifest belongs to a newer dirctl, whose rows this binary
+	// cannot represent. Save would refuse anyway; stopping here keeps the user
+	// from reading two warnings about one file.
+	if m.Frozen() {
+		return
+	}
+
+	if !mutate(m) {
+		return
+	}
+
+	if err := m.Save(path); err != nil {
+		warnManifest(cmd, err)
+	}
+}
+
+func warnManifest(cmd *cobra.Command, err error) {
+	presenter.Errorf(cmd, "Warning: install manifest: %s\n", err)
+}

--- a/cli/cmd/install/manifest.go
+++ b/cli/cmd/install/manifest.go
@@ -65,6 +65,13 @@ func recordInstalls(cmd *cobra.Command, items []applied, agents []agentcfg.Agent
 				entry.Pinned = item.pinned
 				entry.InstalledAt = now
 
+				// Carry forward artifacts the previous row named and this
+				// install did not write, so a partly successful reinstall never
+				// drops the only record of something still on disk.
+				if prior, ok := m.Find(entry.Key()); ok {
+					entry = entry.WithCarriedArtifacts(prior)
+				}
+
 				m.Upsert(entry)
 
 				changed = true

--- a/cli/cmd/install/manifest_test.go
+++ b/cli/cmd/install/manifest_test.go
@@ -1,0 +1,214 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package install
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	oasfv1alpha1 "buf.build/gen/go/agntcy/oasf/protocolbuffers/go/agntcy/oasf/types/v1alpha1"
+	corev1 "github.com/agntcy/dir/api/core/v1"
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/internal/pkgstate"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateManifest points DefaultPath at a temp directory, so these tests never
+// read or write the developer's real manifest.
+func isolateManifest(t *testing.T) string {
+	t.Helper()
+
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+
+	return filepath.Join(configHome, "dirctl", pkgstate.ManifestFileName)
+}
+
+// testCmd is a bare command whose output and errors are captured.
+func testCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	var errOut bytes.Buffer
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&errOut)
+
+	return cmd, &errOut
+}
+
+var (
+	claudeCode = agentcfg.Agent{ID: "claude-code", Name: "Claude Code"}
+	cursor     = agentcfg.Agent{ID: "cursor", Name: "Cursor"}
+)
+
+func testRecord(name, version string) *corev1.Record {
+	return corev1.New(&oasfv1alpha1.Record{Name: name, Version: version})
+}
+
+func TestRecordInstallsWritesOneRowPerAgentThatGotSomething(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, errOut := testCmd(t)
+
+	rec := testRecord("cisco.com/agent", "1.0.0")
+	item := applied{
+		record: rec,
+		pinned: true,
+		outcomes: []agentcfg.Outcome{
+			{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/agent", Action: agentcfg.ActionAdded},
+			// Cursor got nothing, so it must not appear in the manifest.
+			{Agent: "Cursor", Artifact: agentcfg.ArtifactSkill, Action: agentcfg.ActionSkipped, Reason: "no global location"},
+		},
+	}
+
+	recordInstalls(cmd, []applied{item}, []agentcfg.Agent{claudeCode, cursor}, agentcfg.Global)
+
+	m, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	require.Len(t, m.Entries, 1)
+
+	entry := m.Entries[0]
+	assert.Equal(t, "cisco.com/agent", entry.Name)
+	assert.Equal(t, "1.0.0", entry.Version)
+	assert.Equal(t, rec.GetCid(), entry.CID)
+	assert.Equal(t, "claude-code", entry.Agent)
+	assert.Equal(t, pkgstate.ScopeGlobal, entry.Scope)
+	assert.Equal(t, pkgstate.OriginDirectory, entry.Origin)
+	assert.True(t, entry.Pinned)
+	assert.Equal(t, "/skills/agent", entry.SkillPath)
+	assert.False(t, entry.InstalledAt.IsZero())
+	assert.Empty(t, errOut.String())
+}
+
+func TestRecordInstallsReplacesTheRowOnReinstall(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, _ := testCmd(t)
+
+	outcomes := []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/agent", Action: agentcfg.ActionAdded},
+	}
+	agents := []agentcfg.Agent{claudeCode}
+
+	recordInstalls(cmd, []applied{{record: testRecord("cisco.com/agent", "1.0.0"), outcomes: outcomes}}, agents, agentcfg.Global)
+	recordInstalls(cmd, []applied{{record: testRecord("cisco.com/agent", "2.0.0"), outcomes: outcomes}}, agents, agentcfg.Global)
+
+	m, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	require.Len(t, m.Entries, 1)
+	assert.Equal(t, "2.0.0", m.Entries[0].Version)
+}
+
+func TestRecordInstallsSkipsANamelessRecord(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, _ := testCmd(t)
+
+	// Installable by CID, but there is nothing to key a row on.
+	recordInstalls(cmd, []applied{{
+		record: testRecord("", "1.0.0"),
+		outcomes: []agentcfg.Outcome{
+			{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/x", Action: agentcfg.ActionAdded},
+		},
+	}}, []agentcfg.Agent{claudeCode}, agentcfg.Global)
+
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "nothing changed, so no manifest is written")
+}
+
+func TestRecordInstallsSkipsProjectScope(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, _ := testCmd(t)
+
+	// Only global installs are tracked in this iteration.
+	recordInstalls(cmd, []applied{{
+		record: testRecord("cisco.com/agent", "1.0.0"),
+		outcomes: []agentcfg.Outcome{
+			{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/x", Action: agentcfg.ActionAdded},
+		},
+	}}, []agentcfg.Agent{claudeCode}, agentcfg.Project)
+
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestRecordUninstallsDropsTheRow(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, _ := testCmd(t)
+
+	rec := testRecord("cisco.com/agent", "1.0.0")
+	agents := []agentcfg.Agent{claudeCode, cursor}
+
+	recordInstalls(cmd, []applied{{record: rec, outcomes: []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/claude/skills/x", Action: agentcfg.ActionAdded},
+		{Agent: "Cursor", Artifact: agentcfg.ArtifactSkill, Path: "/cursor/skills/x", Action: agentcfg.ActionAdded},
+	}}}, agents, agentcfg.Global)
+
+	recordUninstalls(cmd, []applied{{record: rec, outcomes: []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/claude/skills/x", Action: agentcfg.ActionRemoved},
+		// Cursor's removal failed, so its artifacts are still on disk and its
+		// row has to stay.
+		{Agent: "Cursor", Artifact: agentcfg.ArtifactSkill, Path: "/cursor/skills/x", Action: agentcfg.ActionFailed},
+	}}}, agents, agentcfg.Global)
+
+	m, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	require.Len(t, m.Entries, 1)
+	assert.Equal(t, "cursor", m.Entries[0].Agent)
+}
+
+func TestWithManifestWarnsOnCorruptFileAndCarriesOn(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, errOut := testCmd(t)
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o600))
+
+	recordInstalls(cmd, []applied{{
+		record: testRecord("cisco.com/agent", "1.0.0"),
+		outcomes: []agentcfg.Outcome{
+			{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/x", Action: agentcfg.ActionAdded},
+		},
+	}}, []agentcfg.Agent{claudeCode}, agentcfg.Global)
+
+	// The user is told, and the install still gets recorded: bookkeeping never
+	// fails an install.
+	assert.Contains(t, errOut.String(), "Warning: install manifest")
+
+	m, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	assert.Len(t, m.Entries, 1)
+}
+
+func TestWithManifestLeavesANewerDirctlsFileAlone(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, errOut := testCmd(t)
+
+	future := []byte(`{"schemaVersion": 99, "entries": []}`)
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, future, 0o600))
+
+	recordInstalls(cmd, []applied{{
+		record: testRecord("cisco.com/agent", "1.0.0"),
+		outcomes: []agentcfg.Outcome{
+			{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/x", Action: agentcfg.ActionAdded},
+		},
+	}}, []agentcfg.Agent{claudeCode}, agentcfg.Global)
+
+	assert.Contains(t, errOut.String(), "upgrade dirctl")
+	// Exactly one warning, not one from Load and another from Save.
+	assert.Equal(t, 1, bytes.Count(errOut.Bytes(), []byte("Warning:")))
+
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, future, onDisk)
+}
+
+func TestRecordable(t *testing.T) {
+	assert.True(t, recordable(agentcfg.Global))
+	assert.False(t, recordable(agentcfg.Project))
+}

--- a/cli/cmd/install/manifest_test.go
+++ b/cli/cmd/install/manifest_test.go
@@ -103,6 +103,33 @@ func TestRecordInstallsReplacesTheRowOnReinstall(t *testing.T) {
 	assert.Equal(t, "2.0.0", m.Entries[0].Version)
 }
 
+func TestRecordInstallsCarriesArtifactsThroughAPartialReinstall(t *testing.T) {
+	path := isolateManifest(t)
+	cmd, _ := testCmd(t)
+
+	rec := testRecord("cisco.com/agent", "1.0.0")
+	agents := []agentcfg.Agent{claudeCode}
+
+	recordInstalls(cmd, []applied{{record: rec, outcomes: []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/agent", Action: agentcfg.ActionAdded},
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "agntcy-dir", Action: agentcfg.ActionAdded},
+	}}}, agents, agentcfg.Global)
+
+	// Reinstall where the MCP config could not be written. The key is still in
+	// that config, so the row must keep naming it.
+	recordInstalls(cmd, []applied{{record: testRecord("cisco.com/agent", "2.0.0"), outcomes: []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/agent", Action: agentcfg.ActionUpdated},
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "agntcy-dir", Action: agentcfg.ActionFailed},
+	}}}, agents, agentcfg.Global)
+
+	m, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	require.Len(t, m.Entries, 1)
+	assert.Equal(t, "2.0.0", m.Entries[0].Version)
+	assert.Equal(t, "/skills/agent", m.Entries[0].SkillPath)
+	assert.Equal(t, []string{"agntcy-dir"}, m.Entries[0].MCPServers)
+}
+
 func TestRecordInstallsSkipsANamelessRecord(t *testing.T) {
 	path := isolateManifest(t)
 	cmd, _ := testCmd(t)

--- a/cli/cmd/install/options.go
+++ b/cli/cmd/install/options.go
@@ -6,11 +6,17 @@ package install
 import "github.com/agntcy/dir/cli/cmd/search"
 
 // options holds the shared flags for the install subcommands.
+//
+// Every field here must be bound to a flag. The local e2e suite runs dirctl
+// in-process against this one package-level value, so a field nothing resets
+// keeps whatever the previous spec left in it and turns test failures
+// order-dependent.
 type options struct {
 	agents      []string
 	project     bool
 	dryRun      bool
 	yes         bool
+	pin         bool
 	limit       uint32
 	allVersions bool
 	filters     search.Filters

--- a/cli/cmd/install/run.go
+++ b/cli/cmd/install/run.go
@@ -13,3 +13,7 @@ var runCmd = &cobra.Command{
 		return runInstallCmd(cmd, args[0])
 	},
 }
+
+func init() {
+	addPinFlag(runCmd, &opts)
+}

--- a/cli/cmd/install/uninstall.go
+++ b/cli/cmd/install/uninstall.go
@@ -82,5 +82,5 @@ func init() {
 // top-level `uninstall` shorthand: pull + derive, dry-run plan, confirm, remove,
 // summary.
 func runUninstallCmd(cmd *cobra.Command, input string) error {
-	return runApplyCmd(cmd, input, agentinstall.Uninstall, "\nRemove these artifacts?")
+	return runApplyCmd(cmd, input, agentinstall.Uninstall, recordUninstalls, "\nRemove these artifacts?")
 }

--- a/cli/internal/agentcfg/mcp_engine.go
+++ b/cli/internal/agentcfg/mcp_engine.go
@@ -38,14 +38,14 @@ func mcpConfigPath(target *MCPTarget, env Env, scope Scope) (string, error) {
 func InstallMCP(target *MCPTarget, env Env, entry map[string]any, serverName string, scope Scope, dryRun bool) (Outcome, error) {
 	path, err := mcpConfigPath(target, env, scope)
 	if errors.Is(err, ErrNoScopePath) {
-		return skipScopeOutcome("mcp", scope), nil
+		return skipScopeOutcome(ArtifactMCP, scope), nil
 	}
 
 	if err != nil {
-		return failOutcome(Outcome{Artifact: "mcp"}, fmt.Errorf("resolve mcp config path: %w", err))
+		return failOutcome(Outcome{Artifact: ArtifactMCP}, fmt.Errorf("resolve mcp config path: %w", err))
 	}
 
-	outcome := Outcome{Artifact: "mcp", Path: path}
+	outcome := Outcome{Artifact: ArtifactMCP, Path: path, Server: serverName}
 
 	m, err := loadConfig(target.Format, path)
 	if err != nil {
@@ -84,14 +84,14 @@ func InstallMCP(target *MCPTarget, env Env, entry map[string]any, serverName str
 func RemoveMCP(target *MCPTarget, env Env, serverName string, scope Scope, dryRun bool) (Outcome, error) {
 	path, err := mcpConfigPath(target, env, scope)
 	if errors.Is(err, ErrNoScopePath) {
-		return skipScopeOutcome("mcp", scope), nil
+		return skipScopeOutcome(ArtifactMCP, scope), nil
 	}
 
 	if err != nil {
-		return failOutcome(Outcome{Artifact: "mcp"}, fmt.Errorf("resolve mcp config path: %w", err))
+		return failOutcome(Outcome{Artifact: ArtifactMCP}, fmt.Errorf("resolve mcp config path: %w", err))
 	}
 
-	outcome := Outcome{Artifact: "mcp", Path: path}
+	outcome := Outcome{Artifact: ArtifactMCP, Path: path, Server: serverName}
 
 	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
 		outcome.Action = ActionUnchanged

--- a/cli/internal/agentcfg/result.go
+++ b/cli/internal/agentcfg/result.go
@@ -3,6 +3,14 @@
 
 package agentcfg
 
+// The artifact kinds reported in Outcome.Artifact.
+const (
+	// ArtifactMCP is an MCP server entry in an agent's config file.
+	ArtifactMCP = "mcp"
+	// ArtifactSkill is an Agent Skill file, folder, or managed block.
+	ArtifactSkill = "skill"
+)
+
 // Action is the outcome of touching a single artifact location.
 type Action string
 
@@ -45,9 +53,15 @@ func skipScopeOutcome(artifact string, scope Scope) Outcome {
 type Outcome struct {
 	Record   string // optional record label for batch install grouping
 	Agent    string // human-readable agent name
-	Artifact string // "mcp" or "skill"
+	Artifact string // ArtifactMCP or ArtifactSkill
 	Path     string // absolute path that was (or would be) touched
 	Action   Action
 	Reason   string // populated on skip/fail or notable fallbacks
 	Err      error
+
+	// Server is the config key an MCP server entry was stored under, empty for
+	// skills. One agent gets one outcome per server, all sharing a Path, so this
+	// is the only thing that tells them apart — which is what lets the install
+	// manifest record the server keys that were actually written.
+	Server string
 }

--- a/cli/internal/agentcfg/skill_engine.go
+++ b/cli/internal/agentcfg/skill_engine.go
@@ -24,14 +24,14 @@ const skillFilePerm = 0o644
 func InstallSkill(target *SkillTarget, env Env, slug, canonical string, scope Scope, dryRun bool) (Outcome, error) {
 	path, err := resolveSkillTargetPath(target, env, slug, scope)
 	if errors.Is(err, ErrNoScopePath) {
-		return skipScopeOutcome("skill", scope), nil
+		return skipScopeOutcome(ArtifactSkill, scope), nil
 	}
 
 	if err != nil {
-		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
+		return Outcome{Artifact: ArtifactSkill, Action: ActionFailed, Err: err}, err
 	}
 
-	outcome := Outcome{Artifact: "skill", Path: path}
+	outcome := Outcome{Artifact: ArtifactSkill, Path: path}
 
 	desired, err := renderForTarget(target, slug, canonical, path)
 	if err != nil {
@@ -86,16 +86,16 @@ func InstallSkill(target *SkillTarget, env Env, slug, canonical string, scope Sc
 func InstallSkillBundle(target *SkillTarget, env Env, slug string, archive []byte, scope Scope, dryRun bool) (Outcome, error) {
 	path, err := resolveSkillTargetPath(target, env, slug, scope)
 	if errors.Is(err, ErrNoScopePath) {
-		return skipScopeOutcome("skill", scope), nil
+		return skipScopeOutcome(ArtifactSkill, scope), nil
 	}
 
 	if err != nil {
-		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
+		return Outcome{Artifact: ArtifactSkill, Action: ActionFailed, Err: err}, err
 	}
 
 	destDir := filepath.Dir(path)
 
-	outcome := Outcome{Artifact: "skill", Path: destDir}
+	outcome := Outcome{Artifact: ArtifactSkill, Path: destDir}
 
 	matches, err := exportfmt.SkillBundleMatchesDir(archive, destDir)
 	if err != nil {
@@ -133,14 +133,14 @@ func InstallSkillBundle(target *SkillTarget, env Env, slug string, archive []byt
 func RemoveSkill(target *SkillTarget, env Env, slug string, scope Scope, dryRun bool) (Outcome, error) {
 	path, err := resolveSkillTargetPath(target, env, slug, scope)
 	if errors.Is(err, ErrNoScopePath) {
-		return skipScopeOutcome("skill", scope), nil
+		return skipScopeOutcome(ArtifactSkill, scope), nil
 	}
 
 	if err != nil {
-		return Outcome{Artifact: "skill", Action: ActionFailed, Err: err}, err
+		return Outcome{Artifact: ArtifactSkill, Action: ActionFailed, Err: err}, err
 	}
 
-	outcome := Outcome{Artifact: "skill", Path: path}
+	outcome := Outcome{Artifact: ArtifactSkill, Path: path}
 
 	switch target.Strategy {
 	case SkillFolder:

--- a/cli/internal/agentinstall/apply.go
+++ b/cli/internal/agentinstall/apply.go
@@ -32,7 +32,7 @@ func Install(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, scope ag
 			if arts.hasSkillBundle() && agent.Skill.Strategy != agentcfg.SkillFolder {
 				outcomes = append(outcomes, agentcfg.Outcome{
 					Agent:    agent.Name,
-					Artifact: "skill",
+					Artifact: agentcfg.ArtifactSkill,
 					Action:   agentcfg.ActionSkipped,
 					Reason:   skillBundleFolderOnlyReason,
 				})

--- a/cli/internal/agentinstall/apply.go
+++ b/cli/internal/agentinstall/apply.go
@@ -5,11 +5,15 @@ package agentinstall
 
 import (
 	"maps"
+	"path/filepath"
 
 	"github.com/agntcy/dir/cli/internal/agentcfg"
 )
 
-const skillBundleFolderOnlyReason = "skill bundle requires a multi-file skills directory; this agent only supports single instruction files"
+const (
+	skillBundleFolderOnlyReason = "skill bundle requires a multi-file skills directory; this agent only supports single instruction files"
+	sharedSkillReason           = "shared skill location, written once for another agent"
+)
 
 // Install applies the record's artifacts to the selected agents at the given
 // scope, one outcome per touched artifact. Errors on one agent never abort the rest.
@@ -40,7 +44,9 @@ func Install(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, scope ag
 				continue
 			}
 
-			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug, scope) {
+			if path, shared := claimSkillPath(seenSkill, agent.Skill, env, arts.slug, scope); shared {
+				outcomes = append(outcomes, sharedSkillOutcome(agent, path, arts))
+
 				continue
 			}
 
@@ -79,7 +85,9 @@ func Uninstall(env agentcfg.Env, arts Artifacts, agents []agentcfg.Agent, scope 
 				continue
 			}
 
-			if dedupeSkill(seenSkill, agent.Skill, env, arts.slug, scope) {
+			if path, shared := claimSkillPath(seenSkill, agent.Skill, env, arts.slug, scope); shared {
+				outcomes = append(outcomes, sharedSkillOutcome(agent, path, arts))
+
 				continue
 			}
 
@@ -105,19 +113,52 @@ func styleEntry(base map[string]any, style agentcfg.EntryStyle) map[string]any {
 	return entry
 }
 
-// dedupeSkill reports whether a skill target's resolved path was already acted on
-// this run (e.g. Claude Code and Claude Desktop share one skills folder).
-func dedupeSkill(seen map[string]bool, target *agentcfg.SkillTarget, env agentcfg.Env, slug string, scope agentcfg.Scope) bool {
+// claimSkillPath marks a skill target's resolved path as acted on this run and
+// reports the path, plus whether another agent had already claimed it.
+//
+// Claude Code and Claude Desktop share one skills folder, and so do Zed and
+// Codex CLI, so the artifact is written once. The agents that share it are
+// served by it all the same, which is why the caller reports an outcome for
+// them rather than passing over them in silence: without one, the install
+// manifest would hold a row for the first agent only, and uninstalling for
+// just one of the pair could never clear the other's row.
+func claimSkillPath(
+	seen map[string]bool,
+	target *agentcfg.SkillTarget,
+	env agentcfg.Env,
+	slug string,
+	scope agentcfg.Scope,
+) (string, bool) {
 	path, err := agentcfg.ResolveSkillTargetPath(target, env, slug, scope)
 	if err != nil || path == "" {
-		return false
+		return "", false
 	}
 
 	if seen[path] {
-		return true
+		return path, true
 	}
 
 	seen[path] = true
 
-	return false
+	return path, false
+}
+
+// sharedSkillOutcome reports an agent served by a skill that another agent in
+// this run already wrote or removed. It carries the same path that agent's own
+// outcome carried, so both manifest rows name the same artifact, and reports
+// ActionUnchanged because nothing was written for this agent, which is also
+// how an already-correct or already-absent artifact reports elsewhere.
+func sharedSkillOutcome(agent agentcfg.Agent, path string, arts Artifacts) agentcfg.Outcome {
+	// A bundle's outcome names the folder it was extracted into, not SKILL.md.
+	if arts.hasSkillBundle() {
+		path = filepath.Dir(path)
+	}
+
+	return agentcfg.Outcome{
+		Agent:    agent.Name,
+		Artifact: agentcfg.ArtifactSkill,
+		Path:     path,
+		Action:   agentcfg.ActionUnchanged,
+		Reason:   sharedSkillReason,
+	}
 }

--- a/cli/internal/agentinstall/apply_test.go
+++ b/cli/internal/agentinstall/apply_test.go
@@ -254,10 +254,62 @@ func TestRunInstallDedupesSharedSkillPath(t *testing.T) {
 
 	outcomes := Install(env, arts, agents, agentcfg.Global, false)
 
-	// Both agents resolve to the same skills path, so dedupeSkill collapses the
-	// shared target to a single skill outcome.
-	require.Len(t, outcomes, 1)
-	require.Equal(t, "skill", outcomes[0].Artifact)
+	// Both agents resolve to the same skills path, so the skill is written once.
+	// The second agent is still served by it, so it reports an outcome naming
+	// the same path, which is what gives it a manifest row of its own.
+	require.Len(t, outcomes, 2)
+	require.Equal(t, agentcfg.ArtifactSkill, outcomes[0].Artifact)
+	require.Equal(t, agentcfg.ActionAdded, outcomes[0].Action)
+	require.Equal(t, "Claude Code", outcomes[0].Agent)
+
+	require.Equal(t, agentcfg.ArtifactSkill, outcomes[1].Artifact)
+	require.Equal(t, agentcfg.ActionUnchanged, outcomes[1].Action)
+	require.Equal(t, "Claude Desktop", outcomes[1].Agent)
+	require.Equal(t, outcomes[0].Path, outcomes[1].Path)
+	require.Contains(t, outcomes[1].Reason, "shared skill location")
+
+	// The file is written exactly once, not once per agent.
+	require.FileExists(t, outcomes[0].Path)
+}
+
+func TestRunUninstallReportsTheSharedSkillForBothAgents(t *testing.T) {
+	home := t.TempDir()
+	env := agentcfg.Env{Home: home, GOOS: "linux", Cwd: home}
+
+	var claudeCode, claudeDesktop *agentcfg.SkillTarget
+
+	for _, a := range agentcfg.Registry() {
+		switch a.ID {
+		case claudeCodeID:
+			claudeCode = a.Skill
+		case "claude-desktop":
+			claudeDesktop = a.Skill
+		}
+	}
+
+	require.NotNil(t, claudeCode)
+	require.NotNil(t, claudeDesktop)
+
+	arts := Artifacts{
+		slug:  "code-review",
+		skill: "---\nname: code-review\ndescription: x\n---\n\nbody\n",
+	}
+	agents := []agentcfg.Agent{
+		{Name: "Claude Code", Skill: claudeCode},
+		{Name: "Claude Desktop", Skill: claudeDesktop},
+	}
+
+	require.Len(t, Install(env, arts, agents, agentcfg.Global, false), 2)
+
+	outcomes := Uninstall(env, arts, agents, agentcfg.Global, false)
+
+	// Removed once, reported for both, so both rows can be cleared.
+	require.Len(t, outcomes, 2)
+	require.Equal(t, agentcfg.ActionRemoved, outcomes[0].Action)
+	require.Equal(t, agentcfg.ActionUnchanged, outcomes[1].Action)
+
+	require.True(t, Cleared(agentcfg.Agent{ID: claudeCodeID, Name: "Claude Code"}, outcomes))
+	require.True(t, Cleared(agentcfg.Agent{ID: "claude-desktop", Name: "Claude Desktop"}, outcomes))
 }
 
 func TestRunInstallWritesSkillBundle(t *testing.T) {

--- a/cli/internal/agentinstall/derive.go
+++ b/cli/internal/agentinstall/derive.go
@@ -132,8 +132,8 @@ func deriveSkillArtifacts(record *corev1.Record, arts *Artifacts) error {
 
 		// Listed once here, where a malformed bundle can still be reported as an
 		// error, so SkillFiles stays a plain accessor. The install manifest
-		// records the list, which is what lets a later uninstall or upgrade
-		// remove exactly these files.
+		// records the list so that a later manifest-driven uninstall or upgrade
+		// can remove exactly these files.
 		files, err := exportfmt.SkillBundleFiles(out)
 		if err != nil {
 			return fmt.Errorf("list skill bundle files: %w", err)

--- a/cli/internal/agentinstall/derive.go
+++ b/cli/internal/agentinstall/derive.go
@@ -26,9 +26,10 @@ type mcpServer struct {
 
 // Artifacts is the set of installable artifacts derived from a record's modules.
 type Artifacts struct {
-	slug        string // sanitized record name; skill folder/file + block marker id
-	skill       string // canonical SKILL.md content for single-file skill targets
-	skillBundle []byte // gzip skill bundle when the record stores application/agent-skills+gzip
+	slug        string   // sanitized record name; skill folder/file + block marker id
+	skill       string   // canonical SKILL.md content for single-file skill targets
+	skillBundle []byte   // gzip skill bundle when the record stores application/agent-skills+gzip
+	skillFiles  []string // bundle file list, relative to the installed skill folder
 	mcpServers  []mcpServer
 }
 
@@ -128,6 +129,17 @@ func deriveSkillArtifacts(record *corev1.Record, arts *Artifacts) error {
 		}
 
 		arts.skill = md
+
+		// Listed once here, where a malformed bundle can still be reported as an
+		// error, so SkillFiles stays a plain accessor. The install manifest
+		// records the list, which is what lets a later uninstall or upgrade
+		// remove exactly these files.
+		files, err := exportfmt.SkillBundleFiles(out)
+		if err != nil {
+			return fmt.Errorf("list skill bundle files: %w", err)
+		}
+
+		arts.skillFiles = files
 
 		return nil
 	}

--- a/cli/internal/agentinstall/entry.go
+++ b/cli/internal/agentinstall/entry.go
@@ -33,9 +33,10 @@ func (a Artifacts) SkillFiles() []string { return a.skillFiles }
 
 // BuildEntry builds the install-manifest row for one agent out of the outcomes
 // an apply produced, recording the artifacts that actually landed rather than
-// the ones the record's modules imply. That distinction is the point: a later
-// uninstall or upgrade removes exactly these paths and server keys, without
-// re-fetching a record that may since have been garbage-collected upstream.
+// the ones the record's modules imply. That distinction is the point, though
+// nothing acts on it yet: it is what will let a manifest-driven uninstall or
+// upgrade remove exactly these paths and server keys, without re-fetching a
+// record that may since have been garbage-collected upstream.
 //
 // It reports false when nothing landed for this agent, because every outcome
 // was skipped or failed, so a listing never claims an install that did not

--- a/cli/internal/agentinstall/entry.go
+++ b/cli/internal/agentinstall/entry.go
@@ -74,26 +74,37 @@ func BuildEntry(arts Artifacts, agent agentcfg.Agent, outcomes []agentcfg.Outcom
 	return entry, true
 }
 
-// Cleared reports whether an uninstall left this agent with nothing of ours:
-// it acted on at least one artifact and none of them failed. An agent whose
-// removal failed keeps its manifest row, because its artifacts are still on
-// disk and something still has to remove them.
+// Cleared reports whether an uninstall left this agent with nothing of ours.
+// It takes a confirmation and no contradiction: at least one artifact was
+// removed or found already absent, and none failed.
+//
+// A skip on its own is not a confirmation. It means the artifact's location
+// could not be resolved for this scope, so nothing was removed and nothing was
+// even looked at, while whatever the row recorded may well still be on disk.
+// Dropping the row there would throw away the only note of what to clean up.
+// A skip alongside a real removal is fine, and common: an agent can hold an
+// MCP entry at a scope where it has no skill location.
+//
+// An agent whose removal failed keeps its row too, since its artifacts are
+// still on disk and something has to remove them later.
 func Cleared(agent agentcfg.Agent, outcomes []agentcfg.Outcome) bool {
-	acted := false
+	confirmed := false
 
 	for _, o := range outcomes {
 		if o.Agent != agent.Name {
 			continue
 		}
 
-		if o.Action == agentcfg.ActionFailed {
+		switch o.Action {
+		case agentcfg.ActionFailed:
 			return false
+		case agentcfg.ActionRemoved, agentcfg.ActionUnchanged:
+			confirmed = true
+		case agentcfg.ActionAdded, agentcfg.ActionUpdated, agentcfg.ActionSkipped:
 		}
-
-		acted = true
 	}
 
-	return acted
+	return confirmed
 }
 
 // wrote reports whether an action left our artifact in place: added and updated

--- a/cli/internal/agentinstall/entry.go
+++ b/cli/internal/agentinstall/entry.go
@@ -1,0 +1,111 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentinstall
+
+import (
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/agntcy/dir/cli/internal/pkgstate"
+)
+
+// Slug is the sanitized record name that names the skill folder or file and the
+// managed-block marker.
+func (a Artifacts) Slug() string { return a.slug }
+
+// HasSkill reports whether the record yields a skill artifact at all.
+func (a Artifacts) HasSkill() bool { return a.hasSkill() }
+
+// MCPServerNames lists the config keys the MCP server entries are stored under,
+// in the sorted order DeriveArtifacts fixed so output is stable across runs.
+func (a Artifacts) MCPServerNames() []string {
+	names := make([]string, 0, len(a.mcpServers))
+	for _, srv := range a.mcpServers {
+		names = append(names, srv.name)
+	}
+
+	return names
+}
+
+// SkillFiles lists a skill bundle's files, relative to the installed skill
+// folder. It is empty for a single-file skill, where the recorded skill path is
+// itself the one file.
+func (a Artifacts) SkillFiles() []string { return a.skillFiles }
+
+// BuildEntry builds the install-manifest row for one agent out of the outcomes
+// an apply produced, recording the artifacts that actually landed rather than
+// the ones the record's modules imply. That distinction is the point: a later
+// uninstall or upgrade removes exactly these paths and server keys, without
+// re-fetching a record that may since have been garbage-collected upstream.
+//
+// It reports false when nothing landed for this agent, because every outcome
+// was skipped or failed, so a listing never claims an install that did not
+// happen. The caller fills in the record identity — name, version, CID, scope,
+// origin, pin — and the timestamp, none of which Artifacts carries.
+//
+// Outcomes for other agents are ignored, so the whole apply result can be
+// passed in for each agent in turn.
+func BuildEntry(arts Artifacts, agent agentcfg.Agent, outcomes []agentcfg.Outcome) (pkgstate.Entry, bool) {
+	entry := pkgstate.Entry{Agent: agent.ID}
+	landed := false
+
+	for _, o := range outcomes {
+		if o.Agent != agent.Name || !wrote(o.Action) {
+			continue
+		}
+
+		switch o.Artifact {
+		case agentcfg.ArtifactSkill:
+			entry.SkillPath = o.Path
+			entry.SkillFiles = arts.SkillFiles()
+			landed = true
+		case agentcfg.ArtifactMCP:
+			if o.Server != "" {
+				entry.MCPServers = append(entry.MCPServers, o.Server)
+			}
+
+			landed = true
+		}
+	}
+
+	if !landed {
+		return pkgstate.Entry{}, false
+	}
+
+	return entry, true
+}
+
+// Cleared reports whether an uninstall left this agent with nothing of ours:
+// it acted on at least one artifact and none of them failed. An agent whose
+// removal failed keeps its manifest row, because its artifacts are still on
+// disk and something still has to remove them.
+func Cleared(agent agentcfg.Agent, outcomes []agentcfg.Outcome) bool {
+	acted := false
+
+	for _, o := range outcomes {
+		if o.Agent != agent.Name {
+			continue
+		}
+
+		if o.Action == agentcfg.ActionFailed {
+			return false
+		}
+
+		acted = true
+	}
+
+	return acted
+}
+
+// wrote reports whether an action left our artifact in place: added and updated
+// wrote it, unchanged found it already correct. Skipped and failed left nothing
+// behind, and removed belongs to uninstall.
+func wrote(action agentcfg.Action) bool {
+	switch action {
+	case agentcfg.ActionAdded, agentcfg.ActionUpdated, agentcfg.ActionUnchanged:
+		return true
+	case agentcfg.ActionRemoved, agentcfg.ActionSkipped, agentcfg.ActionFailed:
+		return false
+	default:
+		return false
+	}
+}

--- a/cli/internal/agentinstall/entry_test.go
+++ b/cli/internal/agentinstall/entry_test.go
@@ -109,6 +109,30 @@ func TestBuildEntryIgnoresOtherAgentsOutcomes(t *testing.T) {
 	assert.Equal(t, "/claude/skills/x", entry.SkillPath)
 }
 
+func TestBuildEntryRecordsAnAgentServedByASharedSkill(t *testing.T) {
+	// Claude Code and Claude Desktop share one skills folder, so the file is
+	// written once. Both agents are served by it, so both get a row naming it.
+	claudeDesktop := agentcfg.Agent{ID: "claude-desktop", Name: "Claude Desktop"}
+
+	outcomes := []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/x", Action: agentcfg.ActionAdded},
+		{
+			Agent: "Claude Desktop", Artifact: agentcfg.ArtifactSkill, Path: "/skills/x",
+			Action: agentcfg.ActionUnchanged, Reason: sharedSkillReason,
+		},
+	}
+
+	first, ok := BuildEntry(Artifacts{}, claudeCode, outcomes)
+	require.True(t, ok)
+
+	second, ok := BuildEntry(Artifacts{}, claudeDesktop, outcomes)
+	require.True(t, ok)
+
+	assert.Equal(t, "/skills/x", first.SkillPath)
+	assert.Equal(t, "/skills/x", second.SkillPath)
+	assert.Equal(t, "claude-desktop", second.Agent)
+}
+
 func TestBuildEntryRecordsBundleFileList(t *testing.T) {
 	arts, err := DeriveArtifacts(newSkillBundleRecord(t))
 	require.NoError(t, err)

--- a/cli/internal/agentinstall/entry_test.go
+++ b/cli/internal/agentinstall/entry_test.go
@@ -1,0 +1,150 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package agentinstall
+
+import (
+	"testing"
+
+	"github.com/agntcy/dir/cli/internal/agentcfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// claudeCode is a stand-in agent descriptor: BuildEntry and Cleared only need
+// the ID they record and the display Name the outcomes are tagged with.
+var claudeCode = agentcfg.Agent{ID: "claude-code", Name: "Claude Code"}
+
+func TestAccessorsFromDerivedSkill(t *testing.T) {
+	arts, err := DeriveArtifacts(loadRecord(t, "skill.json"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "code-review", arts.Slug())
+	assert.True(t, arts.HasSkill())
+	assert.Empty(t, arts.MCPServerNames())
+	// A single-file skill has no bundle listing; its path is itself the file.
+	assert.Empty(t, arts.SkillFiles())
+}
+
+func TestAccessorsFromDerivedMCP(t *testing.T) {
+	arts, err := DeriveArtifacts(loadRecord(t, "mcp.json"))
+	require.NoError(t, err)
+
+	assert.False(t, arts.HasSkill())
+	require.Len(t, arts.MCPServerNames(), 1)
+	assert.Equal(t, arts.mcpServers[0].name, arts.MCPServerNames()[0])
+}
+
+func TestSkillFilesFromDerivedBundle(t *testing.T) {
+	arts, err := DeriveArtifacts(newSkillBundleRecord(t))
+	require.NoError(t, err)
+
+	assert.True(t, arts.HasSkill())
+	assert.Equal(t, []string{"SKILL.md"}, arts.SkillFiles())
+}
+
+func TestBuildEntryRecordsWhatLanded(t *testing.T) {
+	arts, err := DeriveArtifacts(loadRecord(t, "multi.json"))
+	require.NoError(t, err)
+
+	outcomes := []agentcfg.Outcome{
+		{
+			Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP,
+			Path: "/home/dev/.claude.json", Server: "code-review", Action: agentcfg.ActionAdded,
+		},
+		{
+			Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill,
+			Path: "/home/dev/.claude/skills/code-review/SKILL.md", Action: agentcfg.ActionUpdated,
+		},
+	}
+
+	entry, ok := BuildEntry(arts, claudeCode, outcomes)
+	require.True(t, ok)
+	assert.Equal(t, "claude-code", entry.Agent)
+	assert.Equal(t, "/home/dev/.claude/skills/code-review/SKILL.md", entry.SkillPath)
+	assert.Equal(t, []string{"code-review"}, entry.MCPServers)
+}
+
+func TestBuildEntryCountsUnchangedAsLanded(t *testing.T) {
+	// The artifact is already there and already correct, so it is installed.
+	entry, ok := BuildEntry(Artifacts{}, claudeCode, []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/skills/x", Action: agentcfg.ActionUnchanged},
+	})
+	require.True(t, ok)
+	assert.Equal(t, "/skills/x", entry.SkillPath)
+}
+
+func TestBuildEntrySkipsAgentThatGotNothing(t *testing.T) {
+	// Every outcome skipped or failed means nothing was written, so no row is
+	// recorded and a later listing cannot claim an install that did not happen.
+	_, ok := BuildEntry(Artifacts{}, claudeCode, []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Action: agentcfg.ActionSkipped, Reason: "no global location"},
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "srv", Action: agentcfg.ActionFailed},
+	})
+	assert.False(t, ok)
+
+	_, ok = BuildEntry(Artifacts{}, claudeCode, nil)
+	assert.False(t, ok)
+}
+
+func TestBuildEntryDropsTheServerThatFailed(t *testing.T) {
+	// Two servers, one written and one not: the row must not claim the failed
+	// one, or a later uninstall would try to remove a key that was never added.
+	entry, ok := BuildEntry(Artifacts{}, claudeCode, []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "wrote-me", Action: agentcfg.ActionAdded},
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "failed-me", Action: agentcfg.ActionFailed},
+	})
+	require.True(t, ok)
+	assert.Equal(t, []string{"wrote-me"}, entry.MCPServers)
+}
+
+func TestBuildEntryIgnoresOtherAgentsOutcomes(t *testing.T) {
+	// The whole apply result is passed in for each agent in turn, so rows must
+	// not pick up paths written for a different agent.
+	entry, ok := BuildEntry(Artifacts{}, claudeCode, []agentcfg.Outcome{
+		{Agent: "Cursor", Artifact: agentcfg.ArtifactSkill, Path: "/cursor/skills/x", Action: agentcfg.ActionAdded},
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Path: "/claude/skills/x", Action: agentcfg.ActionAdded},
+	})
+	require.True(t, ok)
+	assert.Equal(t, "/claude/skills/x", entry.SkillPath)
+}
+
+func TestBuildEntryRecordsBundleFileList(t *testing.T) {
+	arts, err := DeriveArtifacts(newSkillBundleRecord(t))
+	require.NoError(t, err)
+
+	entry, ok := BuildEntry(arts, claudeCode, []agentcfg.Outcome{
+		{
+			Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill,
+			Path: "/home/dev/.claude/skills/summarize", Action: agentcfg.ActionAdded,
+		},
+	})
+	require.True(t, ok)
+	assert.Equal(t, []string{"SKILL.md"}, entry.SkillFiles)
+}
+
+func TestCleared(t *testing.T) {
+	assert.True(t, Cleared(claudeCode, []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Action: agentcfg.ActionRemoved},
+	}))
+
+	// Already absent counts as cleared, so uninstall stays idempotent.
+	assert.True(t, Cleared(claudeCode, []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "srv", Action: agentcfg.ActionUnchanged},
+	}))
+}
+
+func TestClearedFalseWhenSomethingFailed(t *testing.T) {
+	// The artifacts are still on disk, so the row has to stay.
+	assert.False(t, Cleared(claudeCode, []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Action: agentcfg.ActionRemoved},
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "srv", Action: agentcfg.ActionFailed},
+	}))
+}
+
+func TestClearedFalseWhenAgentWasNotTouched(t *testing.T) {
+	assert.False(t, Cleared(claudeCode, nil))
+	assert.False(t, Cleared(claudeCode, []agentcfg.Outcome{
+		{Agent: "Cursor", Artifact: agentcfg.ArtifactSkill, Action: agentcfg.ActionRemoved},
+	}))
+}

--- a/cli/internal/agentinstall/entry_test.go
+++ b/cli/internal/agentinstall/entry_test.go
@@ -134,6 +134,27 @@ func TestCleared(t *testing.T) {
 	}))
 }
 
+func TestClearedFalseWhenOnlySkipped(t *testing.T) {
+	// The location could not be resolved, so nothing was removed and nothing
+	// was even looked at. Whatever the row recorded may still be on disk, and
+	// the row is the only note of what to clean up.
+	assert.False(t, Cleared(claudeCode, []agentcfg.Outcome{
+		{
+			Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill,
+			Action: agentcfg.ActionSkipped, Reason: "no global location for this agent's skill",
+		},
+	}))
+}
+
+func TestClearedWhenASkipAccompaniesARealRemoval(t *testing.T) {
+	// An agent can hold an MCP entry at a scope where it has no skill location.
+	// Removing the entry still clears everything the row could name.
+	assert.True(t, Cleared(claudeCode, []agentcfg.Outcome{
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactMCP, Server: "srv", Action: agentcfg.ActionRemoved},
+		{Agent: "Claude Code", Artifact: agentcfg.ArtifactSkill, Action: agentcfg.ActionSkipped, Reason: "no global location"},
+	}))
+}
+
 func TestClearedFalseWhenSomethingFailed(t *testing.T) {
 	// The artifacts are still on disk, so the row has to stay.
 	assert.False(t, Cleared(claudeCode, []agentcfg.Outcome{

--- a/cli/internal/pkgstate/pkgstate.go
+++ b/cli/internal/pkgstate/pkgstate.go
@@ -141,6 +141,45 @@ func (e Entry) Key() Key {
 	return Key{Name: e.Name, Agent: e.Agent, Scope: e.Scope}
 }
 
+// WithCarriedArtifacts returns e with the artifacts prior still records but
+// this install did not write, carried forward.
+//
+// A row names every artifact dirctl wrote and has not since removed, not only
+// the artifacts the newest install produced. Two cases make the difference
+// matter, and both leave files or config keys on disk that nothing else would
+// ever clean up:
+//
+//   - A partly successful reinstall. The skill is written but the agent's MCP
+//     config cannot be read, so the new row names only the skill while the
+//     earlier install's server key is still in that config.
+//   - A new version that renames its MCP server. Installing it adds the new
+//     key and leaves the old one in place, because plain install removes
+//     nothing first.
+//
+// Skill paths are carried only when the new row has none, since one row holds
+// one skill path and the slug is derived from the record name, so it does not
+// move between installs of the same package.
+func (e Entry) WithCarriedArtifacts(prior Entry) Entry {
+	if e.SkillPath == "" && prior.SkillPath != "" {
+		e.SkillPath = prior.SkillPath
+		e.SkillFiles = prior.SkillFiles
+	}
+
+	seen := make(map[string]bool, len(e.MCPServers))
+	for _, name := range e.MCPServers {
+		seen[name] = true
+	}
+
+	for _, name := range prior.MCPServers {
+		if !seen[name] {
+			e.MCPServers = append(e.MCPServers, name)
+			seen[name] = true
+		}
+	}
+
+	return e
+}
+
 // manifestFile is the on-disk shape. It is separate from Manifest so the
 // schema version is written from the constant on every save and never carried
 // around as a mutable field.

--- a/cli/internal/pkgstate/pkgstate.go
+++ b/cli/internal/pkgstate/pkgstate.go
@@ -6,9 +6,10 @@
 //
 // Installed artifacts carry no provenance of their own — an Agent Skill is
 // marked only with its slug, with no version and no CID — so installed state
-// cannot be reconstructed from disk. This file is the only source of truth for
-// answering "what is installed, and is any of it stale?", and for removing
-// exactly what was written.
+// cannot be reconstructed from disk. This file is therefore the only place that
+// can answer "what is installed, and is any of it stale?", and the only place
+// that will be able to say what to remove once removal stops re-deriving
+// artifacts from the record.
 //
 // Two rules shape the API:
 //
@@ -92,9 +93,10 @@ type Key struct {
 // Entry is one installed package, for one agent, at one scope.
 //
 // The artifact fields record what was actually written, not what the record's
-// modules imply. That is what lets a later uninstall or upgrade remove exactly
-// those files and server keys without re-fetching a record that may since have
-// been garbage-collected upstream.
+// modules imply. Nothing reads them yet: today's uninstall re-derives artifacts
+// from the record and then deletes rows. They exist so that manifest-driven
+// uninstall and upgrade can remove exactly these files and server keys without
+// re-fetching a record that may since have been garbage-collected upstream.
 //
 // There is deliberately no artifact "type" field: one record can yield both a
 // skill and MCP servers, so the kind is derived from these fields for display.

--- a/cli/internal/pkgstate/pkgstate.go
+++ b/cli/internal/pkgstate/pkgstate.go
@@ -1,0 +1,316 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pkgstate owns dirctl's install manifest: the record of what
+// `dirctl install` wrote, where, and for which agent.
+//
+// Installed artifacts carry no provenance of their own — an Agent Skill is
+// marked only with its slug, with no version and no CID — so installed state
+// cannot be reconstructed from disk. This file is the only source of truth for
+// answering "what is installed, and is any of it stale?", and for removing
+// exactly what was written.
+//
+// Two rules shape the API:
+//
+//   - The manifest is bookkeeping, not the product. Losing it must never fail
+//     an install, so every failure here is a value the caller can warn about
+//     and carry on past.
+//   - The path is injected. Load and Save take one and DefaultPath is the only
+//     function that reads the environment, so tests never touch a real home
+//     directory. This is the pattern agentcfg.Env already sets.
+//
+// Readers must also tolerate drift. A user can edit or delete an artifact
+// behind our back, so anything reporting on a row has to stat what it reports
+// rather than trust the row alone.
+package pkgstate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/agntcy/dir/cli/internal/fsutil"
+)
+
+const (
+	// SchemaVersion is the manifest format this binary writes and understands.
+	SchemaVersion = 1
+
+	// ManifestFileName is the manifest's file name.
+	ManifestFileName = "installed.json"
+
+	// configDirName matches the directory the reusable client config already
+	// uses, so dirctl keeps all of its state in one place.
+	configDirName = "dirctl"
+
+	// manifestFilePerm keeps the manifest readable only by its owner: it lists
+	// every path dirctl has written into this user's agent configs.
+	manifestFilePerm = 0o600
+)
+
+// ErrFrozen is returned by Save when the file on disk was written by a newer
+// dirctl. Overwriting it would destroy rows this binary cannot represent, so
+// Save refuses instead.
+var ErrFrozen = errors.New("install manifest was written by a newer dirctl")
+
+// Origin says where a row's upstream lives, which decides how it is
+// version-checked.
+type Origin string
+
+const (
+	// OriginDirectory is a record pulled from a Directory, so its upstream is
+	// the Directory and a version check is a Resolve call.
+	OriginDirectory Origin = "directory"
+
+	// OriginBuiltin is a record dirctl builds from content compiled into the
+	// binary, so its upstream is the binary itself.
+	OriginBuiltin Origin = "builtin"
+)
+
+// Scope says which configuration location a row's artifacts were written to.
+type Scope string
+
+const (
+	// ScopeGlobal is the user's global agent config.
+	ScopeGlobal Scope = "global"
+
+	// ScopeProject is the current repository.
+	ScopeProject Scope = "project"
+)
+
+// Key identifies one row: one package, for one agent, at one scope.
+type Key struct {
+	Name  string
+	Agent string
+	Scope Scope
+}
+
+// Entry is one installed package, for one agent, at one scope.
+//
+// The artifact fields record what was actually written, not what the record's
+// modules imply. That is what lets a later uninstall or upgrade remove exactly
+// those files and server keys without re-fetching a record that may since have
+// been garbage-collected upstream.
+//
+// There is deliberately no artifact "type" field: one record can yield both a
+// skill and MCP servers, so the kind is derived from these fields for display.
+type Entry struct {
+	// Name is the record name, as pushed to the Directory.
+	Name string `json:"name"`
+
+	// Version is the record version that was installed, spelled as the record
+	// spells it. Compare it through cli/util/pkgver, never as text.
+	Version string `json:"version,omitempty"`
+
+	// CID is the content address of the exact record that was installed.
+	CID string `json:"cid,omitempty"`
+
+	// Agent is the agentcfg agent ID, e.g. "claude-code".
+	Agent string `json:"agent"`
+
+	// Scope is where the artifacts landed.
+	Scope Scope `json:"scope"`
+
+	// Origin is where to look for a newer version.
+	Origin Origin `json:"origin"`
+
+	// Pinned holds the package at Version, so a bare upgrade skips it.
+	Pinned bool `json:"pinned,omitempty"`
+
+	// InstalledAt is when this row was last written, in UTC.
+	InstalledAt time.Time `json:"installedAt"`
+
+	// SkillPath is the file or directory the skill landed in. Empty when the
+	// record installed no skill for this agent.
+	SkillPath string `json:"skillPath,omitempty"`
+
+	// SkillFiles are a skill bundle's files, relative to SkillPath. Empty for a
+	// single-file skill, where SkillPath is itself the file.
+	SkillFiles []string `json:"skillFiles,omitempty"`
+
+	// MCPServers are the config keys the MCP server entries were stored under.
+	MCPServers []string `json:"mcpServers,omitempty"`
+}
+
+// Key returns the row's primary key.
+func (e Entry) Key() Key {
+	return Key{Name: e.Name, Agent: e.Agent, Scope: e.Scope}
+}
+
+// manifestFile is the on-disk shape. It is separate from Manifest so the
+// schema version is written from the constant on every save and never carried
+// around as a mutable field.
+type manifestFile struct {
+	SchemaVersion int     `json:"schemaVersion"`
+	Entries       []Entry `json:"entries"`
+}
+
+// Manifest is the in-memory manifest: Load builds one, Save writes it back.
+type Manifest struct {
+	// Entries are in stored order, which Upsert preserves so a file the user
+	// reads does not reshuffle itself between installs.
+	Entries []Entry
+
+	degraded bool
+	frozen   bool
+}
+
+// Load reads the manifest at path.
+//
+// A missing file is an empty manifest and no error — the ordinary
+// first-install case. A file that cannot be understood is also an empty
+// manifest, plus a non-nil error the caller should warn about rather than abort
+// on, because losing the manifest must never fail an install.
+//
+// The two ways a file can be unusable differ in what the next Save does:
+//
+//	corrupt JSON            Degraded. Its rows are already unreadable, so Save
+//	                        overwrites and the user starts a fresh manifest.
+//	schemaVersion too new    Degraded and Frozen. A newer dirctl wrote it, so
+//	                        Save refuses rather than destroy state this binary
+//	                        cannot represent. An unreadable file is frozen too,
+//	                        since its contents are unknown.
+func Load(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return &Manifest{}, nil
+		}
+
+		return &Manifest{degraded: true, frozen: true},
+			fmt.Errorf("read install manifest %s: %w", path, err)
+	}
+
+	var file manifestFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return &Manifest{degraded: true},
+			fmt.Errorf("parse install manifest %s: %w", path, err)
+	}
+
+	if file.SchemaVersion > SchemaVersion {
+		return &Manifest{degraded: true, frozen: true}, fmt.Errorf(
+			"%w: %s has schema version %d, this dirctl understands %d — upgrade dirctl to manage installed packages",
+			ErrFrozen, path, file.SchemaVersion, SchemaVersion)
+	}
+
+	return &Manifest{Entries: file.Entries}, nil
+}
+
+// Save writes the manifest to path through a temp file in the same directory,
+// renamed over the target, so a reader never sees a half-written manifest and
+// no partial file is left behind.
+func (m *Manifest) Save(path string) error {
+	if m.frozen {
+		return fmt.Errorf("%w: refusing to overwrite %s", ErrFrozen, path)
+	}
+
+	// Marshal a non-nil slice so an emptied manifest is `"entries": []` rather
+	// than `"entries": null`.
+	entries := m.Entries
+	if entries == nil {
+		entries = []Entry{}
+	}
+
+	data, err := json.MarshalIndent(manifestFile{
+		SchemaVersion: SchemaVersion,
+		Entries:       entries,
+	}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode install manifest: %w", err)
+	}
+
+	data = append(data, '\n')
+
+	if err := fsutil.WriteAtomic(path, data, fsutil.WriteOptions{FileMode: manifestFilePerm}); err != nil {
+		return fmt.Errorf("write install manifest %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// Degraded reports that the file on disk could not be used, so Entries is
+// empty even though the file may hold rows.
+func (m *Manifest) Degraded() bool { return m.degraded }
+
+// Frozen reports that Save will refuse, because the file belongs to a newer
+// dirctl.
+func (m *Manifest) Frozen() bool { return m.frozen }
+
+// Upsert inserts e, or replaces the row with the same key in place so stored
+// order stays stable.
+func (m *Manifest) Upsert(e Entry) {
+	key := e.Key()
+
+	for i := range m.Entries {
+		if m.Entries[i].Key() == key {
+			m.Entries[i] = e
+
+			return
+		}
+	}
+
+	m.Entries = append(m.Entries, e)
+}
+
+// Remove drops the row with the given key and reports whether one was there.
+func (m *Manifest) Remove(key Key) bool {
+	for i := range m.Entries {
+		if m.Entries[i].Key() == key {
+			m.Entries = append(m.Entries[:i], m.Entries[i+1:]...)
+
+			return true
+		}
+	}
+
+	return false
+}
+
+// Find returns the row with the given key.
+func (m *Manifest) Find(key Key) (Entry, bool) {
+	for _, e := range m.Entries {
+		if e.Key() == key {
+			return e, true
+		}
+	}
+
+	return Entry{}, false
+}
+
+// ByName returns every row for a package name — one per agent and scope it was
+// installed into — in stored order.
+func (m *Manifest) ByName(name string) []Entry {
+	var found []Entry
+
+	for _, e := range m.Entries {
+		if e.Name == name {
+			found = append(found, e)
+		}
+	}
+
+	return found
+}
+
+// DefaultPath returns the global manifest path,
+// $XDG_CONFIG_HOME/dirctl/installed.json, falling back to ~/.config when
+// XDG_CONFIG_HOME is unset — the same convention the reusable client config
+// already follows.
+//
+// This is the only function in the package that reads the environment.
+// Everything else takes the path, which is what keeps the tests hermetic.
+func DefaultPath() (string, error) {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("determine user home directory: %w", err)
+		}
+
+		configHome = filepath.Join(home, ".config")
+	}
+
+	return filepath.Join(configHome, configDirName, ManifestFileName), nil
+}

--- a/cli/internal/pkgstate/pkgstate_test.go
+++ b/cli/internal/pkgstate/pkgstate_test.go
@@ -219,6 +219,67 @@ func TestUpsertKeysOnNameAgentAndScope(t *testing.T) {
 	assert.Len(t, m.Entries, 3)
 }
 
+func TestWithCarriedArtifactsKeepsAServerThisInstallDidNotWrite(t *testing.T) {
+	// A partly successful reinstall: the skill was written, the agent's MCP
+	// config could not be read, so the new row names no server. The earlier
+	// key is still in that config and only the row knows about it.
+	prior := sampleEntry()
+
+	fresh := sampleEntry()
+	fresh.MCPServers = nil
+
+	merged := fresh.WithCarriedArtifacts(prior)
+	assert.Equal(t, []string{"agntcy-dir"}, merged.MCPServers)
+}
+
+func TestWithCarriedArtifactsUnionsRenamedServers(t *testing.T) {
+	// A new version renamed its server. Plain install removes nothing first,
+	// so both keys are on disk and the row must name both.
+	prior := sampleEntry()
+
+	fresh := sampleEntry()
+	fresh.MCPServers = []string{"agntcy-dir-v2"}
+
+	merged := fresh.WithCarriedArtifacts(prior)
+	assert.Equal(t, []string{"agntcy-dir-v2", "agntcy-dir"}, merged.MCPServers)
+}
+
+func TestWithCarriedArtifactsDoesNotDuplicateServers(t *testing.T) {
+	prior := sampleEntry()
+	merged := sampleEntry().WithCarriedArtifacts(prior)
+	assert.Equal(t, []string{"agntcy-dir"}, merged.MCPServers)
+}
+
+func TestWithCarriedArtifactsKeepsASkillThisInstallDidNotWrite(t *testing.T) {
+	prior := sampleEntry()
+
+	fresh := sampleEntry()
+	fresh.SkillPath = ""
+	fresh.SkillFiles = nil
+
+	merged := fresh.WithCarriedArtifacts(prior)
+	assert.Equal(t, prior.SkillPath, merged.SkillPath)
+	assert.Equal(t, prior.SkillFiles, merged.SkillFiles)
+}
+
+func TestWithCarriedArtifactsPrefersTheNewSkill(t *testing.T) {
+	prior := sampleEntry()
+
+	fresh := sampleEntry()
+	fresh.SkillPath = "/home/dev/.claude/skills/renamed"
+	fresh.SkillFiles = []string{"SKILL.md"}
+
+	merged := fresh.WithCarriedArtifacts(prior)
+	assert.Equal(t, "/home/dev/.claude/skills/renamed", merged.SkillPath)
+	assert.Equal(t, []string{"SKILL.md"}, merged.SkillFiles)
+}
+
+func TestWithCarriedArtifactsOnAFirstInstall(t *testing.T) {
+	// No prior row, so there is nothing to carry.
+	entry := sampleEntry()
+	assert.Equal(t, entry, entry.WithCarriedArtifacts(pkgstate.Entry{}))
+}
+
 func TestRemove(t *testing.T) {
 	m := &pkgstate.Manifest{}
 	entry := sampleEntry()

--- a/cli/internal/pkgstate/pkgstate_test.go
+++ b/cli/internal/pkgstate/pkgstate_test.go
@@ -1,0 +1,286 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package pkgstate_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/agntcy/dir/cli/internal/pkgstate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func manifestPath(t *testing.T) string {
+	t.Helper()
+
+	return filepath.Join(t.TempDir(), pkgstate.ManifestFileName)
+}
+
+func sampleEntry() pkgstate.Entry {
+	return pkgstate.Entry{
+		Name:        "cisco.com/agent",
+		Version:     "1.0.0",
+		CID:         "bafyreibsample",
+		Agent:       "claude-code",
+		Scope:       pkgstate.ScopeGlobal,
+		Origin:      pkgstate.OriginDirectory,
+		InstalledAt: time.Date(2026, time.August, 14, 9, 30, 0, 0, time.UTC),
+		SkillPath:   "/home/dev/.claude/skills/cisco.com-agent",
+		SkillFiles:  []string{"SKILL.md", "references/api.md"},
+		MCPServers:  []string{"agntcy-dir"},
+	}
+}
+
+func TestLoadMissingFileIsEmpty(t *testing.T) {
+	m, err := pkgstate.Load(manifestPath(t))
+	require.NoError(t, err)
+	assert.Empty(t, m.Entries)
+	assert.False(t, m.Degraded())
+	assert.False(t, m.Frozen())
+}
+
+func TestSaveThenLoadRoundTrip(t *testing.T) {
+	path := manifestPath(t)
+	entry := sampleEntry()
+
+	m := &pkgstate.Manifest{}
+	m.Upsert(entry)
+	require.NoError(t, m.Save(path))
+
+	loaded, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	require.Len(t, loaded.Entries, 1)
+	assert.Equal(t, entry, loaded.Entries[0])
+}
+
+func TestSaveWritesOwnerOnlyFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not meaningful on Windows")
+	}
+
+	path := manifestPath(t)
+	require.NoError(t, (&pkgstate.Manifest{}).Save(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	// The manifest lists every path dirctl wrote into this user's configs.
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestSaveCreatesMissingParentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "dirctl", pkgstate.ManifestFileName)
+
+	m := &pkgstate.Manifest{}
+	m.Upsert(sampleEntry())
+	require.NoError(t, m.Save(path))
+
+	loaded, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	assert.Len(t, loaded.Entries, 1)
+}
+
+func TestSaveLeavesNoTempFileBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, pkgstate.ManifestFileName)
+
+	m := &pkgstate.Manifest{}
+	m.Upsert(sampleEntry())
+	require.NoError(t, m.Save(path))
+	require.NoError(t, m.Save(path))
+
+	names, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, names, 1)
+	assert.Equal(t, pkgstate.ManifestFileName, names[0].Name())
+}
+
+func TestSaveEmptyManifestWritesAnEmptyList(t *testing.T) {
+	path := manifestPath(t)
+	require.NoError(t, (&pkgstate.Manifest{}).Save(path))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	// Not `null`: a reader in any language sees a list it can iterate.
+	assert.Contains(t, string(data), `"entries": []`)
+	assert.Contains(t, string(data), `"schemaVersion": 1`)
+}
+
+func TestLoadCorruptFileDegradesAndStaysWritable(t *testing.T) {
+	path := manifestPath(t)
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o600))
+
+	m, err := pkgstate.Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse install manifest")
+	assert.Empty(t, m.Entries)
+	assert.True(t, m.Degraded())
+	// Its rows are already unreadable, so a fresh manifest may replace it.
+	assert.False(t, m.Frozen())
+
+	m.Upsert(sampleEntry())
+	require.NoError(t, m.Save(path))
+
+	loaded, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	assert.Len(t, loaded.Entries, 1)
+}
+
+func TestLoadForwardSchemaVersionIsFrozen(t *testing.T) {
+	path := manifestPath(t)
+	future := []byte(`{"schemaVersion": 99, "entries": [{"name": "x", "agent": "claude-code"}]}`)
+	require.NoError(t, os.WriteFile(path, future, 0o600))
+
+	m, err := pkgstate.Load(path)
+	require.Error(t, err)
+	require.ErrorIs(t, err, pkgstate.ErrFrozen)
+	assert.Contains(t, err.Error(), "upgrade dirctl")
+	assert.Empty(t, m.Entries)
+	assert.True(t, m.Degraded())
+	assert.True(t, m.Frozen())
+
+	// Saving would destroy rows this binary cannot represent, so it refuses and
+	// the newer dirctl's file survives untouched.
+	m.Upsert(sampleEntry())
+	require.ErrorIs(t, m.Save(path), pkgstate.ErrFrozen)
+
+	onDisk, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, future, onDisk)
+}
+
+func TestLoadAcceptsMissingSchemaVersion(t *testing.T) {
+	// A hand-written file with no schemaVersion reads as the current format
+	// rather than being thrown away.
+	path := manifestPath(t)
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"entries": [{"name": "x", "agent": "claude-code", "scope": "global"}]}`), 0o600))
+
+	m, err := pkgstate.Load(path)
+	require.NoError(t, err)
+	require.Len(t, m.Entries, 1)
+	assert.Equal(t, "x", m.Entries[0].Name)
+}
+
+func TestLoadUnreadableFileIsFrozen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file modes are not meaningful on Windows")
+	}
+
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+
+	path := manifestPath(t)
+	require.NoError(t, os.WriteFile(path, []byte(`{"schemaVersion":1,"entries":[]}`), 0o000))
+
+	m, err := pkgstate.Load(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read install manifest")
+	// The contents are unknown, so overwriting them is not safe either.
+	assert.True(t, m.Frozen())
+}
+
+func TestUpsertReplacesInPlaceOnTheSameKey(t *testing.T) {
+	m := &pkgstate.Manifest{}
+	m.Upsert(sampleEntry())
+	m.Upsert(pkgstate.Entry{Name: "other", Agent: "cursor", Scope: pkgstate.ScopeGlobal})
+
+	updated := sampleEntry()
+	updated.Version = "2.0.0"
+	m.Upsert(updated)
+
+	require.Len(t, m.Entries, 2)
+	// Replaced where it stood, so the file the user reads keeps its order.
+	assert.Equal(t, "2.0.0", m.Entries[0].Version)
+	assert.Equal(t, "other", m.Entries[1].Name)
+}
+
+func TestUpsertKeysOnNameAgentAndScope(t *testing.T) {
+	m := &pkgstate.Manifest{}
+
+	base := sampleEntry()
+	m.Upsert(base)
+
+	otherAgent := base
+	otherAgent.Agent = "cursor"
+	m.Upsert(otherAgent)
+
+	otherScope := base
+	otherScope.Scope = pkgstate.ScopeProject
+	m.Upsert(otherScope)
+
+	// One package, three rows: the same name is installed for two agents and at
+	// two scopes, and none of them collides.
+	assert.Len(t, m.Entries, 3)
+}
+
+func TestRemove(t *testing.T) {
+	m := &pkgstate.Manifest{}
+	entry := sampleEntry()
+	m.Upsert(entry)
+
+	assert.False(t, m.Remove(pkgstate.Key{Name: "cisco.com/agent", Agent: "cursor", Scope: pkgstate.ScopeGlobal}))
+	assert.Len(t, m.Entries, 1)
+
+	assert.True(t, m.Remove(entry.Key()))
+	assert.Empty(t, m.Entries)
+
+	assert.False(t, m.Remove(entry.Key()))
+}
+
+func TestFind(t *testing.T) {
+	m := &pkgstate.Manifest{}
+	entry := sampleEntry()
+	m.Upsert(entry)
+
+	got, ok := m.Find(entry.Key())
+	require.True(t, ok)
+	assert.Equal(t, entry, got)
+
+	_, ok = m.Find(pkgstate.Key{Name: "missing", Agent: "cursor", Scope: pkgstate.ScopeGlobal})
+	assert.False(t, ok)
+}
+
+func TestByName(t *testing.T) {
+	m := &pkgstate.Manifest{}
+
+	base := sampleEntry()
+	m.Upsert(base)
+
+	cursor := base
+	cursor.Agent = "cursor"
+	m.Upsert(cursor)
+
+	m.Upsert(pkgstate.Entry{Name: "other", Agent: "claude-code", Scope: pkgstate.ScopeGlobal})
+
+	rows := m.ByName("cisco.com/agent")
+	require.Len(t, rows, 2)
+	assert.Equal(t, "claude-code", rows[0].Agent)
+	assert.Equal(t, "cursor", rows[1].Agent)
+
+	assert.Empty(t, m.ByName("nothing-here"))
+}
+
+func TestDefaultPathUsesXDGConfigHome(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join("/tmp", "xdg"))
+
+	path, err := pkgstate.DefaultPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/tmp", "xdg", "dirctl", "installed.json"), path)
+}
+
+func TestDefaultPathFallsBackToHomeConfig(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	path, err := pkgstate.DefaultPath()
+	require.NoError(t, err)
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".config", "dirctl", "installed.json"), path)
+}

--- a/cli/util/pkgver/pkgver.go
+++ b/cli/util/pkgver/pkgver.go
@@ -1,0 +1,102 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pkgver compares record versions as semantic versions.
+//
+// Every client-side "is this newer?" decision goes through here, because the
+// Directory server compares versions as SQL text: `version > ?` against a text
+// column puts "v1.10.0" below "v1.9.0". Ordering therefore has to happen in the
+// CLI, on version strings the server hands back.
+//
+// Comparison is delegated to golang.org/x/mod/semver, which is
+// Go-module-flavored in two ways that matter:
+//
+//   - It requires the "v" prefix. Records commonly store "1.0.0", so Canonical
+//     adds one before comparing.
+//   - It accepts the short forms "v1" and "v1.0", canonicalizing both to
+//     "v1.0.0". That leniency is wanted: a record tagged "1.0" is still
+//     orderable against "1.0.1".
+//
+// Only strings the library rejects outright are incomparable — "main",
+// "latest", "2026-08-14", "1.0.0.0", "V1.0.0", the empty string. Canonical
+// reports "" for those, and a caller must never auto-upgrade across one:
+// nothing can be said about whether it is older or newer than anything else.
+package pkgver
+
+import "golang.org/x/mod/semver"
+
+// Canonical returns raw in canonical semver form ("v1.2.3", "v1.2.3-rc.1"), or
+// "" when raw carries no ordering. A missing "v" prefix is added. Build
+// metadata is dropped, because semver gives it no ordering.
+//
+// An empty result is the comparability test: Canonical(raw) == "" means no
+// claim can be made about where raw sits relative to another version.
+func Canonical(raw string) string {
+	v := raw
+	if v != "" && v[0] != 'v' {
+		v = "v" + v
+	}
+
+	if !semver.IsValid(v) {
+		return ""
+	}
+
+	return semver.Canonical(v)
+}
+
+// Compare returns -1, 0 or +1 as a sorts before, with, or after b.
+//
+// Incomparable versions sort below every comparable one, and two of them
+// compare equal. That ordering is a convenience for sorting a mixed list, not a
+// license to act: before offering an upgrade, check Canonical on both sides, so
+// an unorderable installed version is never silently moved.
+func Compare(a, b string) int {
+	ca, cb := Canonical(a), Canonical(b)
+
+	switch {
+	case ca == "" && cb == "":
+		return 0
+	case ca == "":
+		return -1
+	case cb == "":
+		return 1
+	default:
+		return semver.Compare(ca, cb)
+	}
+}
+
+// IsPrerelease reports whether raw is a comparable version carrying a
+// prerelease suffix, as "v1.0.0-rc.1" does. An incomparable version is not a
+// prerelease — it is simply unordered.
+func IsPrerelease(raw string) bool {
+	c := Canonical(raw)
+	if c == "" {
+		return false
+	}
+
+	return semver.Prerelease(c) != ""
+}
+
+// Newest returns the highest version in versions, spelled the way the caller
+// wrote it, and whether one was found. Incomparable entries are ignored and
+// ties keep the entry seen first.
+//
+// A list with nothing comparable in it reports false, so callers fall back to
+// their own rule rather than pick arbitrarily.
+func Newest(versions []string) (string, bool) {
+	best := ""
+	found := false
+
+	for _, v := range versions {
+		if Canonical(v) == "" {
+			continue
+		}
+
+		if !found || Compare(v, best) > 0 {
+			best = v
+			found = true
+		}
+	}
+
+	return best, found
+}

--- a/cli/util/pkgver/pkgver_test.go
+++ b/cli/util/pkgver/pkgver_test.go
@@ -1,0 +1,124 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package pkgver_test
+
+import (
+	"testing"
+
+	"github.com/agntcy/dir/cli/util/pkgver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCanonical is the truth table for what this CLI can order. The short forms
+// "1" and "1.0" canonicalize rather than fail, which is deliberate: a record
+// tagged "1.0" is still orderable. Everything in the second group carries no
+// ordering at all and must never be auto-upgraded across.
+func TestCanonical(t *testing.T) {
+	orderable := map[string]string{
+		"1":              "v1.0.0",
+		"v1":             "v1.0.0",
+		"1.0":            "v1.0.0",
+		"v1.0":           "v1.0.0",
+		"1.0.0":          "v1.0.0",
+		"v1.0.0":         "v1.0.0",
+		"0.0.0":          "v0.0.0",
+		"1.10.0":         "v1.10.0",
+		"1.0.0-rc.1":     "v1.0.0-rc.1",
+		"v1.0.0-rc.1":    "v1.0.0-rc.1",
+		"1.0.0+build.5":  "v1.0.0",
+		"v1.0.0+build.5": "v1.0.0",
+	}
+
+	for raw, want := range orderable {
+		assert.Equal(t, want, pkgver.Canonical(raw), "Canonical(%q)", raw)
+	}
+
+	unorderable := []string{
+		"",
+		"main",
+		"latest",
+		"2026-08-14",
+		"1.0.0.0",
+		"V1.0.0",
+		" v1.0.0",
+		"v1.0.0 ",
+		"v",
+		"1.0.0-",
+	}
+
+	for _, raw := range unorderable {
+		assert.Empty(t, pkgver.Canonical(raw), "Canonical(%q)", raw)
+	}
+}
+
+// TestCompareOrdersNumerically is the whole reason this package exists: the
+// server's text comparison puts 1.10.0 below 1.9.0.
+func TestCompareOrdersNumerically(t *testing.T) {
+	assert.Positive(t, pkgver.Compare("1.10.0", "1.9.0"))
+	assert.Negative(t, pkgver.Compare("1.9.0", "1.10.0"))
+	assert.Positive(t, pkgver.Compare("2.0.0", "1.99.99"))
+}
+
+func TestCompareEqualForms(t *testing.T) {
+	// Missing "v", short forms, and build metadata are all the same version.
+	assert.Equal(t, 0, pkgver.Compare("1.0.0", "v1.0.0"))
+	assert.Equal(t, 0, pkgver.Compare("v1", "1.0.0"))
+	assert.Equal(t, 0, pkgver.Compare("1.0", "v1.0.0"))
+	assert.Equal(t, 0, pkgver.Compare("1.0.0+a", "1.0.0+b"))
+}
+
+func TestComparePrereleaseSortsBelowRelease(t *testing.T) {
+	assert.Negative(t, pkgver.Compare("1.0.0-rc.1", "1.0.0"))
+	assert.Negative(t, pkgver.Compare("1.0.0-rc.1", "1.0.0-rc.2"))
+}
+
+func TestCompareIncomparable(t *testing.T) {
+	// An unorderable version sorts below every real one, in both directions.
+	assert.Negative(t, pkgver.Compare("main", "1.0.0"))
+	assert.Positive(t, pkgver.Compare("1.0.0", "main"))
+	// Two unorderable versions are equal, so a caller checking for a positive
+	// result never treats one as an upgrade over the other.
+	assert.Equal(t, 0, pkgver.Compare("main", "latest"))
+	assert.Equal(t, 0, pkgver.Compare("", ""))
+}
+
+func TestIsPrerelease(t *testing.T) {
+	assert.True(t, pkgver.IsPrerelease("1.0.0-rc.1"))
+	assert.True(t, pkgver.IsPrerelease("v2.0.0-alpha"))
+	assert.False(t, pkgver.IsPrerelease("1.0.0"))
+	assert.False(t, pkgver.IsPrerelease("1.0.0+build.5"))
+	// Unorderable is not a prerelease; it is simply unordered.
+	assert.False(t, pkgver.IsPrerelease("main"))
+	assert.False(t, pkgver.IsPrerelease(""))
+}
+
+func TestNewest(t *testing.T) {
+	got, ok := pkgver.Newest([]string{"1.9.0", "1.10.0", "1.2.0"})
+	require.True(t, ok)
+	// The caller's spelling is preserved, not the canonical form.
+	assert.Equal(t, "1.10.0", got)
+}
+
+func TestNewestSkipsIncomparable(t *testing.T) {
+	got, ok := pkgver.Newest([]string{"main", "1.0.0", "latest"})
+	require.True(t, ok)
+	assert.Equal(t, "1.0.0", got)
+}
+
+func TestNewestKeepsFirstOfEqualVersions(t *testing.T) {
+	got, ok := pkgver.Newest([]string{"v1.0.0", "1.0.0", "1"})
+	require.True(t, ok)
+	assert.Equal(t, "v1.0.0", got)
+}
+
+func TestNewestFindsNothingComparable(t *testing.T) {
+	got, ok := pkgver.Newest([]string{"main", "latest", ""})
+	assert.False(t, ok)
+	assert.Empty(t, got)
+
+	got, ok = pkgver.Newest(nil)
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}

--- a/cli/util/records/records.go
+++ b/cli/util/records/records.go
@@ -13,8 +13,8 @@ import (
 
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	searchv1 "github.com/agntcy/dir/api/search/v1"
+	"github.com/agntcy/dir/cli/util/pkgver"
 	"github.com/agntcy/dir/client"
-	"golang.org/x/mod/semver"
 )
 
 // CollectCIDs runs a search and returns the matching record CIDs.
@@ -82,6 +82,11 @@ func SanitizeSlug(name string) string {
 
 // LatestByName deduplicates records by name, keeping the highest semver version
 // for each unique name while preserving first-seen order.
+//
+// Ordering goes through cli/util/pkgver, which is the single implementation of
+// "is this newer?" for the CLI. A version the library cannot order is treated
+// as no version at all, so it never displaces a comparable one and never wins
+// by accident.
 func LatestByName(records []*corev1.Record) []*corev1.Record {
 	type entry struct {
 		record  *corev1.Record
@@ -94,7 +99,7 @@ func LatestByName(records []*corev1.Record) []*corev1.Record {
 
 	for _, r := range records {
 		name := r.GetName()
-		ver := canonicalVersion(r.GetVersion())
+		ver := pkgver.Canonical(r.GetVersion())
 
 		existing, seen := best[name]
 		if !seen {
@@ -108,7 +113,7 @@ func LatestByName(records []*corev1.Record) []*corev1.Record {
 			continue
 		}
 
-		if existing.version == "" || semver.Compare(ver, existing.version) > 0 {
+		if existing.version == "" || pkgver.Compare(ver, existing.version) > 0 {
 			best[name] = &entry{record: r, version: ver}
 		}
 	}
@@ -148,17 +153,4 @@ func BatchFileName(record *corev1.Record, index int, seen map[string]int, allVer
 	}
 
 	return base
-}
-
-func canonicalVersion(raw string) string {
-	v := raw
-	if v != "" && v[0] != 'v' {
-		v = "v" + v
-	}
-
-	if semver.IsValid(v) {
-		return v
-	}
-
-	return ""
 }

--- a/cli/util/records/records_test.go
+++ b/cli/util/records/records_test.go
@@ -61,6 +61,26 @@ func TestLatestByNameHandlesVPrefixAndPrerelease(t *testing.T) {
 	assert.NotContains(t, pre[0].GetVersion(), "alpha")
 }
 
+func TestLatestByNameOrdersNumericallyNotAsText(t *testing.T) {
+	// The whole reason ordering goes through pkgver: as text, 1.9.0 sorts
+	// above 1.10.0.
+	out := LatestByName([]*corev1.Record{rec("x", "1.9.0"), rec("x", "1.10.0")})
+	require.Len(t, out, 1)
+	assert.Equal(t, "1.10.0", out[0].GetVersion())
+}
+
+func TestLatestByNameIgnoresUnorderableVersions(t *testing.T) {
+	// A version pkgver cannot order never displaces a comparable one.
+	out := LatestByName([]*corev1.Record{rec("x", "1.0.0"), rec("x", "main")})
+	require.Len(t, out, 1)
+	assert.Equal(t, "1.0.0", out[0].GetVersion())
+
+	// It is still kept when nothing comparable exists, so a name never vanishes.
+	only := LatestByName([]*corev1.Record{rec("x", "main")})
+	require.Len(t, only, 1)
+	assert.Equal(t, "main", only[0].GetVersion())
+}
+
 func TestLatestByNamePreservesFirstSeenOrderAndEmpty(t *testing.T) {
 	out := LatestByName([]*corev1.Record{rec("b", "1.0.0"), rec("a", "1.0.0"), rec("b", "1.0.0")})
 	require.Len(t, out, 2)

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -198,6 +198,11 @@ record's modules imply, so a later uninstall removes exactly those without
 re-fetching a record that may since have been garbage-collected upstream. An
 agent that received nothing — skipped or failed — is not recorded.
 
+A row names every artifact `dirctl` wrote and has not since removed, so
+reinstalling carries forward anything the previous row named that the new
+install did not write. That covers a reinstall where one artifact failed, and a
+new version that renames its MCP server while the old key stays in the config.
+
 The manifest is bookkeeping, not the product: if it cannot be read or written,
 `dirctl` prints a warning and the install still succeeds. Project-scope
 (`--project`) installs are not recorded yet.
@@ -264,9 +269,12 @@ leaving all other content intact. Shares the same flags as install (`--agents`,
 `--project`, `--dry-run`, `--yes`). Idempotent: an agent with nothing of ours
 installed is reported as unchanged, never an error.
 
-The record's row is dropped from the install manifest for every agent it was
-removed from. An agent whose removal failed keeps its row, because its artifacts
-are still on disk.
+The record's row is dropped from the install manifest for every agent whose
+artifacts are confirmed gone, meaning at least one was removed or already
+absent and none failed. An agent keeps its row when a removal failed, and when
+every artifact was skipped because its location could not be resolved for that
+scope — in both cases something may still be on disk, and the row is the only
+note of what it is.
 
 `dirctl uninstall <cid-or-name>` is a top-level shorthand for
 `dirctl install uninstall <cid-or-name>` (same flags and behavior).

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -184,6 +184,24 @@ Writes are atomic and surgical: only our own MCP entry, skill file/folder, or
 delimited managed block is added/updated/removed — all of your existing
 configuration is preserved.
 
+### The install manifest
+
+Installed artifacts carry no provenance of their own: an Agent Skill is marked
+only with its slug, with no version and no CID. So every global install records
+what it wrote in `$XDG_CONFIG_HOME/dirctl/installed.json` (`~/.config` when
+`XDG_CONFIG_HOME` is unset) — one row per record, agent, and scope, holding the
+version and CID that were installed, the skill path and its file list, and the
+MCP server keys.
+
+The row lists the artifacts that were **actually written**, not the ones the
+record's modules imply, so a later uninstall removes exactly those without
+re-fetching a record that may since have been garbage-collected upstream. An
+agent that received nothing — skipped or failed — is not recorded.
+
+The manifest is bookkeeping, not the product: if it cannot be read or written,
+`dirctl` prints a warning and the install still succeeds. Project-scope
+(`--project`) installs are not recorded yet.
+
 ### `dirctl install list`
 
 Lists every supported agent, whether it is detected on this machine, and the
@@ -210,6 +228,7 @@ A2A-only record, points you to `dirctl export`.
 | `--project` | Write into the current repo (project scope) instead of the user's global config | `false` |
 | `--dry-run` | Preview the plan without writing | `false` |
 | `--yes` / `-y` | Skip the confirmation prompt | `false` |
+| `--pin` | Hold the package at the version that was installed. Implied when the reference names an explicit `:version` | `false` |
 
 Valid agent IDs: `claude-code`, `claude-desktop`, `cursor`, `vscode`, `windsurf`,
 `cline`, `roo`, `gemini`, `opencode`, `zed`, `continue`, `codex` (see
@@ -244,6 +263,10 @@ Removes what `install` added for that record — its MCP entry and/or skill —
 leaving all other content intact. Shares the same flags as install (`--agents`,
 `--project`, `--dry-run`, `--yes`). Idempotent: an agent with nothing of ours
 installed is reported as unchanged, never an error.
+
+The record's row is dropped from the install manifest for every agent it was
+removed from. An agent whose removal failed keeps its row, because its artifacts
+are still on disk.
 
 `dirctl uninstall <cid-or-name>` is a top-level shorthand for
 `dirctl install uninstall <cid-or-name>` (same flags and behavior).

--- a/docs/content/dir/dir-cli-reference.md
+++ b/docs/content/dir/dir-cli-reference.md
@@ -194,9 +194,15 @@ version and CID that were installed, the skill path and its file list, and the
 MCP server keys.
 
 The row lists the artifacts that were **actually written**, not the ones the
-record's modules imply, so a later uninstall removes exactly those without
-re-fetching a record that may since have been garbage-collected upstream. An
-agent that received nothing — skipped or failed — is not recorded.
+record's modules imply. An agent that received nothing — skipped or failed — is
+not recorded.
+
+Today the manifest is only bookkeeping: `uninstall` still resolves and pulls
+the record, derives its current artifacts, removes those, and then deletes the
+rows. It does not read `skillFiles` or `mcpServers` to decide what to remove.
+Recording them is what will let a future manifest-driven `uninstall` and
+`upgrade` remove exactly the artifacts that were written, without re-fetching a
+record that may since have been garbage-collected upstream.
 
 A row names every artifact `dirctl` wrote and has not since removed, so
 reinstalling carries forward anything the previous row named that the new


### PR DESCRIPTION
Adds the three leaf packages the rest of dirctl package management is built on, plus the wiring that makes `install` and `uninstall` keep a record of what they did. No new user-facing commands: both behave as they do today and additionally write a manifest row.

`cli/util/pkgver` is semantic version comparison. The server compares versions as SQL text, so `version > ?` against a text column ranks v1.10.0 below v1.9.0; every client-side "is this newer?" decision now orders versions in the CLI instead. `Canonical` adds the "v" prefix records commonly omit and returns `""` for anything `golang.org/x/mod/semver` rejects, which doubles as the comparability test. The short forms `v1` and `v1.0` canonicalize to `v1.0.0` rather than fail, deliberately: a record tagged `1.0` is still orderable. Strings like `main`, `latest`, `2026-08-14` and `1.0.0.0` carry no ordering at all and must never be auto-upgraded across. `Compare` sorts those below every real version so a mixed list still sorts, `Newest` returns the highest entry as the caller spelled it, and `IsPrerelease` keeps release candidates out of upgrade suggestions.

`cli/internal/pkgstate` is the manifest at `$XDG_CONFIG_HOME/dirctl/installed.json`, keyed by (name, agent, scope). Each row stores the artifacts that were **actually written** — skill path, skill file list, MCP server keys — rather than what the record's modules imply. Nothing reads those fields yet: today's `uninstall` still resolves and pulls the record, derives its current artifacts, removes those, and only then deletes rows. They are recorded so that manifest-driven uninstall and upgrade can remove exactly what was written, without re-fetching a record that may since have been garbage-collected upstream. There is no `type` field, because one record can yield both a skill and MCP servers, so the artifact kind is derived for display. `Origin` separates `directory` rows from `builtin` ones. Writes are temp-file plus rename. A missing file reads as empty, a corrupt file degrades to an empty-but-flagged manifest with a warning, and a forward `schemaVersion` is additionally frozen so a newer dirctl's rows are never overwritten. Losing the manifest never fails an install. The path is injected by callers and only `DefaultPath` reads the environment, so the tests are hermetic.

`api/exportfmt.SkillBundleFiles` lists a bundle's regular files. `TarEntry`'s fields are unexported, so this is the one accessor callers outside `exportfmt` have for entry names; a plain-text `SKILL.md` artifact reports the single file the extractor creates for it. `DeriveArtifacts` calls it once, where a malformed bundle can still be reported as an error, which keeps `SkillFiles` a plain accessor.

`agentinstall` gains `Slug`, `HasSkill`, `MCPServerNames`, `SkillFiles`, `BuildEntry`, and `Cleared`, since `Artifacts`'s fields are unexported and `cli/cmd/install` cannot build a row from them. `agentcfg.Outcome` gains a `Server` field: one agent produces one outcome per MCP server, all sharing a config path, so nothing else told them apart and a row could not honestly claim only the keys that were written. `ArtifactMCP` and `ArtifactSkill` replace the artifact-kind string literals in the two placement engines.

`runApplyCmd` and `runBatch` record rows after a successful apply, one per agent that actually received an artifact. Agents whose outcomes were all skipped or failed are not recorded, so a later listing never claims an install that did not happen; on uninstall, an agent whose removal failed keeps its row, because its artifacts are still on disk. Dry runs record nothing, and project-scope installs are not tracked in this iteration — the row shape already carries `scope`, so a committed per-project manifest is a later addition rather than a rewrite. `--pin` is added as a local flag on `install` and `install run`, implied whenever the reference carries an explicit `:version`. It is flag-bound rather than a plain field because the local e2e suite runs dirctl in-process against a package-level `opts` singleton, so anything the harness does not reset leaks between specs.

`records.LatestByName` is refactored onto `pkgver`, so batch install, pull, and export no longer carry a second version-ordering implementation, and `canonicalVersion` is deleted. `cli/util/reference` keeps its own `semver.IsValid` call on purpose: it decides whether the text after a reference's last colon looks like a version rather than a port, which is a question about shape, not about which of two versions is newer.

Shared skill locations are recorded for every agent they serve. Claude Code and Claude Desktop share one skills folder, and so do Zed and Codex CLI, so the skill is written once; `Install` and `Uninstall` now report an `ActionUnchanged` outcome naming that path for the agent that shares it, instead of passing over it in silence. Without that the manifest held a row for the first agent only, and uninstalling for one of a pair could never clear the other's row. The plan and summary gain one line per shared agent.

`list`, `outdated`, `upgrade`, and `pin`/`unpin` stay out of scope. This PR only makes the manifest exist and stay correct. One known gap is deferred with them: uninstalling a shared skill for only one agent of a pair leaves the other's row pointing at a path that is gone. Reconciling it correctly means clearing just that row's skill fields and dropping the row only once nothing is left in it, which is the per-artifact reconciliation the upgrade path has to build anyway.

Closes #2028.

Validation:

- `task test` across all seven modules: pass. `cd cli && go test ./util/pkgver/... ./internal/pkgstate/... ./internal/agentinstall/... ./cmd/install/...` and `cd api && go test ./exportfmt/...` pass, and `./cmd/install/...` passes at `-count=2`, which is what catches the in-process `opts` singleton trap.
- `task lint:go`: 0 issues in every module, with pinned golangci-lint 2.13.2.
- The `pkgver` truth table is verified against `golang.org/x/mod/semver` rather than assumed, including the short forms it accepts and each string it rejects.
- `dirctl install --help`, `install run --help`, and `install uninstall --help` confirm `--pin` renders as a boolean and appears only on the two install entry points.

